### PR TITLE
Add TypeDescriptor import to FindEndpointsCommand

### DIFF
--- a/graphite-cli/src/main/kotlin/io/johnsonlee/graphite/cli/FindEndpointsCommand.kt
+++ b/graphite-cli/src/main/kotlin/io/johnsonlee/graphite/cli/FindEndpointsCommand.kt
@@ -5,6 +5,7 @@ import io.johnsonlee.graphite.core.HttpMethod
 import io.johnsonlee.graphite.core.TypeHierarchyResult
 import io.johnsonlee.graphite.core.TypeStructure
 import io.johnsonlee.graphite.core.FieldStructure
+import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.input.LoaderConfig
 import io.johnsonlee.graphite.sootup.JavaProjectLoader
 import picocli.CommandLine.*


### PR DESCRIPTION
## Summary
Added missing import for `TypeDescriptor` class in the `FindEndpointsCommand` module to support type descriptor functionality.

## Changes
- Added `import io.johnsonlee.graphite.core.TypeDescriptor` to the imports section of `FindEndpointsCommand.kt`

## Details
This import addition enables the `FindEndpointsCommand` class to utilize the `TypeDescriptor` type from the core module, likely for enhanced type handling and endpoint discovery capabilities.