### PR TITLE
docs: bump version to 0.1.0-beta.12 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:graphite-core:0.1.0-beta.11")
-    implementation("io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.11")
+    implementation("io.johnsonlee.graphite:graphite-core:0.1.0-beta.12")
+    implementation("io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.12")
 }
 ```
 
@@ -52,8 +52,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.johnsonlee.graphite:graphite-core:0.1.0-beta.11'
-    implementation 'io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.11'
+    implementation 'io.johnsonlee.graphite:graphite-core:0.1.0-beta.12'
+    implementation 'io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.12'
 }
 ```
 


### PR DESCRIPTION
## Summary
- Update dependency version references in README from 0.1.0-beta.11 to 0.1.0-beta.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)