### PR TITLE
ci: switch release workflow from Sonatype to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,61 +1,43 @@
-name: Publish build to Sonatype
+name: Publish to GitHub Packages
 
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
   repository_dispatch:
     types: [publish]
 
 jobs:
   publish:
-    permissions: write-all
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
     if: github.repository_owner == 'johnsonlee'
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '17'
 
-    - name: Publish Java artifacts to sonatype
+    - name: Publish to GitHub Packages
       run: |
-        echo "Release version ${GITHUB_REF/refs\/tags\/v/} ..."
-        echo "Create GPG private key"
-        echo $GPG_KEY_ARMOR | base64 --decode > ${GITHUB_WORKSPACE}/secring.gpg
-        ./gradlew clean publishMavenJavaPublicationToSonatypeRepository -S --no-daemon \
-            -Pversion=${GITHUB_REF/refs\/tags\/v/} \
-            -POSSRH_USERNAME=${OSSRH_USERNAME} \
-            -POSSRH_PASSWORD=${OSSRH_PASSWORD} \
-            -POSSRH_PACKAGE_GROUP=${OSSRH_PACKAGE_GROUP} \
-            -Psigning.keyId=${GPG_KEY_ID} \
-            -Psigning.password=${GPG_PASSPHRASE} \
-            -Psigning.secretKeyRingFile=${GITHUB_WORKSPACE}/secring.gpg
-        ./gradlew closeAndReleaseRepository -S --no-daemon \
-            -Pversion=${GITHUB_REF/refs\/tags\/v/} \
-            -POSSRH_USERNAME=${OSSRH_USERNAME} \
-            -POSSRH_PASSWORD=${OSSRH_PASSWORD} \
-            -POSSRH_PACKAGE_GROUP=${OSSRH_PACKAGE_GROUP} \
-            -Psigning.keyId=${GPG_KEY_ID} \
-            -Psigning.password=${GPG_PASSPHRASE} \
-            -Psigning.secretKeyRingFile=${GITHUB_WORKSPACE}/secring.gpg
+        VERSION=${GITHUB_REF/refs\/tags\/v/}
+        echo "Publishing version ${VERSION} ..."
+        ./gradlew clean publishAllPublicationsToGitHubPackagesRepository -S --no-daemon \
+            -Pversion=${VERSION}
       env:
-        JAVA_OPTS: -Xmx8g -XX:MetaspaceSize=1g -Dfile.encoding=UTF-8
-        JVM_OPTS:  -Xmx8g -XX:MetaspaceSize=1g -Dfile.encoding=UTF-8
-        GPG_KEY_ARMOR: ${{ secrets.GPG_KEY_ARMOR }}
-        GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_PACKAGE_GROUP: ${{ secrets.OSSRH_PACKAGE_GROUP }}
+        JAVA_OPTS: -Xmx4g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
+        JVM_OPTS: -Xmx4g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         name: Release ${{ github.ref_name }}
         tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
- Replace Sonatype publishing with GitHub Packages
- Remove GPG signing (not required for GitHub Packages)
- Remove OSSRH credentials and closeAndReleaseRepository step
- Update actions to v4 (checkout, setup-java)
- Update Java distribution from adopt to temurin
- Simplify tag pattern to 'v*' for clarity
- Use minimal required permissions (contents:write, packages:write)