### PR TITLE
feat: Collection constant tracking and find-endpoints enhancements

### DIFF
--- a/graphite-cli/src/main/kotlin/io/johnsonlee/graphite/cli/FindArgumentsCommand.kt
+++ b/graphite-cli/src/main/kotlin/io/johnsonlee/graphite/cli/FindArgumentsCommand.kt
@@ -96,6 +96,19 @@ class FindArgumentsCommand : Callable<Int> {
     )
     var libFilters: List<String> = emptyList()
 
+    @Option(
+        names = ["--expand-collections"],
+        description = ["Expand collection factory calls (listOf, Arrays.asList, etc.) to trace element constants"]
+    )
+    var expandCollections: Boolean = false
+
+    @Option(
+        names = ["--max-collection-depth"],
+        description = ["Maximum depth for nested collection expansion (default: 3)"],
+        defaultValue = "3"
+    )
+    var maxCollectionDepth: Int = 3
+
     override fun call(): Int {
         if (!input.toFile().exists()) {
             System.err.println("Error: Input path does not exist: $input")
@@ -180,6 +193,12 @@ class FindArgumentsCommand : Callable<Int> {
                         }
                     }
                     argumentIndex = argIndex
+                    config {
+                        copy(
+                            expandCollections = this@FindArgumentsCommand.expandCollections,
+                            maxCollectionDepth = this@FindArgumentsCommand.maxCollectionDepth
+                        )
+                    }
                 }
             }
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/TypeStructure.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/TypeStructure.kt
@@ -110,13 +110,21 @@ data class TypeStructure(
  * @property declaredType The declared type of the field
  * @property actualTypes Set of actual types assigned to this field (may differ from declared type)
  * @property isGenericParameter True if this field's declared type is a generic parameter (e.g., T)
+ * @property jsonName The JSON property name from @JsonProperty annotation (null if not specified)
+ * @property isJsonIgnored True if the field is marked with @JsonIgnore
  */
 data class FieldStructure(
     val name: String,
     val declaredType: TypeDescriptor,
     val actualTypes: Set<TypeStructure> = emptySet(),
-    val isGenericParameter: Boolean = false
+    val isGenericParameter: Boolean = false,
+    val jsonName: String? = null,
+    val isJsonIgnored: Boolean = false
 ) {
+    /**
+     * Get the effective JSON name (from @JsonProperty or field name)
+     */
+    val effectiveJsonName: String get() = jsonName ?: name
     /**
      * Check if the actual types differ from the declared type
      */

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -76,7 +76,40 @@ interface Graph {
      * @return sequence of matching endpoints
      */
     fun endpoints(pattern: String? = null, httpMethod: HttpMethod? = null): Sequence<EndpointInfo>
+
+    /**
+     * Get Jackson annotation information for a field.
+     *
+     * @param className fully qualified class name
+     * @param fieldName field name
+     * @return JacksonFieldInfo containing @JsonProperty name and @JsonIgnore status, or null if not available
+     */
+    fun jacksonFieldInfo(className: String, fieldName: String): JacksonFieldInfo?
+
+    /**
+     * Get Jackson annotation information for a getter method.
+     *
+     * @param className fully qualified class name
+     * @param methodName getter method name (e.g., "getName")
+     * @return JacksonFieldInfo containing @JsonProperty name and @JsonIgnore status, or null if not available
+     */
+    fun jacksonGetterInfo(className: String, methodName: String): JacksonFieldInfo?
 }
+
+/**
+ * Jackson annotation information for a field or getter.
+ */
+data class JacksonFieldInfo(
+    /**
+     * The JSON property name from @JsonProperty annotation, or null if not specified
+     */
+    val jsonName: String? = null,
+
+    /**
+     * True if the field/getter is marked with @JsonIgnore
+     */
+    val isIgnored: Boolean = false
+)
 
 /**
  * Pattern for matching methods.

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/query/QueryDsl.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/query/QueryDsl.kt
@@ -266,11 +266,8 @@ class ArgumentConstantQuery {
         methodPattern = MethodPatternBuilder().apply(block).build()
     }
 
-    fun config(block: AnalysisConfig.() -> Unit) {
-        analysisConfig = AnalysisConfig().run {
-            block()
-            this
-        }
+    fun config(block: AnalysisConfig.() -> AnalysisConfig) {
+        analysisConfig = AnalysisConfig().block()
     }
 }
 

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -797,6 +797,13 @@ class SootUpAdapter(
             is Local -> getOrCreateLocal(value, method)
             is SootConstant -> getOrCreateConstant(value)
             is JFieldRef -> getOrCreateField(value)
+            is JArrayRef -> {
+                // For array references like $r1[0], return the base array's node
+                // This creates edges from array elements to the array itself,
+                // enabling backward tracing from arrays to their elements
+                val base = value.base
+                if (base is Local) getOrCreateLocal(base, method) else null
+            }
             is AbstractInvokeExpr -> null // Handled separately
             else -> null
         }

--- a/graphite-sootup/src/test/java/sample/ab/AbClient.java
+++ b/graphite-sootup/src/test/java/sample/ab/AbClient.java
@@ -33,4 +33,22 @@ public class AbClient {
         // Mock implementation
         return false;
     }
+
+    /**
+     * Get variants for multiple experiment IDs (List<Integer>).
+     * Used to test collection parameter constant tracking.
+     */
+    public java.util.Map<Integer, String> getOptions(java.util.List<Integer> experimentIds) {
+        // Mock implementation
+        return java.util.Collections.emptyMap();
+    }
+
+    /**
+     * Get variants for multiple experiment enums (List<ExperimentId>).
+     * Used to test collection parameter constant tracking with enums.
+     */
+    public java.util.Map<ExperimentId, String> getOptionsByEnum(java.util.List<ExperimentId> experimentIds) {
+        // Mock implementation
+        return java.util.Collections.emptyMap();
+    }
 }

--- a/graphite-sootup/src/test/java/sample/ab/BatchFeatureService.java
+++ b/graphite-sootup/src/test/java/sample/ab/BatchFeatureService.java
@@ -1,0 +1,57 @@
+package sample.ab;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service that demonstrates batch feature flag lookups using List parameters.
+ * Used to test collection parameter constant tracking.
+ */
+public class BatchFeatureService {
+
+    private final AbClient abClient = new AbClient();
+
+    /**
+     * Test case: Arrays.asList with integer constants
+     */
+    public Map<Integer, String> getBatchOptionsWithArraysAsList() {
+        return abClient.getOptions(Arrays.asList(5001, 5002, 5003));
+    }
+
+    /**
+     * Test case: List.of with integer constants (Java 9+)
+     */
+    public Map<Integer, String> getBatchOptionsWithListOf() {
+        return abClient.getOptions(List.of(6001, 6002));
+    }
+
+    /**
+     * Test case: Arrays.asList with enum constants
+     */
+    public Map<ExperimentId, String> getBatchEnumOptionsWithArraysAsList() {
+        return abClient.getOptionsByEnum(Arrays.asList(
+            ExperimentId.NEW_HOMEPAGE,
+            ExperimentId.CHECKOUT_V2
+        ));
+    }
+
+    /**
+     * Test case: List.of with enum constants
+     */
+    public Map<ExperimentId, String> getBatchEnumOptionsWithListOf() {
+        return abClient.getOptionsByEnum(List.of(
+            ExperimentId.PREMIUM_FEATURES,
+            ExperimentId.DARK_MODE
+        ));
+    }
+
+    /**
+     * Test case: mixed - some constants from variables
+     */
+    public Map<Integer, String> getBatchOptionsWithVariables() {
+        int localId1 = 7001;
+        int localId2 = 7002;
+        return abClient.getOptions(Arrays.asList(localId1, localId2, 7003));
+    }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/CollectionConstantTrackingTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/CollectionConstantTrackingTest.kt
@@ -1,0 +1,228 @@
+package io.johnsonlee.graphite.sootup
+
+import io.johnsonlee.graphite.Graphite
+import io.johnsonlee.graphite.analysis.AnalysisConfig
+import io.johnsonlee.graphite.analysis.DataFlowAnalysis
+import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.input.LoaderConfig
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for collection parameter constant tracking feature.
+ *
+ * This feature allows tracking constants inside collection factory calls like:
+ * - Arrays.asList(1001, 1002, 1003)
+ * - List.of(ExperimentId.A, ExperimentId.B)
+ *
+ * When expandCollections=true, the analysis will trace into the collection
+ * factory arguments to find the individual constant values.
+ */
+class CollectionConstantTrackingTest {
+
+    // Expected integer constants passed via Arrays.asList
+    private val expectedArraysAsListIntegers = setOf(5001, 5002, 5003)
+
+    // Expected integer constants passed via List.of
+    private val expectedListOfIntegers = setOf(6001, 6002)
+
+    // Expected integer constants with local variable indirection
+    private val expectedVariableIntegers = setOf(7001, 7002, 7003)
+
+    // Expected enum constants passed via Arrays.asList
+    private val expectedArraysAsListEnums = setOf("NEW_HOMEPAGE", "CHECKOUT_V2")
+
+    // Expected enum constants passed via List.of
+    private val expectedListOfEnums = setOf("PREMIUM_FEATURES", "DARK_MODE")
+
+    @Test
+    fun `should NOT expand collections when expandCollections is false (default)`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        // Query without expandCollections (default behavior)
+        val results = graphite.query {
+            findArgumentConstants {
+                method {
+                    declaringClass = "sample.ab.AbClient"
+                    name = "getOptions"
+                    parameterTypes = listOf("java.util.List")
+                }
+                argumentIndex = 0
+            }
+        }
+
+        // Should find no integer constants (only the List object)
+        val foundIntegers = results
+            .map { it.constant }
+            .filterIsInstance<IntConstant>()
+            .map { it.value }
+            .toSet()
+
+        println("Without expandCollections, found integers: $foundIntegers")
+        assertTrue(foundIntegers.isEmpty(),
+            "Should NOT find integer constants inside collection when expandCollections=false")
+    }
+
+    @Test
+    fun `should expand Arrays asList to find integer constants`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        // Query with expandCollections enabled
+        val results = graphite.query {
+            findArgumentConstants {
+                method {
+                    declaringClass = "sample.ab.AbClient"
+                    name = "getOptions"
+                    parameterTypes = listOf("java.util.List")
+                }
+                argumentIndex = 0
+                config {
+                    copy(expandCollections = true)
+                }
+            }
+        }
+
+        val foundIntegers = results
+            .map { it.constant }
+            .filterIsInstance<IntConstant>()
+            .map { it.value }
+            .toSet()
+
+        println("With expandCollections, found integers: $foundIntegers")
+
+        // Should find constants from all test methods
+        val allExpected = expectedArraysAsListIntegers + expectedListOfIntegers + expectedVariableIntegers
+
+        allExpected.forEach { expected ->
+            assertTrue(foundIntegers.contains(expected),
+                "Should find integer constant: $expected")
+        }
+    }
+
+    @Test
+    fun `should expand Arrays asList to find enum constants`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        // Query for enum list parameters with expandCollections
+        val results = graphite.query {
+            findArgumentConstants {
+                method {
+                    declaringClass = "sample.ab.AbClient"
+                    name = "getOptionsByEnum"
+                    parameterTypes = listOf("java.util.List")
+                }
+                argumentIndex = 0
+                config {
+                    copy(expandCollections = true)
+                }
+            }
+        }
+
+        val foundEnums = results
+            .map { it.constant }
+            .filterIsInstance<EnumConstant>()
+            .map { it.enumName }
+            .toSet()
+
+        println("With expandCollections, found enums: $foundEnums")
+
+        val allExpectedEnums = expectedArraysAsListEnums + expectedListOfEnums
+
+        allExpectedEnums.forEach { expected ->
+            assertTrue(foundEnums.contains(expected),
+                "Should find enum constant: $expected")
+        }
+    }
+
+    @Test
+    fun `should verify isCollectionFactory detects known factories`() {
+        // Test the companion object helper function
+        val arraysAsList = MethodDescriptor(
+            declaringClass = TypeDescriptor("java.util.Arrays"),
+            name = "asList",
+            parameterTypes = listOf(TypeDescriptor("java.lang.Object[]")),
+            returnType = TypeDescriptor("java.util.List")
+        )
+        assertTrue(DataFlowAnalysis.isCollectionFactory(arraysAsList),
+            "Should detect Arrays.asList as collection factory")
+
+        val listOf = MethodDescriptor(
+            declaringClass = TypeDescriptor("java.util.List"),
+            name = "of",
+            parameterTypes = emptyList(),
+            returnType = TypeDescriptor("java.util.List")
+        )
+        assertTrue(DataFlowAnalysis.isCollectionFactory(listOf),
+            "Should detect List.of as collection factory")
+
+        val kotlinListOf = MethodDescriptor(
+            declaringClass = TypeDescriptor("kotlin.collections.CollectionsKt"),
+            name = "listOf",
+            parameterTypes = listOf(TypeDescriptor("java.lang.Object[]")),
+            returnType = TypeDescriptor("java.util.List")
+        )
+        assertTrue(DataFlowAnalysis.isCollectionFactory(kotlinListOf),
+            "Should detect kotlin listOf as collection factory")
+
+        // Non-factory method
+        val toString = MethodDescriptor(
+            declaringClass = TypeDescriptor("java.lang.Object"),
+            name = "toString",
+            parameterTypes = emptyList(),
+            returnType = TypeDescriptor("java.lang.String")
+        )
+        assertTrue(!DataFlowAnalysis.isCollectionFactory(toString),
+            "Should NOT detect Object.toString as collection factory")
+    }
+
+    @Test
+    fun `should respect maxCollectionDepth for nested collections`() {
+        // This test verifies the depth limiting behavior
+        // In real code, nested collections like listOf(listOf(1,2), listOf(3,4)) would need depth control
+        val config = AnalysisConfig(
+            expandCollections = true,
+            maxCollectionDepth = 2
+        )
+
+        assertEquals(2, config.maxCollectionDepth)
+        assertTrue(config.expandCollections)
+    }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        return if (submodulePath.exists()) submodulePath else rootPath
+    }
+}


