### PR TITLE
docs: bump version to 0.1.0-beta.15 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:graphite-core:0.1.0-beta.14")
-    implementation("io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.14")
+    implementation("io.johnsonlee.graphite:graphite-core:0.1.0-beta.15")
+    implementation("io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.15")
 }
 ```
 
@@ -52,8 +52,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.johnsonlee.graphite:graphite-core:0.1.0-beta.14'
-    implementation 'io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.14'
+    implementation 'io.johnsonlee.graphite:graphite-core:0.1.0-beta.15'
+    implementation 'io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.15'
 }
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document tracks the project's progress and planned work. Updated alongside code changes per the development workflow in [CLAUDE.md](CLAUDE.md).
 
-**Current version:** `0.1.0-beta.14`
+**Current version:** `0.1.0-beta.15`
 
 ## Completed
 


### PR DESCRIPTION
## Summary
- Update version references from 0.1.0-beta.14 to 0.1.0-beta.15 in README and ROADMAP

🤖 Generated with [Claude Code](https://claude.com/claude-code)