### PR TITLE
fix: improve find-endpoints return type field discovery and @JsonProperty handling

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,11 +7,13 @@ gson = "2.11.0"
 lombok = "1.18.30"
 asm = "9.7"
 fastutil = "8.5.13"
+jackson = "2.17.0"
 
 [libraries]
 fastutil = { module = "it.unimi.dsi:fastutil", version.ref = "fastutil" }
 ff4j-core = { module = "org.ff4j:ff4j-core", version.ref = "ff4j" }
 spring-web = { module = "org.springframework:spring-web", version.ref = "spring" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 sootup-core = { module = "org.soot-oss:sootup.core", version.ref = "sootup" }

--- a/graphite-sootup/build.gradle.kts
+++ b/graphite-sootup/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     // Test dependencies - real libraries for integration testing
     testImplementation(libs.ff4j.core)
     testImplementation(libs.spring.web)
+    testImplementation(libs.jackson.annotations)
 
     // Lombok for testing Lombok-generated code analysis
     testCompileOnly(libs.lombok)

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -72,13 +72,16 @@ class SootUpAdapter(
         // 3. Process all methods and build intraprocedural graphs
         processMethods()
 
-        // 4. Extract HTTP endpoints from annotations
+        // 4. Process all class fields (creates FieldNodes for all declared fields)
+        processClassFields()
+
+        // 5. Extract HTTP endpoints from annotations
         processEndpoints()
 
-        // 5. Extract Jackson annotation information
+        // 6. Extract Jackson annotation information
         processJacksonAnnotations()
 
-        // 6. Build call graph if configured
+        // 7. Build call graph if configured
         if (config.buildCallGraph) {
             processCallGraph()
         }
@@ -199,9 +202,7 @@ class SootUpAdapter(
                     val values = getAnnotationValues(annot)
                     // Get the "value" property for the JSON name
                     val value = values["value"]
-                    if (value != null && value is String && value.isNotEmpty()) {
-                        jsonName = value
-                    }
+                    jsonName = extractStringValue(value)
                     // Check for access = JsonProperty.Access.WRITE_ONLY (means ignore in serialization)
                     val access = values["access"]?.toString()
                     if (access?.contains("WRITE_ONLY") == true) {
@@ -216,6 +217,25 @@ class SootUpAdapter(
             io.johnsonlee.graphite.graph.JacksonFieldInfo(jsonName, isIgnored)
         } else {
             null
+        }
+    }
+
+    /**
+     * Extract a string value from annotation value which may be String, List, or other type.
+     */
+    private fun extractStringValue(value: Any?): String? {
+        if (value == null) return null
+        return when (value) {
+            is String -> value.takeIf { it.isNotEmpty() }
+            is List<*> -> value.firstOrNull()?.let { extractStringValue(it) }
+            else -> {
+                // SootUp may wrap values in ConstantValue or similar
+                val strValue = value.toString()
+                    .removeSurrounding("\"")
+                    .removeSurrounding("[", "]")
+                    .removeSurrounding("\"")
+                strValue.takeIf { it.isNotEmpty() && it != "null" }
+            }
         }
     }
 
@@ -485,6 +505,55 @@ class SootUpAdapter(
             .forEach { sootClass ->
                 sootClass.methods.forEach { method ->
                     processMethod(method)
+                }
+            }
+    }
+
+    /**
+     * Process all class fields to ensure FieldNodes are created for all declared fields.
+     *
+     * This is important for return type analysis to discover ALL fields in a class,
+     * not just those that are referenced in methods. Fields may be:
+     * - Public fields accessed directly without getter/setter
+     * - Fields only used by frameworks (Jackson, Lombok, etc.)
+     * - Fields initialized via reflection or deserialization
+     */
+    private fun processClassFields() {
+        view.classes
+            .filter { shouldIncludeClass(it) }
+            .forEach { sootClass ->
+                val className = sootClass.type.fullyQualifiedName
+                sootClass.fields.forEach { field ->
+                    val fieldName = field.name
+
+                    // Skip synthetic fields
+                    if (fieldName.startsWith("\$") || fieldName.startsWith("this\$")) {
+                        return@forEach
+                    }
+
+                    // Use field signature as key (same format as getOrCreateField)
+                    val fieldSig = field.signature.toString()
+                    if (fieldNodes.containsKey(fieldSig)) {
+                        return@forEach
+                    }
+
+                    val declaringClassType = toTypeDescriptor(sootClass.type)
+                    val baseType = toTypeDescriptor(field.type)
+
+                    // Try to get generic type from bytecode signature
+                    val fieldType = getFieldTypeWithGenerics(className, fieldName, baseType)
+
+                    val node = FieldNode(
+                        id = nextNodeId("field"),
+                        descriptor = FieldDescriptor(
+                            declaringClass = declaringClassType,
+                            name = fieldName,
+                            type = fieldType
+                        ),
+                        isStatic = field.isStatic
+                    )
+                    fieldNodes[fieldSig] = node
+                    graphBuilder.addNode(node)
                 }
             }
     }

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -111,7 +111,9 @@ class SootUpAdapter(
      * Supports @RequestMapping, @GetMapping, @PostMapping, @PutMapping, @DeleteMapping, @PatchMapping
      */
     private fun processEndpoints() {
-        view.classes.toList().forEach { sootClass ->
+        view.classes
+            .filter { shouldIncludeClass(it) }
+            .forEach { sootClass ->
             if (sootClass !is JavaSootClass) return@forEach
 
             val className = sootClass.type.fullyQualifiedName
@@ -153,7 +155,9 @@ class SootUpAdapter(
      * Supports @JsonProperty, @JsonIgnore, and @JsonProperty(access = JsonProperty.Access.*)
      */
     private fun processJacksonAnnotations() {
-        view.classes.toList().forEach { sootClass ->
+        view.classes
+            .filter { shouldIncludeClass(it) }
+            .forEach { sootClass ->
             if (sootClass !is JavaSootClass) return@forEach
 
             val className = sootClass.type.fullyQualifiedName

--- a/graphite-sootup/src/test/java/sample/jackson/JacksonController.java
+++ b/graphite-sootup/src/test/java/sample/jackson/JacksonController.java
@@ -1,0 +1,30 @@
+package sample.jackson;
+
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Test controller for @JsonProperty annotation extraction.
+ */
+@RestController
+@RequestMapping("/api/jackson")
+public class JacksonController {
+
+    @GetMapping("/user/{id}")
+    public JacksonDTO getUser(@PathVariable String id) {
+        JacksonDTO dto = new JacksonDTO();
+        dto.setUserId(id);
+        dto.setUserName("John Doe");
+        dto.setEmail("john@example.com");
+        dto.setAge(30);
+        dto.setActive(true);
+        return dto;
+    }
+
+    @GetMapping("/user-direct/{id}")
+    public JacksonDTO getUserDirect(@PathVariable String id) {
+        // Using constructor
+        JacksonDTO dto = new JacksonDTO(id, "Jane Doe", "jane@example.com", 25);
+        dto.active = true;
+        return dto;
+    }
+}

--- a/graphite-sootup/src/test/java/sample/jackson/JacksonDTO.java
+++ b/graphite-sootup/src/test/java/sample/jackson/JacksonDTO.java
@@ -1,0 +1,60 @@
+package sample.jackson;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Test DTO for @JsonProperty annotation extraction.
+ */
+public class JacksonDTO {
+
+    @JsonProperty("user_id")
+    private String userId;
+
+    @JsonProperty("user_name")
+    private String userName;
+
+    @JsonProperty("email_address")
+    private String email;
+
+    @JsonIgnore
+    private String password;
+
+    // Field without @JsonProperty - should use field name
+    private int age;
+
+    // Public field with @JsonProperty
+    @JsonProperty("is_active")
+    public boolean active;
+
+    public JacksonDTO() {}
+
+    public JacksonDTO(String userId, String userName, String email, int age) {
+        this.userId = userId;
+        this.userName = userName;
+        this.email = email;
+        this.age = age;
+    }
+
+    @JsonProperty("user_id")
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+
+    @JsonProperty("user_name")
+    public String getUserName() { return userName; }
+    public void setUserName(String userName) { this.userName = userName; }
+
+    @JsonProperty("email_address")
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    @JsonIgnore
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+    public int getAge() { return age; }
+    public void setAge(int age) { this.age = age; }
+
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JacksonAnnotationTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JacksonAnnotationTest.kt
@@ -1,0 +1,121 @@
+package io.johnsonlee.graphite.sootup
+
+import io.johnsonlee.graphite.Graphite
+import io.johnsonlee.graphite.input.LoaderConfig
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Test for @JsonProperty annotation extraction and field discovery.
+ */
+class JacksonAnnotationTest {
+
+    @Test
+    fun `should extract JsonProperty names from DTO fields`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.jackson"),
+            buildCallGraph = false,
+            verbose = { println(it) }
+        ))
+
+        val graph = loader.load(testClassesDir)
+
+        // Check Jackson field info is extracted
+        val userIdInfo = graph.jacksonFieldInfo("sample.jackson.JacksonDTO", "userId")
+        println("userId field info: $userIdInfo")
+        assertEquals("user_id", userIdInfo?.jsonName, "userId should have @JsonProperty(\"user_id\")")
+
+        val userNameInfo = graph.jacksonFieldInfo("sample.jackson.JacksonDTO", "userName")
+        println("userName field info: $userNameInfo")
+        assertEquals("user_name", userNameInfo?.jsonName, "userName should have @JsonProperty(\"user_name\")")
+
+        val emailInfo = graph.jacksonFieldInfo("sample.jackson.JacksonDTO", "email")
+        println("email field info: $emailInfo")
+        assertEquals("email_address", emailInfo?.jsonName, "email should have @JsonProperty(\"email_address\")")
+
+        val passwordInfo = graph.jacksonFieldInfo("sample.jackson.JacksonDTO", "password")
+        println("password field info: $passwordInfo")
+        assertTrue(passwordInfo?.isIgnored == true, "password should be @JsonIgnore")
+
+        val activeInfo = graph.jacksonFieldInfo("sample.jackson.JacksonDTO", "active")
+        println("active field info: $activeInfo")
+        assertEquals("is_active", activeInfo?.jsonName, "active should have @JsonProperty(\"is_active\")")
+    }
+
+    @Test
+    fun `should discover all fields in return type analysis`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.jackson"),
+            buildCallGraph = false,
+            verbose = { println(it) }
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        // Analyze return type for getUser method
+        val results = graphite.query {
+            findTypeHierarchy {
+                method {
+                    declaringClass = "sample.jackson.JacksonController"
+                    name = "getUser"
+                }
+            }
+        }
+
+        assertTrue(results.isNotEmpty(), "Should have type hierarchy result")
+        val result = results.first()
+
+        println("Return structures:")
+        result.returnStructures.forEach { structure ->
+            println("  Type: ${structure.formatTypeName()}")
+            structure.fields.forEach { (name, field) ->
+                println("    Field: $name (effectiveJsonName=${field.effectiveJsonName}, isJsonIgnored=${field.isJsonIgnored})")
+            }
+        }
+
+        // Check that fields are discovered
+        val returnStructure = result.returnStructures.firstOrNull()
+        assertTrue(returnStructure != null, "Should have return structure")
+
+        val fields = returnStructure.fields
+        println("\nDiscovered fields: ${fields.keys}")
+
+        // All non-ignored fields should be present
+        assertTrue(fields.containsKey("userId") || fields.any { it.value.effectiveJsonName == "user_id" },
+            "Should discover userId field")
+        assertTrue(fields.containsKey("userName") || fields.any { it.value.effectiveJsonName == "user_name" },
+            "Should discover userName field")
+        assertTrue(fields.containsKey("email") || fields.any { it.value.effectiveJsonName == "email_address" },
+            "Should discover email field")
+        assertTrue(fields.containsKey("age") || fields.any { it.value.effectiveJsonName == "age" },
+            "Should discover age field")
+        assertTrue(fields.containsKey("active") || fields.any { it.value.effectiveJsonName == "is_active" },
+            "Should discover active field")
+
+        // Check effectiveJsonName uses @JsonProperty
+        val userIdField = fields.entries.find { it.key == "userId" || it.value.effectiveJsonName == "user_id" }?.value
+        assertEquals("user_id", userIdField?.effectiveJsonName, "userId effectiveJsonName should be 'user_id'")
+
+        // password should be ignored
+        val passwordField = fields["password"]
+        assertTrue(passwordField == null || passwordField.isJsonIgnored, "password should be ignored or not present")
+    }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        return if (submodulePath.exists()) submodulePath else rootPath
+    }
+}


### PR DESCRIPTION
This commit fixes two issues with find-endpoints return type analysis:

1. **Missing fields in output**: Added new strategy to discover ALL declared
   fields from class definitions, not just those referenced via setters,
   getters, or assignments. This ensures fields used by frameworks (Jackson,
   Lombok) or accessed directly as public fields are properly discovered.

2. **@JsonProperty field names**: Fixed annotation value extraction to handle
   various value types (String, List, wrapped values) that SootUp may return.

Changes:
- TypeHierarchyAnalysis: Added `addDeclaredFields()` strategy to discover
  fields from FieldNode declarations
- SootUpAdapter: Added `processClassFields()` to create FieldNodes for all
  class fields, not just referenced ones
- SootUpAdapter: Added `extractStringValue()` to properly extract @JsonProperty
  values from various annotation value formats
- Added test fixtures (JacksonDTO, JacksonController) and test for validation