### PR TITLE
refactor: reduce buildGraph() from 6 view.classes iterations to 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,35 @@ if (isSpecialCase && config.enableSpecialHandling) {
 - Bug only surfaced in production use, not in tests
 - **Rule**: Test coverage should mirror real-world usage patterns
 
+### Why `buildGraph()` Is Not Parallelized
+
+After reducing `SootUpAdapter.buildGraph()` from 6 passes to 2, parallel processing of classes within each pass was evaluated and rejected.
+
+#### Where time is spent
+
+| Phase | Per-class cost | Notes |
+|-------|---------------|-------|
+| `processTypeHierarchyForClass` | Trivial | A few map insertions per class |
+| `extractEnumValues` | Moderate | `<clinit>` parsing, enum classes only |
+| `processMethod` | **Heavy** | Statement graph traversal, node/edge creation — the bottleneck |
+| `processClassFieldsForClass` | Light | Iterate declared fields |
+| `processEndpointsForClass` | Light | Annotation reflection |
+| `processJacksonAnnotationsForClass` | Light | Annotation reflection |
+
+#### Why not parallel
+
+1. **The bottleneck is upstream.** SootUp's `JavaView` construction (class resolution, body interception) dominates total load time. `buildGraph()` itself is a small fraction — parallelizing it yields marginal wall-clock improvement.
+
+2. **Memory regression.** `DefaultGraph.Builder` uses fastutil `Int2ObjectOpenHashMap` for nodes and edges (51% memory savings over `HashMap`). There is no concurrent fastutil equivalent — parallelism would require falling back to `ConcurrentHashMap<Int, *>`, undoing the memory optimization that matters most for large applications.
+
+3. **Shared mutable state.** Six adapter-level maps (`localNodes`, `fieldNodes`, `parameterNodes`, `constantNodes`, `methodReturnNodes`, `allocationNodes`) are written during method processing. `constantNodes` deduplication (`getOrPut` + `graphBuilder.addNode` side-effect) is particularly hard to make atomic without locking.
+
+4. **Complexity vs. gain.** Thread-safe constant deduplication, concurrent edge list building, and race condition testing add significant complexity for a phase that processes ~200 filtered classes in under a second on typical workloads.
+
+#### If revisited
+
+If profiling reveals `buildGraph()` as a bottleneck on very large codebases, the preferred approach would be **per-class builders merged at end** (each class gets an independent builder, results merged sequentially after all classes are processed) rather than concurrent shared state. This avoids thread-safety issues but requires handling cross-class constant deduplication at merge time.
+
 ## Productivity Insights
 
 ### Claude vs Staff Engineer: Type Hierarchy Analysis Feature

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ This document tracks the project's progress and planned work. Updated alongside 
 - [x] Smart JAR filtering to reduce memory usage
 - [x] Complete constant type support (int, long, float, double, string, boolean, null, enum)
 - [x] Branch scope and control flow edge support
+- [x] Single-pass class processing: reduced `buildGraph()` from 6 `view.classes` iterations to 2 (type hierarchy + enum values; methods + fields + endpoints + Jackson annotations)
 
 ### CLI: `find-args` (`graphite-cli-find-args`)
 
@@ -81,11 +82,11 @@ This document tracks the project's progress and planned work. Updated alongside 
 
 ## In Progress
 
-- [ ] PR #20: docs — bump version to 0.1.0-beta.13
+(None)
 
 ## Planned
 
-### Unused Field Detection (`find-dead-code`)
+### 1. Unused Field Detection (`find-dead-code`)
 
 Detect fields that are never read or written outside their own class.
 
@@ -105,7 +106,7 @@ Scope:
 - `SourceCodeEditor` — add `DeleteField` action with PSI support for Java and Kotlin
 - `FindDeadCodeCommand` — report unused fields in text/JSON output, support `--delete`
 
-### Multi-Round Deletion (`find-dead-code`)
+### 2. Multi-Round Deletion (`find-dead-code`)
 
 Current implementation deletes dead code in a single pass. After cleanup branch or method deletion, new unreferenced methods/fields may emerge that weren't detectable in the first round. Add iterative deletion: delete → recompile → reload bytecode → reanalyze → delete again, until convergence (no new dead code found).
 

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -79,25 +79,30 @@ class SootUpAdapter(
      * Build the complete graph from the SootUp view
      */
     fun buildGraph(): Graph {
-        // 1. Process all classes and build type hierarchy
-        processTypeHierarchy()
+        // Pass 1: All classes — type hierarchy + enum values
+        // Enum values must be fully collected before processing methods
+        // (a method in class A may reference an enum from class B)
+        view.classes.forEach { sootClass ->
+            processTypeHierarchyForClass(sootClass)
+            if (sootClass.isEnum) {
+                extractEnumValues(sootClass)
+            }
+        }
 
-        // 2. Extract enum constant values
-        processEnumValues()
+        // Pass 2: Filtered classes — methods + fields + endpoints + Jackson
+        // Methods before fields (fields check fieldNodes map for duplicates)
+        view.classes
+            .filter { shouldIncludeClass(it) }
+            .forEach { sootClass ->
+                sootClass.methods.forEach { method ->
+                    processMethod(method)
+                }
+                processClassFieldsForClass(sootClass)
+                processEndpointsForClass(sootClass)
+                processJacksonAnnotationsForClass(sootClass)
+            }
 
-        // 3. Process all methods and build intraprocedural graphs
-        processMethods()
-
-        // 4. Process all class fields (creates FieldNodes for all declared fields)
-        processClassFields()
-
-        // 5. Extract HTTP endpoints from annotations
-        processEndpoints()
-
-        // 6. Extract Jackson annotation information
-        processJacksonAnnotations()
-
-        // 7. Build call graph if configured
+        // Build call graph if configured
         if (config.buildCallGraph) {
             processCallGraph()
         }
@@ -105,100 +110,79 @@ class SootUpAdapter(
         return graphBuilder.build()
     }
 
-    /**
-     * Extract enum constant values from enum classes.
-     * Parses the <clinit> method to find constructor arguments.
-     */
-    private fun processEnumValues() {
-        val enumClasses = view.classes.filter { it.isEnum }.toList()
-        log("Found ${enumClasses.size} enum classes to process")
-
-        enumClasses.forEach { enumClass ->
-            extractEnumValues(enumClass)
-        }
-    }
-
     private fun log(message: String) {
         config.verbose?.invoke(message)
     }
 
     /**
-     * Extract HTTP endpoints from Spring MVC annotations.
+     * Extract HTTP endpoints from Spring MVC annotations for a single class.
      * Supports @RequestMapping, @GetMapping, @PostMapping, @PutMapping, @DeleteMapping, @PatchMapping
      */
-    private fun processEndpoints() {
-        view.classes
-            .filter { shouldIncludeClass(it) }
-            .forEach { sootClass ->
-            if (sootClass !is JavaSootClass) return@forEach
+    private fun processEndpointsForClass(sootClass: SootClass) {
+        if (sootClass !is JavaSootClass) return
 
-            val className = sootClass.type.fullyQualifiedName
+        val className = sootClass.type.fullyQualifiedName
 
-            // Get class-level @RequestMapping path prefix
-            val classAnnotations = sootClass.annotations
-            val classPath = extractRequestMappingPath(classAnnotations)
+        // Get class-level @RequestMapping path prefix
+        val classAnnotations = sootClass.annotations
+        val classPath = extractRequestMappingPath(classAnnotations)
 
-            sootClass.methods.toList().forEach { method ->
-                if (method !is JavaSootMethod) return@forEach
+        sootClass.methods.toList().forEach { method ->
+            if (method !is JavaSootMethod) return@forEach
 
-                val methodAnnotations = method.annotations
-                val httpMethod = findHttpMethod(methodAnnotations)
+            val methodAnnotations = method.annotations
+            val httpMethod = findHttpMethod(methodAnnotations)
 
-                if (httpMethod != null) {
-                    val methodPath = extractMappingPath(methodAnnotations)
-                    val fullPath = combinePaths(classPath, methodPath)
-                    val produces = extractAnnotationArrayValue(methodAnnotations, "produces")
-                    val consumes = extractAnnotationArrayValue(methodAnnotations, "consumes")
+            if (httpMethod != null) {
+                val methodPath = extractMappingPath(methodAnnotations)
+                val fullPath = combinePaths(classPath, methodPath)
+                val produces = extractAnnotationArrayValue(methodAnnotations, "produces")
+                val consumes = extractAnnotationArrayValue(methodAnnotations, "consumes")
 
-                    val methodDescriptor = toMethodDescriptor(method)
+                val methodDescriptor = toMethodDescriptor(method)
 
-                    val endpoint = EndpointInfo(
-                        method = methodDescriptor,
-                        httpMethod = httpMethod,
-                        path = fullPath,
-                        produces = produces,
-                        consumes = consumes
-                    )
-                    graphBuilder.addEndpoint(endpoint)
-                    log("Found endpoint: ${httpMethod.name} $fullPath -> ${className}.${methodDescriptor.name}")
-                }
+                val endpoint = EndpointInfo(
+                    method = methodDescriptor,
+                    httpMethod = httpMethod,
+                    path = fullPath,
+                    produces = produces,
+                    consumes = consumes
+                )
+                graphBuilder.addEndpoint(endpoint)
+                log("Found endpoint: ${httpMethod.name} $fullPath -> ${className}.${methodDescriptor.name}")
             }
         }
     }
 
     /**
-     * Extract Jackson annotation information from fields and getter methods.
+     * Extract Jackson annotation information from fields and getter methods for a single class.
      * Supports @JsonProperty, @JsonIgnore, and @JsonProperty(access = JsonProperty.Access.*)
      */
-    private fun processJacksonAnnotations() {
-        view.classes
-            .filter { shouldIncludeClass(it) }
-            .forEach { sootClass ->
-            if (sootClass !is JavaSootClass) return@forEach
+    private fun processJacksonAnnotationsForClass(sootClass: SootClass) {
+        if (sootClass !is JavaSootClass) return
 
-            val className = sootClass.type.fullyQualifiedName
+        val className = sootClass.type.fullyQualifiedName
 
-            // Process field annotations
-            sootClass.fields.forEach { field ->
-                val fieldName = field.name
-                val jacksonInfo = extractJacksonInfo(field.annotations)
-                if (jacksonInfo != null) {
-                    graphBuilder.addJacksonFieldInfo(className, fieldName, jacksonInfo)
-                }
+        // Process field annotations
+        sootClass.fields.forEach { field ->
+            val fieldName = field.name
+            val jacksonInfo = extractJacksonInfo(field.annotations)
+            if (jacksonInfo != null) {
+                graphBuilder.addJacksonFieldInfo(className, fieldName, jacksonInfo)
             }
+        }
 
-            // Process getter method annotations
-            sootClass.methods.forEach { method ->
-                if (method !is JavaSootMethod) return@forEach
+        // Process getter method annotations
+        sootClass.methods.forEach { method ->
+            if (method !is JavaSootMethod) return@forEach
 
-                val methodName = method.name
-                // Only process getter methods (getXxx or isXxx)
-                if ((methodName.startsWith("get") && methodName.length > 3) ||
-                    (methodName.startsWith("is") && methodName.length > 2)) {
-                    val jacksonInfo = extractJacksonInfo(method.annotations)
-                    if (jacksonInfo != null) {
-                        graphBuilder.addJacksonGetterInfo(className, methodName, jacksonInfo)
-                    }
+            val methodName = method.name
+            // Only process getter methods (getXxx or isXxx)
+            if ((methodName.startsWith("get") && methodName.length > 3) ||
+                (methodName.startsWith("is") && methodName.length > 2)) {
+                val jacksonInfo = extractJacksonInfo(method.annotations)
+                if (jacksonInfo != null) {
+                    graphBuilder.addJacksonGetterInfo(className, methodName, jacksonInfo)
                 }
             }
         }
@@ -520,42 +504,30 @@ class SootUpAdapter(
         }
     }
 
-    private fun processTypeHierarchy() {
-        view.classes.forEach { sootClass ->
-            val classType = toTypeDescriptor(sootClass.type)
+    private fun processTypeHierarchyForClass(sootClass: SootClass) {
+        val classType = toTypeDescriptor(sootClass.type)
 
-            // Process superclass
-            sootClass.superclass.ifPresent { superType ->
-                graphBuilder.addTypeRelation(
-                    classType,
-                    toTypeDescriptor(superType),
-                    TypeRelation.EXTENDS
-                )
-            }
+        // Process superclass
+        sootClass.superclass.ifPresent { superType ->
+            graphBuilder.addTypeRelation(
+                classType,
+                toTypeDescriptor(superType),
+                TypeRelation.EXTENDS
+            )
+        }
 
-            // Process interfaces
-            sootClass.interfaces.forEach { interfaceType ->
-                graphBuilder.addTypeRelation(
-                    classType,
-                    toTypeDescriptor(interfaceType),
-                    TypeRelation.IMPLEMENTS
-                )
-            }
+        // Process interfaces
+        sootClass.interfaces.forEach { interfaceType ->
+            graphBuilder.addTypeRelation(
+                classType,
+                toTypeDescriptor(interfaceType),
+                TypeRelation.IMPLEMENTS
+            )
         }
     }
 
-    private fun processMethods() {
-        view.classes
-            .filter { shouldIncludeClass(it) }
-            .forEach { sootClass ->
-                sootClass.methods.forEach { method ->
-                    processMethod(method)
-                }
-            }
-    }
-
     /**
-     * Process all class fields to ensure FieldNodes are created for all declared fields.
+     * Process all declared fields for a single class, ensuring FieldNodes are created.
      *
      * This is important for return type analysis to discover ALL fields in a class,
      * not just those that are referenced in methods. Fields may be:
@@ -563,44 +535,40 @@ class SootUpAdapter(
      * - Fields only used by frameworks (Jackson, Lombok, etc.)
      * - Fields initialized via reflection or deserialization
      */
-    private fun processClassFields() {
-        view.classes
-            .filter { shouldIncludeClass(it) }
-            .forEach { sootClass ->
-                val className = sootClass.type.fullyQualifiedName
-                sootClass.fields.forEach { field ->
-                    val fieldName = field.name
+    private fun processClassFieldsForClass(sootClass: SootClass) {
+        val className = sootClass.type.fullyQualifiedName
+        sootClass.fields.forEach { field ->
+            val fieldName = field.name
 
-                    // Skip synthetic fields
-                    if (fieldName.startsWith("\$") || fieldName.startsWith("this\$")) {
-                        return@forEach
-                    }
-
-                    // Use field signature as key (same format as getOrCreateField)
-                    val fieldSig = field.signature.toString()
-                    if (fieldNodes.containsKey(fieldSig)) {
-                        return@forEach
-                    }
-
-                    val declaringClassType = toTypeDescriptor(sootClass.type)
-                    val baseType = toTypeDescriptor(field.type)
-
-                    // Try to get generic type from bytecode signature
-                    val fieldType = getFieldTypeWithGenerics(className, fieldName, baseType)
-
-                    val node = FieldNode(
-                        id = nextNodeId("field"),
-                        descriptor = FieldDescriptor(
-                            declaringClass = declaringClassType,
-                            name = fieldName,
-                            type = fieldType
-                        ),
-                        isStatic = field.isStatic
-                    )
-                    fieldNodes[fieldSig] = node
-                    graphBuilder.addNode(node)
-                }
+            // Skip synthetic fields
+            if (fieldName.startsWith("\$") || fieldName.startsWith("this\$")) {
+                return@forEach
             }
+
+            // Use field signature as key (same format as getOrCreateField)
+            val fieldSig = field.signature.toString()
+            if (fieldNodes.containsKey(fieldSig)) {
+                return@forEach
+            }
+
+            val declaringClassType = toTypeDescriptor(sootClass.type)
+            val baseType = toTypeDescriptor(field.type)
+
+            // Try to get generic type from bytecode signature
+            val fieldType = getFieldTypeWithGenerics(className, fieldName, baseType)
+
+            val node = FieldNode(
+                id = nextNodeId("field"),
+                descriptor = FieldDescriptor(
+                    declaringClass = declaringClassType,
+                    name = fieldName,
+                    type = fieldType
+                ),
+                isStatic = field.isStatic
+            )
+            fieldNodes[fieldSig] = node
+            graphBuilder.addNode(node)
+        }
     }
 
     private fun processMethod(method: SootMethod) {


### PR DESCRIPTION
## Summary

- Merge 6 separate `process*()` passes over `view.classes` in `SootUpAdapter.buildGraph()` into 2:
  - **Pass 1** (all classes): type hierarchy + enum values
  - **Pass 2** (filtered classes): methods + fields + endpoints + Jackson annotations
- Extract per-class methods (`processTypeHierarchyForClass`, `processClassFieldsForClass`, `processEndpointsForClass`, `processJacksonAnnotationsForClass`) from loop bodies
- Document the decision not to parallelize `buildGraph()` (fastutil memory savings vs `ConcurrentHashMap`, shared mutable state barriers)

## Test plan

- [x] `./gradlew check` passes — all existing tests validate correctness (pure refactor, no behavioral change)
- [x] `./gradlew koverLog` — coverage >= 98% across all modules (graphite-core 98.2%, graphite-sootup 98.0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)