### PR TITLE
Support enum value references in constructor arguments

### DIFF
--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
@@ -109,6 +109,26 @@ data class NullConstant(
 }
 
 /**
+ * Represents a reference from one enum's constructor argument to another enum constant.
+ *
+ * For example, in:
+ * ```java
+ * enum TaskConfig {
+ *     URGENT(Priority.HIGH);
+ *     TaskConfig(Priority priority) { ... }
+ * }
+ * ```
+ * The constructor argument `Priority.HIGH` is stored as:
+ * `EnumValueReference(enumClass = "com.example.Priority", enumName = "HIGH")`
+ */
+data class EnumValueReference(
+    val enumClass: String,
+    val enumName: String
+) {
+    override fun toString(): String = "$enumClass.$enumName"
+}
+
+/**
  * A local variable in a method
  */
 data class LocalVariable(

--- a/graphite-sootup/src/test/java/sample/ab/Priority.java
+++ b/graphite-sootup/src/test/java/sample/ab/Priority.java
@@ -1,0 +1,21 @@
+package sample.ab;
+
+/**
+ * Simple enum representing priority levels.
+ * Used as a constructor argument for other enums to test cross-enum references.
+ */
+public enum Priority {
+    HIGH(1),
+    MEDIUM(2),
+    LOW(3);
+
+    private final int level;
+
+    Priority(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+}

--- a/graphite-sootup/src/test/java/sample/ab/TaskConfig.java
+++ b/graphite-sootup/src/test/java/sample/ab/TaskConfig.java
@@ -1,0 +1,30 @@
+package sample.ab;
+
+/**
+ * Enum that references another enum (Priority) in its constructor.
+ * Tests the cross-enum reference pattern where one enum's value
+ * is another enum constant.
+ *
+ * Bytecode pattern in {@code <clinit>}:
+ * <pre>
+ *   $stack0 = new TaskConfig
+ *   $stack1 = getstatic Priority.HIGH [Priority]
+ *   invokespecial TaskConfig.&lt;init&gt;($stack0, "URGENT", 0, $stack1)
+ *   putstatic TaskConfig.URGENT [TaskConfig]
+ * </pre>
+ */
+public enum TaskConfig {
+    URGENT(Priority.HIGH),
+    NORMAL(Priority.MEDIUM),
+    DEFERRED(Priority.LOW);
+
+    private final Priority priority;
+
+    TaskConfig(Priority priority) {
+        this.priority = priority;
+    }
+
+    public Priority getPriority() {
+        return priority;
+    }
+}

--- a/graphite-sootup/src/test/java/sample/ab/TaskConfigWithId.java
+++ b/graphite-sootup/src/test/java/sample/ab/TaskConfigWithId.java
@@ -1,0 +1,27 @@
+package sample.ab;
+
+/**
+ * Enum that has both a primitive constructor argument and an enum reference.
+ * Tests mixed argument types: int + enum reference.
+ */
+public enum TaskConfigWithId {
+    URGENT_TASK(100, Priority.HIGH),
+    NORMAL_TASK(200, Priority.MEDIUM),
+    DEFERRED_TASK(300, Priority.LOW);
+
+    private final int id;
+    private final Priority priority;
+
+    TaskConfigWithId(int id, Priority priority) {
+        this.id = id;
+        this.priority = priority;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public Priority getPriority() {
+        return priority;
+    }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/EnumValueReferenceTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/EnumValueReferenceTest.kt
@@ -1,0 +1,162 @@
+package io.johnsonlee.graphite.sootup
+
+import io.johnsonlee.graphite.core.EnumValueReference
+import io.johnsonlee.graphite.input.LoaderConfig
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for enum value references — when one enum's constructor argument
+ * is a reference to another enum constant.
+ *
+ * Example patterns:
+ * ```java
+ * enum TaskConfig {
+ *     URGENT(Priority.HIGH),     // constructor arg is another enum constant
+ *     NORMAL(Priority.MEDIUM);
+ *     TaskConfig(Priority p) { ... }
+ * }
+ *
+ * enum TaskConfigWithId {
+ *     URGENT_TASK(100, Priority.HIGH),  // mixed: int + enum reference
+ *     NORMAL_TASK(200, Priority.MEDIUM);
+ *     TaskConfigWithId(int id, Priority p) { ... }
+ * }
+ * ```
+ */
+class EnumValueReferenceTest {
+
+    @Test
+    fun `should extract enum value references from TaskConfig`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false,
+            verbose = { println(it) }
+        ))
+
+        val graph = loader.load(testClassesDir)
+
+        // Verify TaskConfig.URGENT has Priority.HIGH as constructor arg
+        val urgentValues = graph.enumValues("sample.ab.TaskConfig", "URGENT")
+        println("TaskConfig.URGENT values: $urgentValues")
+        assertNotNull(urgentValues, "Should extract values for TaskConfig.URGENT")
+        assertEquals(1, urgentValues.size, "TaskConfig.URGENT should have 1 constructor arg")
+        val urgentRef = urgentValues[0]
+        assertTrue(urgentRef is EnumValueReference, "Constructor arg should be EnumValueReference, got: ${urgentRef?.javaClass?.simpleName}")
+        assertEquals("sample.ab.Priority", (urgentRef as EnumValueReference).enumClass)
+        assertEquals("HIGH", urgentRef.enumName)
+
+        // Verify TaskConfig.NORMAL has Priority.MEDIUM as constructor arg
+        val normalValues = graph.enumValues("sample.ab.TaskConfig", "NORMAL")
+        println("TaskConfig.NORMAL values: $normalValues")
+        assertNotNull(normalValues, "Should extract values for TaskConfig.NORMAL")
+        assertEquals(1, normalValues.size, "TaskConfig.NORMAL should have 1 constructor arg")
+        val normalRef = normalValues[0]
+        assertTrue(normalRef is EnumValueReference, "Constructor arg should be EnumValueReference, got: ${normalRef?.javaClass?.simpleName}")
+        assertEquals("sample.ab.Priority", (normalRef as EnumValueReference).enumClass)
+        assertEquals("MEDIUM", normalRef.enumName)
+
+        // Verify TaskConfig.DEFERRED has Priority.LOW as constructor arg
+        val deferredValues = graph.enumValues("sample.ab.TaskConfig", "DEFERRED")
+        println("TaskConfig.DEFERRED values: $deferredValues")
+        assertNotNull(deferredValues, "Should extract values for TaskConfig.DEFERRED")
+        assertEquals(1, deferredValues.size, "TaskConfig.DEFERRED should have 1 constructor arg")
+        val deferredRef = deferredValues[0]
+        assertTrue(deferredRef is EnumValueReference, "Constructor arg should be EnumValueReference, got: ${deferredRef?.javaClass?.simpleName}")
+        assertEquals("sample.ab.Priority", (deferredRef as EnumValueReference).enumClass)
+        assertEquals("LOW", deferredRef.enumName)
+    }
+
+    @Test
+    fun `should extract mixed constructor args with enum references`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false,
+            verbose = { println(it) }
+        ))
+
+        val graph = loader.load(testClassesDir)
+
+        // Verify TaskConfigWithId.URGENT_TASK has [100, Priority.HIGH]
+        val urgentValues = graph.enumValues("sample.ab.TaskConfigWithId", "URGENT_TASK")
+        println("TaskConfigWithId.URGENT_TASK values: $urgentValues")
+        assertNotNull(urgentValues, "Should extract values for TaskConfigWithId.URGENT_TASK")
+        assertEquals(2, urgentValues.size, "TaskConfigWithId.URGENT_TASK should have 2 constructor args")
+        assertEquals(100, urgentValues[0], "First arg should be int 100")
+        val urgentRef = urgentValues[1]
+        assertTrue(urgentRef is EnumValueReference, "Second arg should be EnumValueReference, got: ${urgentRef?.javaClass?.simpleName}")
+        assertEquals("sample.ab.Priority", (urgentRef as EnumValueReference).enumClass)
+        assertEquals("HIGH", urgentRef.enumName)
+
+        // Verify TaskConfigWithId.NORMAL_TASK has [200, Priority.MEDIUM]
+        val normalValues = graph.enumValues("sample.ab.TaskConfigWithId", "NORMAL_TASK")
+        println("TaskConfigWithId.NORMAL_TASK values: $normalValues")
+        assertNotNull(normalValues, "Should extract values for TaskConfigWithId.NORMAL_TASK")
+        assertEquals(2, normalValues.size)
+        assertEquals(200, normalValues[0], "First arg should be int 200")
+        val normalRef = normalValues[1]
+        assertTrue(normalRef is EnumValueReference, "Second arg should be EnumValueReference")
+        assertEquals("sample.ab.Priority", (normalRef as EnumValueReference).enumClass)
+        assertEquals("MEDIUM", normalRef.enumName)
+
+        // Verify TaskConfigWithId.DEFERRED_TASK has [300, Priority.LOW]
+        val deferredValues = graph.enumValues("sample.ab.TaskConfigWithId", "DEFERRED_TASK")
+        println("TaskConfigWithId.DEFERRED_TASK values: $deferredValues")
+        assertNotNull(deferredValues, "Should extract values for TaskConfigWithId.DEFERRED_TASK")
+        assertEquals(2, deferredValues.size)
+        assertEquals(300, deferredValues[0], "First arg should be int 300")
+        val deferredRef = deferredValues[1]
+        assertTrue(deferredRef is EnumValueReference, "Second arg should be EnumValueReference")
+        assertEquals("sample.ab.Priority", (deferredRef as EnumValueReference).enumClass)
+        assertEquals("LOW", deferredRef.enumName)
+    }
+
+    @Test
+    fun `should still extract primitive enum values correctly`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.ab"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+
+        // Verify Priority enum itself still has correct primitive values
+        val highValues = graph.enumValues("sample.ab.Priority", "HIGH")
+        assertNotNull(highValues, "Should extract values for Priority.HIGH")
+        assertEquals(1, highValues.size)
+        assertEquals(1, highValues[0], "Priority.HIGH should have value 1")
+
+        val mediumValues = graph.enumValues("sample.ab.Priority", "MEDIUM")
+        assertNotNull(mediumValues, "Should extract values for Priority.MEDIUM")
+        assertEquals(2, mediumValues[0], "Priority.MEDIUM should have value 2")
+
+        val lowValues = graph.enumValues("sample.ab.Priority", "LOW")
+        assertNotNull(lowValues, "Should extract values for Priority.LOW")
+        assertEquals(3, lowValues[0], "Priority.LOW should have value 3")
+
+        // Also verify ExperimentId still works (regression check)
+        val checkoutValues = graph.enumValues("sample.ab.ExperimentId", "CHECKOUT_V2")
+        assertNotNull(checkoutValues, "Should extract values for ExperimentId.CHECKOUT_V2")
+        assertEquals(1002, checkoutValues[0], "ExperimentId.CHECKOUT_V2 should have value 1002")
+    }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        return if (submodulePath.exists()) submodulePath else rootPath
+    }
+}


