### PR TITLE
Include collection types in field discovery for type analysis

### DIFF
--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/TypeHierarchyAnalysis.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/TypeHierarchyAnalysis.kt
@@ -761,11 +761,14 @@ class TypeHierarchyAnalysis(
                     if (fieldName in fields) return@forEach
 
                     val returnType = getter.returnType
-                    if (shouldAnalyzeType(returnType.className)) {
-                        val actualTypes = if (depth < config.maxDepth) {
+                    // Include fields with analyzable types, primitive/wrapper types, or collection types
+                    if (shouldAnalyzeType(returnType.className) ||
+                        isPrimitiveOrWrapper(returnType.className) ||
+                        isCollectionType(returnType.className)) {
+                        val actualTypes = if (shouldAnalyzeType(returnType.className) && depth < config.maxDepth) {
                             setOf(buildTypeStructure(returnType, getter, depth + 1))
                         } else {
-                            setOf(TypeStructure.simple(returnType.className))
+                            emptySet()
                         }
 
                         // Get Jackson annotation info from getter method

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/TypeHierarchyAnalysis.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/TypeHierarchyAnalysis.kt
@@ -819,9 +819,11 @@ class TypeHierarchyAnalysis(
                 val fieldType = fieldNode.descriptor.type
 
                 // Skip if field type should not be analyzed
+                // But allow collection types (List, Set, Map, etc.) as their element types may be relevant
                 if (!shouldAnalyzeType(fieldType.className) &&
                     fieldType.className != "java.lang.Object" &&
-                    !isPrimitiveOrWrapper(fieldType.className)) {
+                    !isPrimitiveOrWrapper(fieldType.className) &&
+                    !isCollectionType(fieldType.className)) {
                     return@forEach
                 }
 
@@ -864,6 +866,22 @@ class TypeHierarchyAnalysis(
             "java.lang.String", "java.math.BigDecimal", "java.math.BigInteger",
             "java.util.Date", "java.time.LocalDate", "java.time.LocalDateTime",
             "java.time.ZonedDateTime", "java.time.Instant"
+        )
+    }
+
+    /**
+     * Check if a type is a collection or container type.
+     * These types should be included in field discovery even when their package
+     * is not in includePackages, because they are containers whose element types
+     * may be relevant for analysis.
+     */
+    private fun isCollectionType(className: String): Boolean {
+        return className in setOf(
+            "java.util.List", "java.util.ArrayList", "java.util.LinkedList",
+            "java.util.Set", "java.util.HashSet", "java.util.LinkedHashSet", "java.util.TreeSet",
+            "java.util.Map", "java.util.HashMap", "java.util.LinkedHashMap", "java.util.TreeMap",
+            "java.util.Collection", "java.util.Queue", "java.util.Deque",
+            "java.util.Optional"
         )
     }
 

--- a/graphite-sootup/src/test/java/sample/collections/CollectionController.java
+++ b/graphite-sootup/src/test/java/sample/collections/CollectionController.java
@@ -1,0 +1,19 @@
+package sample.collections;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller that returns DTOs with multiple List fields.
+ * Used to test that find-endpoints discovers all List fields.
+ */
+@RestController
+public class CollectionController {
+
+    @GetMapping("/api/multiple-lists")
+    public MultipleListFieldsDTO getMultipleLists() {
+        MultipleListFieldsDTO dto = new MultipleListFieldsDTO();
+        // All fields should be discovered even without explicit assignment here
+        return dto;
+    }
+}

--- a/graphite-sootup/src/test/java/sample/collections/MultipleListFieldsDTO.java
+++ b/graphite-sootup/src/test/java/sample/collections/MultipleListFieldsDTO.java
@@ -1,0 +1,66 @@
+package sample.collections;
+
+import java.util.List;
+
+/**
+ * DTO with multiple List fields of different generic types.
+ * Used to test that all List fields are discovered, not just some.
+ */
+public class MultipleListFieldsDTO {
+    private List<String> names;
+    private List<Integer> scores;
+    private List<UserInfo> users;
+    private List<OrderInfo> orders;
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+
+    public List<Integer> getScores() {
+        return scores;
+    }
+
+    public void setScores(List<Integer> scores) {
+        this.scores = scores;
+    }
+
+    public List<UserInfo> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<UserInfo> users) {
+        this.users = users;
+    }
+
+    public List<OrderInfo> getOrders() {
+        return orders;
+    }
+
+    public void setOrders(List<OrderInfo> orders) {
+        this.orders = orders;
+    }
+
+    public static class UserInfo {
+        private String id;
+        private String name;
+
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+
+    public static class OrderInfo {
+        private String orderId;
+        private double amount;
+
+        public String getOrderId() { return orderId; }
+        public void setOrderId(String orderId) { this.orderId = orderId; }
+        public double getAmount() { return amount; }
+        public void setAmount(double amount) { this.amount = amount; }
+    }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/MultipleListFieldsTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/MultipleListFieldsTest.kt
@@ -1,0 +1,120 @@
+package io.johnsonlee.graphite.sootup
+
+import io.johnsonlee.graphite.Graphite
+import io.johnsonlee.graphite.input.LoaderConfig
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Tests that multiple List fields with different generic types are all discovered.
+ *
+ * This is a regression test for the bug where only some List fields were output
+ * while others were skipped because java.util.List was not in includePackages.
+ */
+class MultipleListFieldsTest {
+
+    @Test
+    fun `should discover all List fields regardless of generic type`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.collections"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        // Use findTypeHierarchy to analyze the return type
+        val results = graphite.query {
+            findTypeHierarchy {
+                method {
+                    declaringClass = "sample.collections.CollectionController"
+                    name = "getMultipleLists"
+                }
+            }
+        }
+
+        assertTrue(results.isNotEmpty(), "Should find the getMultipleLists method")
+
+        val result = results.first()
+        assertTrue(result.returnStructures.isNotEmpty(), "Should have return structures")
+
+        val returnStructure = result.returnStructures.first()
+        val fieldNames = returnStructure.fields.keys
+
+        println("=== Discovered Fields ===")
+        returnStructure.fields.forEach { (name, field) ->
+            println("  $name: ${field.declaredType.className}")
+        }
+
+        // All four List fields should be discovered
+        val expectedFields = setOf("names", "scores", "users", "orders")
+        expectedFields.forEach { fieldName ->
+            assertTrue(
+                fieldName in fieldNames,
+                "Field '$fieldName' should be discovered. Found fields: $fieldNames"
+            )
+        }
+
+        // Verify all are List types
+        expectedFields.forEach { fieldName ->
+            val field = returnStructure.fields[fieldName]
+            assertTrue(
+                field?.declaredType?.className == "java.util.List",
+                "Field '$fieldName' should be List type, got: ${field?.declaredType?.className}"
+            )
+        }
+    }
+
+    @Test
+    fun `should discover List fields via getter-based strategy`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.collections"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        val results = graphite.query {
+            findTypeHierarchy {
+                method {
+                    declaringClass = "sample.collections.CollectionController"
+                    name = "getMultipleLists"
+                }
+            }
+        }
+
+        val returnStructure = results.first().returnStructures.first()
+
+        // Check that all fields were discovered (should work via getter-based discovery)
+        println("=== Field Discovery Test ===")
+        println("Total fields discovered: ${returnStructure.fields.size}")
+
+        returnStructure.fields.forEach { (name, field) ->
+            println("  $name:")
+            println("    declaredType: ${field.declaredType.className}")
+            println("    typeArgs: ${field.declaredType.typeArguments.map { it.className }}")
+        }
+
+        // All 4 List fields must be discovered
+        assertTrue(
+            returnStructure.fields.size >= 4,
+            "Should discover at least 4 List fields, found: ${returnStructure.fields.size}"
+        )
+    }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        return if (submodulePath.exists()) submodulePath else rootPath
+    }
+}


### PR DESCRIPTION
## Summary
Enhanced the type hierarchy analysis to properly handle collection and container types during field discovery. This ensures that fields with collection types (List, Set, Map, etc.) are included in the analysis even when their package is not in the configured `includePackages`, since their element types may be relevant for analysis.

## Key Changes
- Added `isCollectionType()` method to identify common Java collection and container types (List, Set, Map, Queue, Deque, Optional, and their implementations)
- Modified getter field analysis to include fields with collection types alongside analyzable and primitive/wrapper types
- Updated field discovery logic to allow collection types through the filter, enabling analysis of their element types
- Changed behavior to return empty set instead of simple type structure when depth limit is reached, preventing unnecessary type information for non-analyzable types
- Added clarifying comments explaining why collection types are treated specially in field discovery

## Implementation Details
The `isCollectionType()` method checks against a predefined set of common Java collection classes including:
- List implementations (ArrayList, LinkedList)
- Set implementations (HashSet, LinkedHashSet, TreeSet)
- Map implementations (HashMap, LinkedHashMap, TreeMap)
- Other container types (Collection, Queue, Deque, Optional)

This allows the analysis to traverse into collection element types which may contain relevant domain objects, improving the completeness of the type hierarchy analysis.