### PR TITLE
Improve tree structure formatting with proper ASCII art and generic type support

### DIFF
--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/TypeStructure.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/TypeStructure.kt
@@ -54,10 +54,14 @@ data class TypeStructure(
         sb.append(formatTypeName())
         sb.appendLine()
 
-        fields.entries.sortedBy { it.key }.forEach { (name, field) ->
+        val sortedFields = fields.entries.sortedBy { it.key }
+        sortedFields.forEachIndexed { index, (name, field) ->
+            val isLast = index == sortedFields.size - 1
             sb.append(indent)
-            sb.append("├── $name: ")
-            sb.append(field.toTreeString("$indent│   "))
+            sb.append(if (isLast) "└── " else "├── ")
+            sb.append("$name: ")
+            val childIndent = indent + if (isLast) "    " else "│   "
+            sb.append(field.toTreeString(childIndent))
         }
 
         return sb.toString()
@@ -168,10 +172,14 @@ data class FieldStructure(
                 sb.appendLine(actual.formatTypeName())
             }
             // Print nested fields
-            actual.fields.entries.sortedBy { it.key }.forEach { (name, field) ->
+            val sortedFields = actual.fields.entries.sortedBy { it.key }
+            sortedFields.forEachIndexed { index, (name, field) ->
+                val isLast = index == sortedFields.size - 1
                 sb.append(indent)
-                sb.append("├── $name: ")
-                sb.append(field.toTreeString("$indent│   "))
+                sb.append(if (isLast) "└── " else "├── ")
+                sb.append("$name: ")
+                val childIndent = indent + if (isLast) "    " else "│   "
+                sb.append(field.toTreeString(childIndent))
             }
         } else {
             // Multiple possible types


### PR DESCRIPTION
## Summary
This PR enhances the tree structure visualization in the graphite CLI and core modules by implementing proper ASCII tree formatting with correct connector characters and adding support for displaying generic type arguments.

## Key Changes

- **Improved ASCII tree formatting**: Updated tree structure output to use proper ASCII art connectors:
  - Last child nodes now use `└──` instead of `├──`
  - Proper indentation adjustment for child nodes under last items (4 spaces instead of `│   `)
  - Applied consistently across `FindEndpointsCommand` and `TypeStructure`

- **Generic type support**: Added `formatDeclaredType()` method to display generic type arguments:
  - Formats types like `List<User>`, `Map<String, Integer>` instead of just `List`, `Map`
  - Extracts and displays type arguments in a readable format

- **Code refactoring**: 
  - Changed from `forEach` to `forEachIndexed` to track last element position
  - Extracted sorted fields into variables for better readability and to avoid multiple sorting operations

## Implementation Details

The tree formatting now correctly identifies the last child in a collection and adjusts both the connector character and the indentation for subsequent lines. This creates a more visually accurate tree structure that properly represents the hierarchy without unnecessary vertical lines under the last items.

The generic type formatting extracts `typeArguments` from `TypeDescriptor` and joins them with commas, providing better visibility into complex field types.