### PR TITLE
fix: remove expandCollections config that breaks backward slice

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,10 @@ lombok = "1.18.30"
 asm = "9.7"
 fastutil = "8.5.13"
 jackson = "2.17.0"
+guava = "33.0.0-jre"
 
 [libraries]
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
 fastutil = { module = "it.unimi.dsi:fastutil", version.ref = "fastutil" }
 ff4j-core = { module = "org.ff4j:ff4j-core", version.ref = "ff4j" }
 spring-web = { module = "org.springframework:spring-web", version.ref = "spring" }

--- a/graphite-cli/src/main/kotlin/io/johnsonlee/graphite/cli/FindArgumentsCommand.kt
+++ b/graphite-cli/src/main/kotlin/io/johnsonlee/graphite/cli/FindArgumentsCommand.kt
@@ -97,19 +97,6 @@ class FindArgumentsCommand : Callable<Int> {
     var libFilters: List<String> = emptyList()
 
     @Option(
-        names = ["--expand-collections"],
-        description = ["Expand collection factory calls (listOf, Arrays.asList, etc.) to trace element constants"]
-    )
-    var expandCollections: Boolean = false
-
-    @Option(
-        names = ["--max-collection-depth"],
-        description = ["Maximum depth for nested collection expansion (default: 3)"],
-        defaultValue = "3"
-    )
-    var maxCollectionDepth: Int = 3
-
-    @Option(
         names = ["--show-path"],
         description = ["Show propagation paths for each constant value (useful for complexity analysis)"]
     )
@@ -213,12 +200,6 @@ class FindArgumentsCommand : Callable<Int> {
                         }
                     }
                     argumentIndex = argIndex
-                    config {
-                        copy(
-                            expandCollections = this@FindArgumentsCommand.expandCollections,
-                            maxCollectionDepth = this@FindArgumentsCommand.maxCollectionDepth
-                        )
-                    }
                 }
             }
 

--- a/graphite-sootup/build.gradle.kts
+++ b/graphite-sootup/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     testImplementation(libs.ff4j.core)
     testImplementation(libs.spring.web)
     testImplementation(libs.jackson.annotations)
+    testImplementation(libs.guava)
 
     // Lombok for testing Lombok-generated code analysis
     testCompileOnly(libs.lombok)

--- a/graphite-sootup/src/test/java/sample/ab/GuavaListPatterns.java
+++ b/graphite-sootup/src/test/java/sample/ab/GuavaListPatterns.java
@@ -1,0 +1,89 @@
+package sample.ab;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * Test fixture for Guava List construction patterns.
+ */
+public class GuavaListPatterns {
+
+    private final AbClient abClient = new AbClient();
+
+    /**
+     * Pattern: ImmutableList.of(...)
+     * Expected: 9001, 9002
+     */
+    public void immutableListOf() {
+        abClient.getOptions(ImmutableList.of(9001, 9002));
+    }
+
+    /**
+     * Pattern: ImmutableList.of(...) with single element
+     * Expected: 9003
+     */
+    public void immutableListOfSingle() {
+        abClient.getOptions(ImmutableList.of(9003));
+    }
+
+    /**
+     * Pattern: Lists.newArrayList(...)
+     * Expected: 9101, 9102
+     */
+    public void listsNewArrayList() {
+        abClient.getOptions(Lists.newArrayList(9101, 9102));
+    }
+
+    /**
+     * Pattern: ImmutableList.builder().add(...).build()
+     * Expected: 9201, 9202
+     */
+    public void immutableListBuilder() {
+        List<Integer> list = ImmutableList.<Integer>builder()
+            .add(9201)
+            .add(9202)
+            .build();
+        abClient.getOptions(list);
+    }
+
+    /**
+     * Pattern: ImmutableList.copyOf(...)
+     * Expected: 9301, 9302
+     */
+    public void immutableListCopyOf() {
+        List<Integer> source = Lists.newArrayList(9301, 9302);
+        abClient.getOptions(ImmutableList.copyOf(source));
+    }
+
+    // ==================== Enum Patterns ====================
+
+    /**
+     * Pattern: ImmutableList.of with enum
+     * Expected: NEW_HOMEPAGE, CHECKOUT_V2
+     */
+    public void immutableListOfEnum() {
+        abClient.getOptionsByEnum(ImmutableList.of(ExperimentId.NEW_HOMEPAGE, ExperimentId.CHECKOUT_V2));
+    }
+
+    /**
+     * Pattern: Lists.newArrayList with enum
+     * Expected: PREMIUM_FEATURES, DARK_MODE
+     */
+    public void listsNewArrayListEnum() {
+        abClient.getOptionsByEnum(Lists.newArrayList(ExperimentId.PREMIUM_FEATURES, ExperimentId.DARK_MODE));
+    }
+
+    // ==================== Static Field Patterns ====================
+
+    private static final ImmutableList<Integer> STATIC_IMMUTABLE = ImmutableList.of(9401, 9402);
+
+    /**
+     * Pattern: Static field initialized with ImmutableList.of
+     * Expected: 9401, 9402
+     */
+    public void staticFieldImmutableList() {
+        abClient.getOptions(STATIC_IMMUTABLE);
+    }
+}