### PR DESCRIPTION
## Summary
Add support for tracking and extracting enum constant references when one enum's constructor takes another enum as an argument. This enables proper analysis of cross-enum dependencies in Java code.

## Changes
- **New `EnumValueReference` data class** in `Node.kt`: Represents a reference from one enum's constructor argument to another enum constant (e.g., `Priority.HIGH`)
  
- **Enhanced `SootUpAdapter`**: 
  - Added tracking of static field reads to detect enum constant references in bytecode patterns like `$stack1 = getstatic Priority.HIGH`
  - Extended `extractValueFromArg()` to handle direct `JFieldRef` arguments in constructor calls
  - Validates that field type matches declaring class to correctly identify enum constants

- **Test fixtures**: Added three new enum test classes:
  - `Priority`: Simple enum with primitive constructor arguments
  - `TaskConfig`: Enum with another enum as constructor argument
  - `TaskConfigWithId`: Enum with mixed arguments (primitive + enum reference)

- **Comprehensive test suite** (`EnumValueReferenceTest`):
  - Verifies extraction of single enum references from `TaskConfig`
  - Tests mixed constructor arguments (int + enum reference) in `TaskConfigWithId`
  - Regression test ensuring primitive enum values still extract correctly

## Implementation Details
The solution detects the bytecode pattern where enum constants are loaded via `getstatic` instructions and passed to enum constructors. The `EnumValueReference` object stores both the fully qualified enum class name and the constant name, allowing downstream analysis to resolve cross-enum relationships.