### PR TITLE
perf: cache backward slice results in DataFlowAnalysis

### DIFF
--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/DataFlowAnalysis.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/DataFlowAnalysis.kt
@@ -13,6 +13,8 @@ class DataFlowAnalysis(
     private val graph: Graph,
     private val config: AnalysisConfig = AnalysisConfig()
 ) {
+    private val backwardSliceCache = mutableMapOf<NodeId, DataFlowResult>()
+
     /**
      * Backward slice: find all nodes that can flow TO the given node.
      *
@@ -21,6 +23,7 @@ class DataFlowAnalysis(
      * - Trace backward to find all possible constant values
      */
     fun backwardSlice(from: NodeId): DataFlowResult {
+        backwardSliceCache[from]?.let { return it }
         val visited = mutableSetOf<NodeId>()
         val sources = mutableListOf<SourceInfo>()
         val paths = mutableListOf<DataFlowPath>()
@@ -93,7 +96,9 @@ class DataFlowAnalysis(
         }
 
         traverse(from, emptyList(), emptyList(), null, 0)
-        return DataFlowResult(sources, paths, propagationPaths, graph)
+        return DataFlowResult(sources, paths, propagationPaths, graph).also {
+            backwardSliceCache[from] = it
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Cache `backwardSlice` results by `NodeId` in `DataFlowAnalysis` to avoid redundant graph traversals
- When using multiple `-i` argument indices, the same argument node may be analyzed repeatedly across different call sites — the cache eliminates this duplication

## Test plan
- [x] Verify compilation passes
- [ ] Run `find-args` with `-i 1,2,3,4,5,6,7,8,9` and confirm improved performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)