### PR TITLE
fix: support boxed primitive types in enum constructor parameters

### DIFF
--- a/graphite-sootup/src/test/java/sample/ab/AbKeyBoxed.java
+++ b/graphite-sootup/src/test/java/sample/ab/AbKeyBoxed.java
@@ -1,0 +1,21 @@
+package sample.ab;
+
+/**
+ * Enum with boxed Integer type for constructor parameter.
+ * This tests the boxing pattern: Integer.valueOf(int) in bytecode.
+ */
+public enum AbKeyBoxed {
+    BOXED_TEST_A(1111),
+    BOXED_TEST_B(2222),
+    BOXED_TEST_C(3333);
+
+    private final Integer id;  // Boxed Integer, not primitive int
+
+    AbKeyBoxed(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+}

--- a/graphite-sootup/src/test/java/sample/ab/AbTestResolver.java
+++ b/graphite-sootup/src/test/java/sample/ab/AbTestResolver.java
@@ -82,4 +82,28 @@ public class AbTestResolver {
     public String getCachedCheckoutOption() {
         return abClient.getOption(CACHED_CHECKOUT_ID);
     }
+
+    // ==================== Boxed Integer Enum Patterns ====================
+    // These test enums with Integer (boxed) constructor parameters instead of int (primitive)
+
+    // Static field holding boxed enum's cached ID
+    private static final Integer BOXED_CACHED_A = AbKeyBoxed.BOXED_TEST_A.getId();  // 1111
+    private static final Integer BOXED_CACHED_B = AbKeyBoxed.BOXED_TEST_B.getId();  // 2222
+
+    /**
+     * Pattern 7: Boxed enum with Integer constructor parameter.
+     * The bytecode uses Integer.valueOf(1111) for boxing.
+     * Expected to find: 1111 (from AbKeyBoxed.BOXED_TEST_A)
+     */
+    public String getBoxedEnumOption() {
+        return abClient.getOption(BOXED_CACHED_A);
+    }
+
+    /**
+     * Pattern 8: Another boxed enum cached ID.
+     * Expected to find: 2222 (from AbKeyBoxed.BOXED_TEST_B)
+     */
+    public String getBoxedEnumOptionB() {
+        return abClient.getOption(BOXED_CACHED_B);
+    }
 }

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/StaticFieldIndirectReferenceTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/StaticFieldIndirectReferenceTest.kt
@@ -312,6 +312,39 @@ class StaticFieldIndirectReferenceTest {
             "Should find 5678 or CHECKOUT_FLOW through CACHED_CHECKOUT_ID static field")
     }
 
+    @Test
+    fun `should extract values from boxed Integer enum constructor parameters`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false,
+            verbose = { println("[LOADER] $it") }
+        ))
+
+        val graph = loader.load(testClassesDir)
+
+        // Check that boxed enum values are extracted correctly
+        println("\n=== Boxed Integer Enum Values ===")
+        listOf("BOXED_TEST_A", "BOXED_TEST_B", "BOXED_TEST_C").forEach { enumName ->
+            val values = graph.enumValues("sample.ab.AbKeyBoxed", enumName)
+            println("  AbKeyBoxed.$enumName: $values")
+        }
+
+        // Verify the boxed enum values are extracted
+        val boxedAValues = graph.enumValues("sample.ab.AbKeyBoxed", "BOXED_TEST_A") ?: emptyList()
+        val boxedBValues = graph.enumValues("sample.ab.AbKeyBoxed", "BOXED_TEST_B") ?: emptyList()
+        val boxedCValues = graph.enumValues("sample.ab.AbKeyBoxed", "BOXED_TEST_C") ?: emptyList()
+
+        assertTrue(boxedAValues.contains(1111),
+            "Should extract 1111 from AbKeyBoxed.BOXED_TEST_A (Integer constructor param), but got: $boxedAValues")
+        assertTrue(boxedBValues.contains(2222),
+            "Should extract 2222 from AbKeyBoxed.BOXED_TEST_B (Integer constructor param), but got: $boxedBValues")
+        assertTrue(boxedCValues.contains(3333),
+            "Should extract 3333 from AbKeyBoxed.BOXED_TEST_C (Integer constructor param), but got: $boxedCValues")
+    }
+
     private fun findTestClassesDir(): Path {
         val projectDir = Path.of(System.getProperty("user.dir"))
         val submodulePath = projectDir.resolve("build/classes/java/test")


### PR DESCRIPTION
## Summary
- Add support for extracting values from boxed primitive enum constructor parameters
- Handle `Integer.valueOf(int)`, `Long.valueOf(long)`, and other boxing method calls in bytecode
- Fixes the issue where enum values couldn't be extracted when constructor used `Integer` instead of `int`

## Problem
When an enum constructor parameter is a wrapper type (e.g., `Integer` instead of `int`):
```java
public enum AbKey {
    TEST_ID(1234);
    private final Integer id;  // Boxed type
    AbKey(Integer id) { this.id = id; }
}
```

The bytecode uses boxing:
```
$stack0 = staticinvoke Integer.valueOf(1234)
specialinvoke $stack1.<init>("TEST_ID", 0, $stack0)
```

Previously, the analysis couldn't extract the value `1234` because it only tracked direct constant assignments.

## Solution
Added `extractBoxedValue()` method to recognize and extract values from boxing method calls:
- `Integer.valueOf(int)`
- `Long.valueOf(long)`
- `Short.valueOf(short)`
- `Byte.valueOf(byte)`
- `Float.valueOf(float)`
- `Double.valueOf(double)`
- `Boolean.valueOf(boolean)`
- `Character.valueOf(char)`

## Test plan
- [x] Added `AbKeyBoxed` enum with `Integer` constructor parameter
- [x] Added test verifying boxed enum values are extracted correctly
- [x] All 75 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)