--- a/graphite-sootup/src/test/java/sample/ab/ListConstructionPatterns.java
+++ b/graphite-sootup/src/test/java/sample/ab/ListConstructionPatterns.java
@@ -1,0 +1,135 @@
+package sample.ab;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Test fixture for various List construction patterns.
+ * Tests that backward slice can trace constants through all common ways of creating Lists.
+ */
+public class ListConstructionPatterns {
+
+    private final AbClient abClient = new AbClient();
+
+    // ==================== JDK Patterns ====================
+
+    /**
+     * Pattern: Arrays.asList(...)
+     * Expected: 1001, 1002
+     */
+    public void arraysAsList() {
+        abClient.getOptions(Arrays.asList(1001, 1002));
+    }
+
+    /**
+     * Pattern: List.of(...) - Java 9+
+     * Expected: 2001, 2002
+     */
+    public void listOf() {
+        abClient.getOptions(List.of(2001, 2002));
+    }
+
+    /**
+     * Pattern: Collections.singletonList(...)
+     * Expected: 3001
+     */
+    public void collectionsSingletonList() {
+        abClient.getOptions(Collections.singletonList(3001));
+    }
+
+    // ==================== Unsupported Patterns (SootUpAdapter limitation) ====================
+    // These patterns are not currently tracked because SootUpAdapter doesn't model:
+    // - ArrayList.add() method calls
+    // - Constructor wrapping (new ArrayList<>(collection))
+    // - Stream intermediate operations
+
+    /**
+     * Pattern: new ArrayList<>() with add()
+     * NOT SUPPORTED - add() calls are not tracked as dataflow
+     */
+    public void arrayListWithAdd() {
+        List<Integer> list = new ArrayList<>();
+        list.add(4001);
+        list.add(4002);
+        abClient.getOptions(list);
+    }
+
+    /**
+     * Pattern: new ArrayList<>(Arrays.asList(...))
+     * NOT SUPPORTED - constructor argument is not tracked as dataflow
+     */
+    public void arrayListFromAsList() {
+        List<Integer> list = new ArrayList<>(Arrays.asList(5001, 5002));
+        abClient.getOptions(list);
+    }
+
+    /**
+     * Pattern: Stream.of(...).collect(Collectors.toList())
+     * NOT SUPPORTED - Stream intermediate operations not tracked
+     */
+    public void streamCollect() {
+        List<Integer> list = Stream.of(6001, 6002).collect(Collectors.toList());
+        abClient.getOptions(list);
+    }
+
+    /**
+     * Pattern: Stream.of(...).toList() - Java 16+
+     * Note: This compiles to Stream.toList() which is different from Collectors.toList()
+     * Expected: 7001, 7002
+     */
+    public void streamToList() {
+        List<Integer> list = Stream.of(7001, 7002).toList();
+        abClient.getOptions(list);
+    }
+
+    // ==================== Enum Patterns ====================
+
+    /**
+     * Pattern: Arrays.asList with enum
+     * Expected: NEW_HOMEPAGE, CHECKOUT_V2
+     */
+    public void arraysAsListEnum() {
+        abClient.getOptionsByEnum(Arrays.asList(ExperimentId.NEW_HOMEPAGE, ExperimentId.CHECKOUT_V2));
+    }
+
+    /**
+     * Pattern: List.of with enum
+     * Expected: PREMIUM_FEATURES, DARK_MODE
+     */
+    public void listOfEnum() {
+        abClient.getOptionsByEnum(List.of(ExperimentId.PREMIUM_FEATURES, ExperimentId.DARK_MODE));
+    }
+
+    /**
+     * Pattern: Collections.singletonList with enum
+     * Expected: NEW_HOMEPAGE
+     */
+    public void singletonListEnum() {
+        abClient.getOptionsByEnum(Collections.singletonList(ExperimentId.NEW_HOMEPAGE));
+    }
+
+    // ==================== Static Field Patterns ====================
+
+    private static final List<Integer> STATIC_LIST = Arrays.asList(8001, 8002);
+    private static final List<Integer> STATIC_LIST_OF = List.of(8003, 8004);
+
+    /**
+     * Pattern: Static field initialized with Arrays.asList
+     * Expected: 8001, 8002
+     */
+    public void staticFieldArraysAsList() {
+        abClient.getOptions(STATIC_LIST);
+    }
+
+    /**
+     * Pattern: Static field initialized with List.of
+     * Expected: 8003, 8004
+     */
+    public void staticFieldListOf() {
+        abClient.getOptions(STATIC_LIST_OF);
+    }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ListConstructionPatternsTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ListConstructionPatternsTest.kt
@@ -1,0 +1,214 @@
+package io.johnsonlee.graphite.sootup
+
+import io.johnsonlee.graphite.Graphite
+import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.input.LoaderConfig
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Tests for various List construction patterns.
+ * Verifies that backward slice can trace constants through all common ways of creating Lists.
+ */
+class ListConstructionPatternsTest {
+
+    // ==================== JDK Pattern Expected Values ====================
+
+    private val expectedArraysAsList = setOf(1001, 1002)
+    private val expectedListOf = setOf(2001, 2002)
+    private val expectedSingletonList = setOf(3001)
+    private val expectedStreamToList = setOf(7001, 7002)
+    private val expectedStaticField = setOf(8001, 8002, 8003, 8004)
+
+    // Unsupported patterns (SootUpAdapter limitation):
+    // - ArrayList.add() - 4001, 4002
+    // - new ArrayList<>(collection) - 5001, 5002
+    // - Stream.collect() - 6001, 6002
+
+    // ==================== Guava Pattern Expected Values ====================
+
+    private val expectedImmutableListOf = setOf(9001, 9002, 9003)
+    private val expectedListsNewArrayList = setOf(9101, 9102)
+    private val expectedImmutableListBuilder = setOf(9201, 9202)
+    private val expectedImmutableListCopyOf = setOf(9301, 9302)
+    private val expectedStaticImmutable = setOf(9401, 9402)
+
+    @Test
+    fun `should trace constants through JDK List construction patterns`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        val results = graphite.query {
+            findArgumentConstants {
+                method {
+                    declaringClass = "sample.ab.AbClient"
+                    name = "getOptions"
+                    parameterTypes = listOf("java.util.List")
+                }
+                argumentIndex = 0
+            }
+        }
+
+        val foundIntegers = results
+            .filter { it.callSite.caller.declaringClass.className == "sample.ab.ListConstructionPatterns" }
+            .map { it.constant }
+            .filterIsInstance<IntConstant>()
+            .map { it.value }
+            .toSet()
+
+        println("Found integers from ListConstructionPatterns: $foundIntegers")
+
+        // Test supported JDK patterns
+        assertContainsAllInts("Arrays.asList", foundIntegers, expectedArraysAsList)
+        assertContainsAllInts("List.of", foundIntegers, expectedListOf)
+        assertContainsAllInts("Collections.singletonList", foundIntegers, expectedSingletonList)
+        assertContainsAllInts("Stream.toList", foundIntegers, expectedStreamToList)
+        assertContainsAllInts("Static field", foundIntegers, expectedStaticField)
+
+        // Note: ArrayList.add, new ArrayList<>(collection), Stream.collect are NOT supported
+    }
+
+    @Test
+    fun `should trace constants through Guava List construction patterns`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        val results = graphite.query {
+            findArgumentConstants {
+                method {
+                    declaringClass = "sample.ab.AbClient"
+                    name = "getOptions"
+                    parameterTypes = listOf("java.util.List")
+                }
+                argumentIndex = 0
+            }
+        }
+
+        val foundIntegers = results
+            .filter { it.callSite.caller.declaringClass.className == "sample.ab.GuavaListPatterns" }
+            .map { it.constant }
+            .filterIsInstance<IntConstant>()
+            .map { it.value }
+            .toSet()
+
+        println("Found integers from GuavaListPatterns: $foundIntegers")
+
+        // Test each Guava pattern
+        assertContainsAllInts("ImmutableList.of", foundIntegers, expectedImmutableListOf)
+        assertContainsAllInts("Lists.newArrayList", foundIntegers, expectedListsNewArrayList)
+        assertContainsAllInts("ImmutableList.builder", foundIntegers, expectedImmutableListBuilder)
+        assertContainsAllInts("ImmutableList.copyOf", foundIntegers, expectedImmutableListCopyOf)
+        assertContainsAllInts("Static ImmutableList", foundIntegers, expectedStaticImmutable)
+    }
+
+    @Test
+    fun `should trace enum constants through JDK List patterns`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        val results = graphite.query {
+            findArgumentConstants {
+                method {
+                    declaringClass = "sample.ab.AbClient"
+                    name = "getOptionsByEnum"
+                    parameterTypes = listOf("java.util.List")
+                }
+                argumentIndex = 0
+            }
+        }
+
+        val foundEnums = results
+            .filter { it.callSite.caller.declaringClass.className == "sample.ab.ListConstructionPatterns" }
+            .map { it.constant }
+            .filterIsInstance<EnumConstant>()
+            .map { it.enumName }
+            .toSet()
+
+        println("Found enums from ListConstructionPatterns: $foundEnums")
+
+        // Expected enums from JDK patterns
+        val expectedEnums = setOf("NEW_HOMEPAGE", "CHECKOUT_V2", "PREMIUM_FEATURES", "DARK_MODE")
+        assertContainsAllStrings("JDK enum patterns", foundEnums, expectedEnums)
+    }
+
+    @Test
+    fun `should trace enum constants through Guava List patterns`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+        val graphite = Graphite.from(graph)
+
+        val results = graphite.query {
+            findArgumentConstants {
+                method {
+                    declaringClass = "sample.ab.AbClient"
+                    name = "getOptionsByEnum"
+                    parameterTypes = listOf("java.util.List")
+                }
+                argumentIndex = 0
+            }
+        }
+
+        val foundEnums = results
+            .filter { it.callSite.caller.declaringClass.className == "sample.ab.GuavaListPatterns" }
+            .map { it.constant }
+            .filterIsInstance<EnumConstant>()
+            .map { it.enumName }
+            .toSet()
+
+        println("Found enums from GuavaListPatterns: $foundEnums")
+
+        // Expected enums from Guava patterns
+        val expectedEnums = setOf("NEW_HOMEPAGE", "CHECKOUT_V2", "PREMIUM_FEATURES", "DARK_MODE")
+        assertContainsAllStrings("Guava enum patterns", foundEnums, expectedEnums)
+    }
+
+    private fun assertContainsAllInts(pattern: String, actual: Set<Int>, expected: Set<Int>) {
+        val missing = expected - actual
+        assertTrue(missing.isEmpty(), "$pattern: missing constants $missing (found: $actual)")
+    }
+
+    private fun assertContainsAllStrings(pattern: String, actual: Set<String>, expected: Set<String>) {
+        val missing = expected - actual
+        assertTrue(missing.isEmpty(), "$pattern: missing constants $missing (found: $actual)")
+    }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        return if (submodulePath.exists()) submodulePath else rootPath
+    }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/StaticFieldIndirectReferenceTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/StaticFieldIndirectReferenceTest.kt
@@ -100,9 +100,6 @@ class StaticFieldIndirectReferenceTest {
                     parameterTypes = listOf("java.util.List")
                 }
                 argumentIndex = 0
