### PR TITLE
fix: complete constant type support in SootUpAdapter

### DIFF
--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -10,6 +10,10 @@ import sootup.core.jimple.basic.Local
 import sootup.core.jimple.basic.Value
 import sootup.core.jimple.common.constant.IntConstant as SootIntConstant
 import sootup.core.jimple.common.constant.LongConstant as SootLongConstant
+import sootup.core.jimple.common.constant.FloatConstant as SootFloatConstant
+import sootup.core.jimple.common.constant.DoubleConstant as SootDoubleConstant
+import sootup.core.jimple.common.constant.BooleanConstant as SootBooleanConstant
+import sootup.core.jimple.common.constant.NullConstant as SootNullConstant
 import sootup.core.jimple.common.constant.StringConstant as SootStringConstant
 import sootup.core.jimple.common.constant.Constant as SootConstant
 import sootup.core.jimple.common.expr.AbstractInstanceInvokeExpr
@@ -930,18 +934,36 @@ class SootUpAdapter(
                     id = nextNodeId("const"),
                     value = constant.value
                 )
-                is SootLongConstant -> IntConstant(
+                is SootLongConstant -> LongConstant(
                     id = nextNodeId("const"),
-                    value = constant.value.toInt() // Simplified
+                    value = constant.value
+                )
+                is SootFloatConstant -> FloatConstant(
+                    id = nextNodeId("const"),
+                    value = constant.value
+                )
+                is SootDoubleConstant -> DoubleConstant(
+                    id = nextNodeId("const"),
+                    value = constant.value
+                )
+                is SootBooleanConstant -> BooleanConstant(
+                    id = nextNodeId("const"),
+                    value = constant == SootBooleanConstant.getTrue()
                 )
                 is SootStringConstant -> StringConstant(
                     id = nextNodeId("const"),
                     value = constant.value
                 )
-                else -> IntConstant(
-                    id = nextNodeId("const"),
-                    value = 0 // Fallback
+                is SootNullConstant -> NullConstant(
+                    id = nextNodeId("const")
                 )
+                else -> {
+                    log("Unsupported constant type: ${constant.javaClass.simpleName} = $constant")
+                    IntConstant(
+                        id = nextNodeId("const"),
+                        value = 0
+                    )
+                }
             }
             graphBuilder.addNode(node)
             node
@@ -977,7 +999,11 @@ class SootUpAdapter(
         return when (constant) {
             is SootIntConstant -> constant.value
             is SootLongConstant -> constant.value
+            is SootFloatConstant -> constant.value
+            is SootDoubleConstant -> constant.value
+            is SootBooleanConstant -> constant == SootBooleanConstant.getTrue()
             is SootStringConstant -> constant.value
+            is SootNullConstant -> null
             else -> null
         }
     }

--- a/graphite-sootup/src/test/java/sample/ab/MixedParamKey.java
+++ b/graphite-sootup/src/test/java/sample/ab/MixedParamKey.java
@@ -1,0 +1,34 @@
+package sample.ab;
+
+/**
+ * Enum with various constant types for constructor parameters.
+ * Tests that Float, Double, Boolean, and Long constants are correctly extracted.
+ */
+public enum MixedParamKey {
+    FLOAT_KEY(1.5f),
+    DOUBLE_KEY(2.718),
+    BOOL_KEY(true),
+    LONG_KEY(9999999999L);
+
+    private final Object value;
+
+    MixedParamKey(float value) {
+        this.value = value;
+    }
+
+    MixedParamKey(double value) {
+        this.value = value;
+    }
+
+    MixedParamKey(boolean value) {
+        this.value = value;
+    }
+
+    MixedParamKey(long value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix Long truncation**: `LongConstant` was being converted to `IntConstant` via `.toInt()`, silently losing precision for values outside Int range (e.g., `9999999999L` → `1410065407`)
- **Add missing constant types**: Float, Double, Boolean, and Null constants now map to their correct Graphite node types instead of falling through to `IntConstant(value=0)`
- **Log unsupported types**: Unknown constant types now emit a warning via `log()` instead of silently returning a zero-valued `IntConstant`

## Test plan

- [x] New test `should extract float, double, boolean, and long enum constructor values` validates all four new types via `MixedParamKey` enum fixture
- [x] All 76 existing + new tests pass (`./gradlew :graphite-sootup:test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)