### PR DESCRIPTION
## Summary

- **Collection Parameter Constant Tracking**: Added support for analyzing constants inside collection parameters like `getOptions(List<Integer>)` and `getOptions(List<Enum>)` in `find-args` command
- **find-endpoints Bug Fixes**: Resolved circular reference truncation, added inherited field support, getter method recognition, and Jackson annotation handling
- **OpenAPI 3.0 Output Format**: Changed `find-endpoints -f schema` output to generate proper OpenAPI 3.0 specification

## Changes

### 1. Collection Parameter Constant Tracking

When using `find-args` to find AB IDs, methods like `getOptions(List<Integer>)` can now have their collection contents analyzed:


Enable with `--expand-collections` flag

```bash
graphite find-args --expand-collections /path/to/app.jar
```

Implementation:
- Added collection factory detection (`Arrays.asList()`, `List.of()`, `listOf()`, etc.)
- Added `JArrayRef` handling in SootUpAdapter to create edges from array elements to base array
- New `AnalysisConfig` options: `expandCollections`, `maxCollectionDepth`

### 2. find-endpoints Bug Fixes

| Bug | Fix |
|-----|-----|
| Circular reference causing output truncation | Added visited set and depth limit checks |
| Inherited fields not included | Added `collectAllSupertypes()` using type hierarchy graph |
| Getter methods not supported | Added pattern matching for `getXxx()`/`isXxx()` methods |
| Jackson annotations not supported | Added `@JsonProperty` and `@JsonIgnore` extraction |

### 3. OpenAPI 3.0 Output Format

The `-f schema` output now generates valid OpenAPI 3.0 specification with paths and components/schemas.

## Test plan

- [x] Collection constant tracking tests (`CollectionConstantTrackingTest.kt`)
- [x] Verify expandCollections=false does not find collection elements
- [x] Verify expandCollections=true finds integer and enum constants
- [ ] Verify find-endpoints with circular reference types
- [ ] Verify inherited fields appear in output