-                config {
-                    copy(expandCollections = true)
-                }
             }
         }
 
@@ -178,9 +175,6 @@ class StaticFieldIndirectReferenceTest {
                     parameterTypes = listOf("java.util.List")
                 }
                 argumentIndex = 0
-                config {
-                    copy(expandCollections = true)
-                }
             }
         }
 
@@ -226,9 +220,6 @@ class StaticFieldIndirectReferenceTest {
                     parameterTypes = listOf("java.util.List")
                 }
                 argumentIndex = 0
-                config {
-                    copy(expandCollections = true)
-                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Fix bug where `expandCollections=false` (default) caused backward slice to return early on collection factory calls like `List.of()` and `Arrays.asList()`, preventing constant tracking
- Remove `expandCollections` and `maxCollectionDepth` from `AnalysisConfig`
- Remove `--expand-collections` CLI option from `find-args` command
- Add comprehensive tests for JDK and Guava List construction patterns

## Problem

After alpha.18, patterns like `List.of(AbKey.KEY, ...)` stopped being tracked. The root cause was the collection factory special handling that would `return` early when `expandCollections=false`:

```kotlin
if (isCollFactory) {
    if (config.expandCollections) {
        // trace incoming edges
    }
    return  // <- BUG: this breaks normal backward traversal
}
```

## Solution

Remove the entire `expandCollections` feature. The default backward slice behavior already traverses all incoming edges correctly, including those from collection factory arguments.

## Supported List Construction Patterns

| Pattern | Status |
|---------|--------|
| `Arrays.asList(...)` | ✅ |
| `List.of(...)` | ✅ |
| `Collections.singletonList(...)` | ✅ |
| `Stream.of(...).toList()` | ✅ |
| `ImmutableList.of(...)` | ✅ |
| `Lists.newArrayList(...)` | ✅ |
| Static field references | ✅ |

## Test plan

- [x] All existing tests pass
- [x] New `ListConstructionPatternsTest` covers JDK and Guava patterns
- [x] `StaticFieldIndirectReferenceTest` verifies `List.of(AbKey.KEY)` pattern

🤖 Generated with [Claude Code](https://claude.ai/claude-code)