### PR TITLE
docs: bump version to 0.1.0-beta.16 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:graphite-core:0.1.0-beta.15")
-    implementation("io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.15")
+    implementation("io.johnsonlee.graphite:graphite-core:0.1.0-beta.16")
+    implementation("io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.16")
 }
 ```
 
@@ -52,8 +52,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.johnsonlee.graphite:graphite-core:0.1.0-beta.15'
-    implementation 'io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.15'
+    implementation 'io.johnsonlee.graphite:graphite-core:0.1.0-beta.16'
+    implementation 'io.johnsonlee.graphite:graphite-sootup:0.1.0-beta.16'
 }
 ```
 


### PR DESCRIPTION
## Summary
- Update version references from 0.1.0-beta.15 to 0.1.0-beta.16 in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)