### PR TITLE
feat: add WebGraph-backed graph storage

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ fastutil = "8.5.13"
 jackson = "2.17.0"
 guava = "33.0.0-jre"
 snakeyaml = "2.2"
+webgraph = "3.6.12"
+zipkin = "3.5.1"
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 fastutil = { module = "it.unimi.dsi:fastutil", version.ref = "fastutil" }
@@ -28,3 +30,5 @@ sootup-callgraph = { module = "org.soot-oss:sootup.callgraph", version.ref = "so
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
+webgraph = { module = "it.unimi.dsi:webgraph", version.ref = "webgraph" }
+zipkin-server = { module = "io.zipkin:zipkin-server", version.ref = "zipkin" }

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Edge.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Edge.kt
@@ -1,12 +1,13 @@
 package io.johnsonlee.graphite.core
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
+import java.io.Serializable
 
 /**
  * Edges represent relationships between nodes.
  * The edge type determines how values flow or relate.
  */
-sealed interface Edge {
+sealed interface Edge : Serializable {
     val from: NodeId
     val to: NodeId
 }
@@ -101,7 +102,7 @@ enum class ControlFlowKind {
 data class BranchComparison(
     val operator: ComparisonOp,
     val comparandNodeId: NodeId
-)
+) : Serializable
 
 enum class ComparisonOp {
     EQ, NE, LT, GE, GT, LE

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
@@ -1,12 +1,13 @@
 package io.johnsonlee.graphite.core
 
+import java.io.Serializable
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Base interface for all nodes in the analysis graph.
  * Every element in the program that can participate in dataflow is a Node.
  */
-sealed interface Node {
+sealed interface Node : Serializable {
     val id: NodeId
 }
 
@@ -15,7 +16,7 @@ sealed interface Node {
  * Saves ~36 bytes per node compared to String-based IDs.
  */
 @JvmInline
-value class NodeId(val value: Int) {
+value class NodeId(val value: Int) : Serializable {
     companion object {
         private val counter = AtomicInteger(0)
 
@@ -124,7 +125,7 @@ data class NullConstant(
 data class EnumValueReference(
     val enumClass: String,
     val enumName: String
-) {
+) : Serializable {
     override fun toString(): String = "$enumClass.$enumName"
 }
 
@@ -184,7 +185,7 @@ data class CallSiteNode(
 data class TypeDescriptor(
     val className: String,
     val typeArguments: List<TypeDescriptor> = emptyList()
-) {
+) : Serializable {
     val simpleName: String get() = className.substringAfterLast('.')
 
     fun isSubtypeOf(other: TypeDescriptor): Boolean {
@@ -198,7 +199,7 @@ data class MethodDescriptor(
     val name: String,
     val parameterTypes: List<TypeDescriptor>,
     val returnType: TypeDescriptor
-) {
+) : Serializable {
     val signature: String get() = "${declaringClass.className}.$name(${parameterTypes.joinToString(",") { it.className }})"
 }
 
@@ -206,4 +207,4 @@ data class FieldDescriptor(
     val declaringClass: TypeDescriptor,
     val name: String,
     val type: TypeDescriptor
-)
+) : Serializable

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/DefaultGraph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/DefaultGraph.kt
@@ -106,6 +106,8 @@ class DefaultGraph private constructor(
     override fun branchScopesFor(conditionNodeId: NodeId): Sequence<BranchScope> =
         branchScopeIndex[conditionNodeId.value]?.asSequence() ?: emptySequence()
 
+    override fun typeHierarchyTypes(): Set<String> = typeHierarchy.allKeys()
+
     /**
      * Builder for constructing DefaultGraph instances.
      * Uses concurrent collections during building, then compacts to fastutil collections.
@@ -221,6 +223,8 @@ class TypeHierarchy private constructor(
 
     fun subtypes(type: TypeDescriptor): Sequence<TypeDescriptor> =
         subtypeMap[type.className]?.asSequence() ?: emptySequence()
+
+    fun allKeys(): Set<String> = supertypeMap.keys + subtypeMap.keys
 
     class Builder {
         private val supertypes = mutableMapOf<String, MutableSet<TypeDescriptor>>()

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -94,6 +94,11 @@ interface Graph {
      */
     fun branchScopesFor(conditionNodeId: NodeId): Sequence<BranchScope>
 
+    /**
+     * Get all type names that have type hierarchy information (supertypes or subtypes).
+     */
+    fun typeHierarchyTypes(): Set<String> = emptySet()
+
 }
 
 /**

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
@@ -203,6 +203,24 @@ class DefaultGraphTest {
         assertEquals(0, graph.supertypes(fooType).count())
     }
 
+    @Test
+    fun `typeHierarchyTypes returns all types with relations`() {
+        val graph = DefaultGraph.Builder()
+            .addTypeRelation(barType, fooType, TypeRelation.EXTENDS)
+            .build()
+
+        val types = graph.typeHierarchyTypes()
+        assertTrue(types.contains("com.example.Foo"))
+        assertTrue(types.contains("com.example.Bar"))
+        assertEquals(2, types.size)
+    }
+
+    @Test
+    fun `typeHierarchyTypes returns empty when no relations`() {
+        val graph = DefaultGraph.Builder().build()
+        assertTrue(graph.typeHierarchyTypes().isEmpty())
+    }
+
     // ========================================================================
     // Enum values
     // ========================================================================

--- a/graphite-webgraph/build.gradle.kts
+++ b/graphite-webgraph/build.gradle.kts
@@ -1,0 +1,23 @@
+description = "Graphite WebGraph Store - Disk-backed graph storage using WebGraph compression"
+
+plugins {
+    id("org.jetbrains.kotlinx.kover") version "0.9.1"
+}
+
+val testFixtures: Configuration by configurations.creating
+
+dependencies {
+    api(project(":graphite-core"))
+    implementation(libs.webgraph)
+    testImplementation(project(":graphite-sootup"))
+    "testFixtures"("${libs.zipkin.server.get().module}:${libs.zipkin.server.get().versionConstraint.requiredVersion}:exec@jar")
+}
+
+tasks.test {
+    doFirst {
+        val zipkinJar = testFixtures.resolve().firstOrNull()
+        if (zipkinJar != null) {
+            systemProperty("zipkin.jar.path", zipkinJar.absolutePath)
+        }
+    }
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -1,0 +1,206 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.MethodPattern
+import it.unimi.dsi.webgraph.ArrayListMutableGraph
+import it.unimi.dsi.webgraph.BVGraph
+import it.unimi.dsi.webgraph.Transform
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Save and load [Graph] instances using WebGraph compression.
+ *
+ * The graph is stored as:
+ * - BVGraph files for adjacency structure (forward + backward per edge type)
+ * - Binary files for node data, edge metadata, and graph metadata
+ */
+object GraphStore {
+
+    private const val NODES_FILE = "nodes.bin"
+    private const val EDGES_FILE = "edges.bin"
+    private const val METADATA_FILE = "metadata.bin"
+    private const val FORWARD_GRAPH = "forward"
+    private const val BACKWARD_GRAPH = "backward"
+
+    /**
+     * Save a graph to disk in WebGraph format.
+     */
+    fun save(graph: Graph, dir: Path) {
+        Files.createDirectories(dir)
+
+        // 1. Collect all nodes and find max node ID for graph sizing
+        val allNodes = mutableListOf<Node>()
+        val maxNodeId = collectNodes(graph, allNodes)
+
+        // 2. Collect all edges
+        val allEdges = mutableListOf<Edge>()
+        val forwardAdj = ArrayListMutableGraph(maxNodeId + 1)
+
+        for (node in allNodes) {
+            for (edge in graph.outgoing(node.id)) {
+                allEdges.add(edge)
+                try {
+                    forwardAdj.addArc(edge.from.value, edge.to.value)
+                } catch (e: IllegalArgumentException) {
+                    // Duplicate arc - skip
+                }
+            }
+        }
+
+        // 3. Save BVGraph (forward)
+        val forwardImmutable = forwardAdj.immutableView()
+        BVGraph.store(forwardImmutable, dir.resolve(FORWARD_GRAPH).toString())
+
+        // 4. Save BVGraph (backward = transpose)
+        val backward = Transform.transpose(forwardImmutable)
+        BVGraph.store(backward, dir.resolve(BACKWARD_GRAPH).toString())
+
+        // 5. Save nodes
+        NodeSerializer.saveNodes(allNodes.asSequence(), dir.resolve(NODES_FILE))
+
+        // 6. Save edges (with type info)
+        NodeSerializer.saveEdges(allEdges, dir.resolve(EDGES_FILE))
+
+        // 7. Save metadata
+        val metadata = collectMetadata(graph)
+        NodeSerializer.saveMetadata(metadata, dir.resolve(METADATA_FILE))
+    }
+
+    /**
+     * Load a graph from disk.
+     */
+    fun load(dir: Path): Graph {
+        require(Files.isDirectory(dir)) { "Not a directory: $dir" }
+
+        val forward = BVGraph.load(dir.resolve(FORWARD_GRAPH).toString())
+        val backward = BVGraph.load(dir.resolve(BACKWARD_GRAPH).toString())
+        val nodes = NodeSerializer.loadNodes(dir.resolve(NODES_FILE))
+        val edges = NodeSerializer.loadEdges(dir.resolve(EDGES_FILE))
+        val metadata = NodeSerializer.loadMetadata(dir.resolve(METADATA_FILE))
+
+        return WebGraphBackedGraph(forward, backward, nodes, edges, metadata)
+    }
+
+    private fun collectNodes(graph: Graph, result: MutableList<Node>): Int {
+        var maxId = 0
+        for (node in graph.nodes(Node::class.java)) {
+            result.add(node)
+            if (node.id.value > maxId) maxId = node.id.value
+        }
+        return maxId
+    }
+
+    private fun collectMetadata(graph: Graph): GraphMetadata {
+        // Collect type hierarchy
+        val supertypes = mutableMapOf<String, Set<TypeDescriptor>>()
+        val subtypes = mutableMapOf<String, Set<TypeDescriptor>>()
+
+        // Walk all types referenced in the graph (nodes + methods)
+        val allTypes = mutableSetOf<TypeDescriptor>()
+        graph.nodes(Node::class.java).forEach { node ->
+            when (node) {
+                is LocalVariable -> {
+                    allTypes.add(node.type)
+                    allTypes.add(node.method.declaringClass)
+                }
+                is FieldNode -> {
+                    allTypes.add(node.descriptor.declaringClass)
+                    allTypes.add(node.descriptor.type)
+                }
+                is ParameterNode -> {
+                    allTypes.add(node.type)
+                    allTypes.add(node.method.declaringClass)
+                }
+                is ReturnNode -> {
+                    node.actualType?.let { allTypes.add(it) }
+                    allTypes.add(node.method.declaringClass)
+                    allTypes.add(node.method.returnType)
+                }
+                is CallSiteNode -> {
+                    allTypes.add(node.callee.declaringClass)
+                    allTypes.add(node.callee.returnType)
+                    allTypes.add(node.caller.declaringClass)
+                }
+                is EnumConstant -> allTypes.add(node.enumType)
+                else -> {}
+            }
+        }
+        // Also collect types from registered methods
+        graph.methods(MethodPattern()).forEach { method ->
+            allTypes.add(method.declaringClass)
+            allTypes.add(method.returnType)
+            method.parameterTypes.forEach { allTypes.add(it) }
+        }
+
+        // Include all types that have hierarchy info (covers types not referenced by nodes)
+        graph.typeHierarchyTypes().forEach { allTypes.add(TypeDescriptor(it)) }
+
+        for (type in allTypes) {
+            val sups = graph.supertypes(type).toSet()
+            if (sups.isNotEmpty()) supertypes[type.className] = sups
+            val subs = graph.subtypes(type).toSet()
+            if (subs.isNotEmpty()) subtypes[type.className] = subs
+        }
+
+        // Collect methods
+        val methods = graph.methods(MethodPattern())
+            .associateBy { it.signature }
+
+        // Collect enum values - we can't enumerate all enum keys from Graph interface,
+        // so we extract from EnumConstant nodes
+        val enumValues = mutableMapOf<String, List<Any?>>()
+        graph.nodes(EnumConstant::class.java).forEach { ec ->
+            val key = "${ec.enumType.className}#${ec.enumName}"
+            if (key !in enumValues) {
+                val values = graph.enumValues(ec.enumType.className, ec.enumName)
+                if (values != null) enumValues[key] = values
+            }
+        }
+
+        // Collect member annotations - extract from all classes referenced in nodes
+        val memberAnnotations = mutableMapOf<String, Map<String, Map<String, Any?>>>()
+        val classMembers = mutableSetOf<Pair<String, String>>()
+        graph.nodes(Node::class.java).forEach { node ->
+            when (node) {
+                is FieldNode -> classMembers.add(node.descriptor.declaringClass.className to node.descriptor.name)
+                is CallSiteNode -> classMembers.add(node.callee.declaringClass.className to node.callee.name)
+                is ParameterNode -> classMembers.add(node.method.declaringClass.className to node.method.name)
+                is ReturnNode -> classMembers.add(node.method.declaringClass.className to node.method.name)
+                else -> {}
+            }
+        }
+        // Also add <class> level annotations
+        val allClasses = classMembers.map { it.first }.toSet()
+        for (className in allClasses) {
+            classMembers.add(className to "<class>")
+        }
+        for ((className, memberName) in classMembers) {
+            val annotations = graph.memberAnnotations(className, memberName)
+            if (annotations.isNotEmpty()) {
+                memberAnnotations["$className#$memberName"] = annotations
+            }
+        }
+
+        // Collect branch scopes
+        val branchScopes = graph.branchScopes().map { bs ->
+            BranchScopeData(
+                conditionNodeId = bs.conditionNodeId.value,
+                method = bs.method,
+                comparison = bs.comparison,
+                trueBranchNodeIds = bs.trueBranchNodeIds.toIntArray(),
+                falseBranchNodeIds = bs.falseBranchNodeIds.toIntArray()
+            )
+        }.toList()
+
+        return GraphMetadata(
+            methods = methods,
+            supertypes = supertypes,
+            subtypes = subtypes,
+            enumValues = enumValues,
+            memberAnnotations = memberAnnotations,
+            branchScopes = branchScopes
+        )
+    }
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
@@ -1,0 +1,93 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.*
+import java.io.*
+import java.nio.file.Path
+
+/**
+ * Serializes and deserializes graph nodes and metadata to/from binary files.
+ */
+internal object NodeSerializer {
+
+    fun saveNodes(nodes: Sequence<Node>, file: Path) {
+        ObjectOutputStream(BufferedOutputStream(file.toFile().outputStream())).use { oos ->
+            val list = nodes.toList()
+            oos.writeInt(list.size)
+            for (node in list) {
+                oos.writeObject(node)
+            }
+        }
+    }
+
+    fun loadNodes(file: Path): Map<Int, Node> {
+        val result = mutableMapOf<Int, Node>()
+        ObjectInputStream(BufferedInputStream(file.toFile().inputStream())).use { ois ->
+            val count = ois.readInt()
+            repeat(count) {
+                val node = ois.readObject() as Node
+                result[node.id.value] = node
+            }
+        }
+        return result
+    }
+
+    fun saveEdges(edges: List<Edge>, file: Path) {
+        ObjectOutputStream(BufferedOutputStream(file.toFile().outputStream())).use { oos ->
+            oos.writeInt(edges.size)
+            for (edge in edges) {
+                oos.writeObject(edge)
+            }
+        }
+    }
+
+    fun loadEdges(file: Path): List<Edge> {
+        val result = mutableListOf<Edge>()
+        ObjectInputStream(BufferedInputStream(file.toFile().inputStream())).use { ois ->
+            val count = ois.readInt()
+            repeat(count) {
+                result.add(ois.readObject() as Edge)
+            }
+        }
+        return result
+    }
+
+    fun saveMetadata(metadata: GraphMetadata, file: Path) {
+        ObjectOutputStream(BufferedOutputStream(file.toFile().outputStream())).use { oos ->
+            oos.writeObject(metadata)
+        }
+    }
+
+    fun loadMetadata(file: Path): GraphMetadata {
+        ObjectInputStream(BufferedInputStream(file.toFile().inputStream())).use { ois ->
+            return ois.readObject() as GraphMetadata
+        }
+    }
+}
+
+/**
+ * Holds all non-graph metadata that doesn't fit in the adjacency structure.
+ */
+data class GraphMetadata(
+    val methods: Map<String, MethodDescriptor>,
+    val supertypes: Map<String, Set<TypeDescriptor>>,
+    val subtypes: Map<String, Set<TypeDescriptor>>,
+    val enumValues: Map<String, List<Any?>>,
+    val memberAnnotations: Map<String, Map<String, Map<String, Any?>>>,
+    val branchScopes: List<BranchScopeData>
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+data class BranchScopeData(
+    val conditionNodeId: Int,
+    val method: MethodDescriptor,
+    val comparison: BranchComparison,
+    val trueBranchNodeIds: IntArray,
+    val falseBranchNodeIds: IntArray
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
@@ -1,0 +1,96 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.input.EmptyResourceAccessor
+import io.johnsonlee.graphite.input.ResourceAccessor
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet
+import it.unimi.dsi.webgraph.ImmutableGraph
+
+/**
+ * A [Graph] implementation backed by WebGraph's compressed adjacency structure.
+ *
+ * Forward and backward edges are stored as separate BVGraph files for efficient
+ * successor and predecessor queries. Node data and metadata are loaded into memory.
+ */
+internal class WebGraphBackedGraph(
+    private val forward: ImmutableGraph,
+    private val backward: ImmutableGraph,
+    private val nodesById: Map<Int, Node>,
+    private val allEdges: List<Edge>,
+    private val metadata: GraphMetadata
+) : Graph {
+
+    // Index: nodeId -> outgoing edges
+    private val outgoingIndex: Map<Int, List<Edge>> by lazy {
+        allEdges.groupBy { it.from.value }
+    }
+
+    // Index: nodeId -> incoming edges
+    private val incomingIndex: Map<Int, List<Edge>> by lazy {
+        allEdges.groupBy { it.to.value }
+    }
+
+    // Lazy branch scope materialization
+    private val branchScopeIndex: Map<Int, List<BranchScope>> by lazy {
+        metadata.branchScopes.map { raw ->
+            BranchScope(
+                conditionNodeId = NodeId(raw.conditionNodeId),
+                method = raw.method,
+                comparison = raw.comparison,
+                trueBranchNodeIds = IntOpenHashSet(raw.trueBranchNodeIds),
+                falseBranchNodeIds = IntOpenHashSet(raw.falseBranchNodeIds)
+            )
+        }.groupBy { it.conditionNodeId.value }
+    }
+
+    override fun node(id: NodeId): Node? = nodesById[id.value]
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+        nodesById.values.asSequence().filter { type.isInstance(it) } as Sequence<T>
+
+    override fun outgoing(id: NodeId): Sequence<Edge> =
+        outgoingIndex[id.value]?.asSequence() ?: emptySequence()
+
+    override fun incoming(id: NodeId): Sequence<Edge> =
+        incomingIndex[id.value]?.asSequence() ?: emptySequence()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Edge> outgoing(id: NodeId, type: Class<T>): Sequence<T> =
+        outgoing(id).filter { type.isInstance(it) } as Sequence<T>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Edge> incoming(id: NodeId, type: Class<T>): Sequence<T> =
+        incoming(id).filter { type.isInstance(it) } as Sequence<T>
+
+    override fun callSites(methodPattern: MethodPattern): Sequence<CallSiteNode> =
+        nodes(CallSiteNode::class.java).filter { methodPattern.matches(it.callee) }
+
+    override fun supertypes(type: TypeDescriptor): Sequence<TypeDescriptor> =
+        metadata.supertypes[type.className]?.asSequence() ?: emptySequence()
+
+    override fun subtypes(type: TypeDescriptor): Sequence<TypeDescriptor> =
+        metadata.subtypes[type.className]?.asSequence() ?: emptySequence()
+
+    override fun methods(pattern: MethodPattern): Sequence<MethodDescriptor> =
+        metadata.methods.values.asSequence().filter { pattern.matches(it) }
+
+    override fun enumValues(enumClass: String, enumName: String): List<Any?>? =
+        metadata.enumValues["$enumClass#$enumName"]
+
+    override fun memberAnnotations(className: String, memberName: String): Map<String, Map<String, Any?>> =
+        metadata.memberAnnotations["$className#$memberName"] ?: emptyMap()
+
+    override val resources: ResourceAccessor = EmptyResourceAccessor
+
+    override fun branchScopes(): Sequence<BranchScope> =
+        branchScopeIndex.values.asSequence().flatMap { it.asSequence() }
+
+    override fun branchScopesFor(conditionNodeId: NodeId): Sequence<BranchScope> =
+        branchScopeIndex[conditionNodeId.value]?.asSequence() ?: emptySequence()
+
+    override fun typeHierarchyTypes(): Set<String> =
+        metadata.supertypes.keys + metadata.subtypes.keys
+}

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -1,0 +1,671 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.graph.nodes
+import io.johnsonlee.graphite.input.EmptyResourceAccessor
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GraphStoreTest {
+
+    @Test
+    fun `round-trip save and load preserves nodes`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            // Verify nodes
+            val originalNodes = graph.nodes(Node::class.java).toList()
+            val loadedNodes = loaded.nodes(Node::class.java).toList()
+            assertEquals(originalNodes.size, loadedNodes.size, "Node count should match")
+
+            for (node in originalNodes) {
+                assertNotNull(loaded.node(node.id), "Node ${node.id} should exist in loaded graph")
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves outgoing edges`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val nodes = graph.nodes(Node::class.java).toList()
+            for (node in nodes) {
+                val originalEdges = graph.outgoing(node.id).toList()
+                val loadedEdges = loaded.outgoing(node.id).toList()
+                assertEquals(originalEdges.size, loadedEdges.size,
+                    "Outgoing edge count should match for node ${node.id}")
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves incoming edges`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val nodes = graph.nodes(Node::class.java).toList()
+            for (node in nodes) {
+                val originalEdges = graph.incoming(node.id).toList()
+                val loadedEdges = loaded.incoming(node.id).toList()
+                assertEquals(originalEdges.size, loadedEdges.size,
+                    "Incoming edge count should match for node ${node.id}")
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves typed edge queries`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val node = graph.nodes(Node::class.java).first()
+            val originalDataFlow = graph.outgoing(node.id, DataFlowEdge::class.java).toList()
+            val loadedDataFlow = loaded.outgoing(node.id, DataFlowEdge::class.java).toList()
+            assertEquals(originalDataFlow.size, loadedDataFlow.size)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves methods`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val originalMethods = graph.methods(MethodPattern()).toList()
+            val loadedMethods = loaded.methods(MethodPattern()).toList()
+            assertEquals(originalMethods.size, loadedMethods.size)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves member annotations`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val annotations = loaded.memberAnnotations("com.example.Foo", "bar")
+            assertEquals(
+                graph.memberAnnotations("com.example.Foo", "bar"),
+                annotations
+            )
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves type hierarchy`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val child = TypeDescriptor("com.example.Child")
+            val parent = TypeDescriptor("com.example.Parent")
+            assertTrue(loaded.supertypes(child).any { it.className == "com.example.Parent" })
+            assertTrue(loaded.subtypes(parent).any { it.className == "com.example.Child" })
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves enum values`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val values = loaded.enumValues("com.example.Status", "ACTIVE")
+            assertEquals(listOf(1, "active"), values)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves call sites`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val originalCallSites = graph.nodes(CallSiteNode::class.java).toList()
+            val loadedCallSites = loaded.nodes(CallSiteNode::class.java).toList()
+            assertEquals(originalCallSites.size, loadedCallSites.size)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `load from nonexistent directory throws`() {
+        try {
+            GraphStore.load(Files.createTempFile("not", "dir"))
+            assertTrue(false, "Should have thrown")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `empty graph round-trips`() {
+        val graph = DefaultGraph.Builder().build()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+            assertEquals(0, loaded.nodes(Node::class.java).count())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // All constant node types round-trip
+    // ========================================================================
+
+    @Test
+    fun `round-trip preserves all constant node types`() {
+        val builder = DefaultGraph.Builder()
+        val strConst = StringConstant(NodeId.next(), "hello")
+        val longConst = LongConstant(NodeId.next(), 123456789L)
+        val floatConst = FloatConstant(NodeId.next(), 3.14f)
+        val doubleConst = DoubleConstant(NodeId.next(), 2.718281828)
+        val boolConst = BooleanConstant(NodeId.next(), true)
+        val nullConst = NullConstant(NodeId.next())
+        val intConst = IntConstant(NodeId.next(), 99)
+
+        builder.addNode(strConst)
+        builder.addNode(longConst)
+        builder.addNode(floatConst)
+        builder.addNode(doubleConst)
+        builder.addNode(boolConst)
+        builder.addNode(nullConst)
+        builder.addNode(intConst)
+
+        val graph = builder.build()
+        val dir = Files.createTempDirectory("webgraph-const-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val loadedStr = loaded.node(strConst.id) as StringConstant
+            assertEquals("hello", loadedStr.value)
+
+            val loadedLong = loaded.node(longConst.id) as LongConstant
+            assertEquals(123456789L, loadedLong.value)
+
+            val loadedFloat = loaded.node(floatConst.id) as FloatConstant
+            assertEquals(3.14f, loadedFloat.value)
+
+            val loadedDouble = loaded.node(doubleConst.id) as DoubleConstant
+            assertEquals(2.718281828, loadedDouble.value)
+
+            val loadedBool = loaded.node(boolConst.id) as BooleanConstant
+            assertEquals(true, loadedBool.value)
+
+            val loadedNull = loaded.node(nullConst.id) as NullConstant
+            assertNull(loadedNull.value)
+
+            assertEquals(7, loaded.nodes(ConstantNode::class.java).count())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // ControlFlowEdge and TypeEdge round-trip
+    // ========================================================================
+
+    @Test
+    fun `round-trip preserves ControlFlowEdge with BranchComparison`() {
+        val builder = DefaultGraph.Builder()
+        val n1 = IntConstant(NodeId.next(), 1)
+        val n2 = IntConstant(NodeId.next(), 2)
+        val n3 = IntConstant(NodeId.next(), 0)
+        builder.addNode(n1)
+        builder.addNode(n2)
+        builder.addNode(n3)
+
+        val comparison = BranchComparison(ComparisonOp.EQ, n3.id)
+        val cfEdge = ControlFlowEdge(n1.id, n2.id, ControlFlowKind.BRANCH_TRUE, comparison)
+        val seqEdge = ControlFlowEdge(n2.id, n3.id, ControlFlowKind.SEQUENTIAL)
+        builder.addEdge(cfEdge)
+        builder.addEdge(seqEdge)
+
+        val graph = builder.build()
+        val dir = Files.createTempDirectory("webgraph-cf-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val loadedCfEdges = loaded.outgoing(n1.id, ControlFlowEdge::class.java).toList()
+            assertEquals(1, loadedCfEdges.size)
+            assertEquals(ControlFlowKind.BRANCH_TRUE, loadedCfEdges[0].kind)
+            assertNotNull(loadedCfEdges[0].comparison)
+            assertEquals(ComparisonOp.EQ, loadedCfEdges[0].comparison!!.operator)
+            assertEquals(n3.id, loadedCfEdges[0].comparison!!.comparandNodeId)
+
+            val loadedSeqEdges = loaded.outgoing(n2.id, ControlFlowEdge::class.java).toList()
+            assertEquals(1, loadedSeqEdges.size)
+            assertEquals(ControlFlowKind.SEQUENTIAL, loadedSeqEdges[0].kind)
+            assertNull(loadedSeqEdges[0].comparison)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves TypeEdge`() {
+        val builder = DefaultGraph.Builder()
+        val n1 = IntConstant(NodeId.next(), 1)
+        val n2 = IntConstant(NodeId.next(), 2)
+        builder.addNode(n1)
+        builder.addNode(n2)
+
+        val typeEdge = TypeEdge(n1.id, n2.id, TypeRelation.IMPLEMENTS)
+        builder.addEdge(typeEdge)
+
+        val graph = builder.build()
+        val dir = Files.createTempDirectory("webgraph-type-edge-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val loadedEdges = loaded.outgoing(n1.id, TypeEdge::class.java).toList()
+            assertEquals(1, loadedEdges.size)
+            assertEquals(TypeRelation.IMPLEMENTS, loadedEdges[0].kind)
+            assertEquals(n2.id, loadedEdges[0].to)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Branch scopes round-trip
+    // ========================================================================
+
+    @Test
+    fun `round-trip preserves branch scopes`() {
+        val builder = DefaultGraph.Builder()
+        val fooType = TypeDescriptor("com.example.Foo")
+        val method = MethodDescriptor(fooType, "check", emptyList(), TypeDescriptor("boolean"))
+        builder.addMethod(method)
+
+        val condNode = IntConstant(NodeId.next(), 0)
+        val trueNode = IntConstant(NodeId.next(), 1)
+        val falseNode = IntConstant(NodeId.next(), 2)
+        builder.addNode(condNode)
+        builder.addNode(trueNode)
+        builder.addNode(falseNode)
+
+        val comp = BranchComparison(ComparisonOp.NE, condNode.id)
+        builder.addBranchScope(condNode.id, method, comp, intArrayOf(trueNode.id.value), intArrayOf(falseNode.id.value))
+
+        val graph = builder.build()
+        val dir = Files.createTempDirectory("webgraph-branch-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val scopes = loaded.branchScopes().toList()
+            assertEquals(1, scopes.size)
+            assertEquals(condNode.id, scopes[0].conditionNodeId)
+            assertEquals(ComparisonOp.NE, scopes[0].comparison.operator)
+            assertTrue(scopes[0].trueBranchNodeIds.contains(trueNode.id.value))
+            assertTrue(scopes[0].falseBranchNodeIds.contains(falseNode.id.value))
+
+            // Also test branchScopesFor
+            val scopesFor = loaded.branchScopesFor(condNode.id).toList()
+            assertEquals(1, scopesFor.size)
+
+            // branchScopesFor with unknown node returns empty
+            assertEquals(0, loaded.branchScopesFor(NodeId(999999)).count())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // callSites with pattern filtering on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `callSites with pattern filtering on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-callsite-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            // Match existing callee
+            val matched = loaded.callSites(MethodPattern(declaringClass = "com.example.Foo", name = "baz")).toList()
+            assertEquals(1, matched.size)
+
+            // No match
+            val noMatch = loaded.callSites(MethodPattern(name = "nonexistent")).toList()
+            assertTrue(noMatch.isEmpty())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Reified nodes<T>() type filtering on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `reified nodes type filtering on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-reified-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val intConstants = loaded.nodes<IntConstant>().toList()
+            assertEquals(1, intConstants.size)
+            assertEquals(42, intConstants[0].value)
+
+            val callSites = loaded.nodes<CallSiteNode>().toList()
+            assertEquals(1, callSites.size)
+
+            val fields = loaded.nodes<FieldNode>().toList()
+            assertEquals(1, fields.size)
+
+            val params = loaded.nodes<ParameterNode>().toList()
+            assertEquals(1, params.size)
+
+            val locals = loaded.nodes<LocalVariable>().toList()
+            assertEquals(1, locals.size)
+
+            val returns = loaded.nodes<ReturnNode>().toList()
+            assertEquals(1, returns.size)
+
+            val enums = loaded.nodes<EnumConstant>().toList()
+            assertEquals(1, enums.size)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Resources on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `loaded graph resources returns EmptyResourceAccessor`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-resources-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            assertTrue(loaded.resources === EmptyResourceAccessor)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Type hierarchy on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `typeHierarchyTypes on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-hierarchy-types-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val types = loaded.typeHierarchyTypes()
+            assertTrue(types.contains("com.example.Parent"))
+            assertTrue(types.contains("com.example.Child"))
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `supertypes and subtypes return empty for unknown type on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-hierarchy-empty-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            assertEquals(0, loaded.supertypes(TypeDescriptor("com.nonexistent.Type")).count())
+            assertEquals(0, loaded.subtypes(TypeDescriptor("com.nonexistent.Type")).count())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Enum values on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `enumValues returns null for missing enum on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-enum-null-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            assertNull(loaded.enumValues("com.example.Missing", "MISSING"))
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Member annotations on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `memberAnnotations returns empty for unknown member on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-annot-empty-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            assertTrue(loaded.memberAnnotations("com.example.Unknown", "unknown").isEmpty())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Methods on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `methods with pattern filter on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-method-filter-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val barMethods = loaded.methods(MethodPattern(name = "bar")).toList()
+            assertEquals(1, barMethods.size)
+            assertEquals("bar", barMethods[0].name)
+
+            val allMethods = loaded.methods(MethodPattern()).toList()
+            assertEquals(2, allMethods.size)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Incoming edges on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `incoming typed edges on loaded graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-incoming-typed-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            // The local node has incoming DataFlowEdges (from param and constant)
+            val locals = loaded.nodes<LocalVariable>().toList()
+            assertEquals(1, locals.size)
+            val localId = locals[0].id
+
+            val incomingDf = loaded.incoming(localId, DataFlowEdge::class.java).toList()
+            assertEquals(2, incomingDf.size)
+
+            // No incoming CallEdge to local
+            val incomingCall = loaded.incoming(localId, CallEdge::class.java).toList()
+            assertEquals(0, incomingCall.size)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Outgoing/incoming for node without edges on loaded graph
+    // ========================================================================
+
+    @Test
+    fun `outgoing and incoming return empty for isolated node on loaded graph`() {
+        val builder = DefaultGraph.Builder()
+        val isolated = IntConstant(NodeId.next(), 999)
+        builder.addNode(isolated)
+        val graph = builder.build()
+
+        val dir = Files.createTempDirectory("webgraph-isolated-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            assertEquals(0, loaded.outgoing(isolated.id).count())
+            assertEquals(0, loaded.incoming(isolated.id).count())
+            assertEquals(0, loaded.outgoing(isolated.id, DataFlowEdge::class.java).count())
+            assertEquals(0, loaded.incoming(isolated.id, DataFlowEdge::class.java).count())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // ReturnNode with actualType for metadata collection
+    // ========================================================================
+
+    @Test
+    fun `round-trip preserves ReturnNode with actualType`() {
+        val builder = DefaultGraph.Builder()
+        val fooType = TypeDescriptor("com.example.Foo")
+        val method = MethodDescriptor(fooType, "getData", emptyList(), TypeDescriptor("java.lang.Object"))
+        val returnNode = ReturnNode(NodeId.next(), method, actualType = TypeDescriptor("com.example.ConcreteData"))
+        builder.addNode(returnNode)
+        builder.addMethod(method)
+
+        val graph = builder.build()
+        val dir = Files.createTempDirectory("webgraph-return-actual-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val loadedReturn = loaded.node(returnNode.id) as ReturnNode
+            assertNotNull(loadedReturn.actualType)
+            assertEquals("com.example.ConcreteData", loadedReturn.actualType!!.className)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Test graph builder
+    // ========================================================================
+
+    private fun buildTestGraph(): io.johnsonlee.graphite.graph.Graph {
+        val builder = DefaultGraph.Builder()
+
+        val fooType = TypeDescriptor("com.example.Foo")
+        val parentType = TypeDescriptor("com.example.Parent")
+        val childType = TypeDescriptor("com.example.Child")
+        val method = MethodDescriptor(fooType, "bar", listOf(TypeDescriptor("int")), TypeDescriptor("void"))
+
+        // Nodes
+        val param = ParameterNode(NodeId.next(), 0, TypeDescriptor("int"), method)
+        val local = LocalVariable(NodeId.next(), "x", TypeDescriptor("int"), method)
+        val constant = IntConstant(NodeId.next(), 42)
+        val returnNode = ReturnNode(NodeId.next(), method)
+        val callee = MethodDescriptor(fooType, "baz", emptyList(), TypeDescriptor("void"))
+        val callSite = CallSiteNode(NodeId.next(), method, callee, 10, null, listOf(param.id))
+        val enumConst = EnumConstant(NodeId.next(), TypeDescriptor("com.example.Status"), "ACTIVE", listOf(1, "active"))
+        val field = FieldNode(NodeId.next(), FieldDescriptor(fooType, "name", TypeDescriptor("java.lang.String")), false)
+
+        builder.addNode(param)
+        builder.addNode(local)
+        builder.addNode(constant)
+        builder.addNode(returnNode)
+        builder.addNode(callSite)
+        builder.addNode(enumConst)
+        builder.addNode(field)
+
+        // Edges
+        builder.addEdge(DataFlowEdge(param.id, local.id, DataFlowKind.ASSIGN))
+        builder.addEdge(DataFlowEdge(constant.id, local.id, DataFlowKind.ASSIGN))
+        builder.addEdge(DataFlowEdge(local.id, returnNode.id, DataFlowKind.RETURN_VALUE))
+        builder.addEdge(CallEdge(callSite.id, callSite.id, isVirtual = false))
+
+        // Method
+        builder.addMethod(method)
+        builder.addMethod(callee)
+
+        // Type hierarchy
+        builder.addTypeRelation(childType, parentType, TypeRelation.EXTENDS)
+
+        // Enum values
+        builder.addEnumValues("com.example.Status", "ACTIVE", listOf(1, "active"))
+
+        // Annotations
+        builder.addMemberAnnotation("com.example.Foo", "bar", "javax.annotation.Nullable", emptyMap())
+
+        return builder.build()
+    }
+}

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/ZipkinIntegrationTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/ZipkinIntegrationTest.kt
@@ -1,0 +1,115 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.input.LoaderConfig
+import io.johnsonlee.graphite.sootup.JavaProjectLoader
+import org.junit.Assume.assumeTrue
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration test using Zipkin Server fat JAR from Maven Central.
+ * Tests end-to-end: load bytecode -> build graph -> save WebGraph -> load back -> verify.
+ */
+class ZipkinIntegrationTest {
+
+    companion object {
+        private val zipkinJar: Path? by lazy {
+            val resource = System.getProperty("zipkin.jar.path")
+            if (resource != null) Path.of(resource)
+            else {
+                // Try to find from Gradle resolved configuration
+                val gradleCache = Path.of(System.getProperty("user.home"), ".gradle", "caches")
+                if (!Files.exists(gradleCache)) return@lazy null
+                Files.walk(gradleCache)
+                    .filter { it.fileName.toString() == "zipkin-server-3.5.1-exec.jar" }
+                    .findFirst()
+                    .orElse(null)
+            }
+        }
+    }
+
+    @org.junit.Before
+    fun checkFixture() {
+        assumeTrue("Zipkin JAR not available", zipkinJar != null && Files.exists(zipkinJar!!))
+    }
+
+    @Test
+    fun `load Zipkin and verify graph has nodes and edges`() {
+        val graph = loadZipkinGraph()
+
+        val nodeCount = graph.nodes(Node::class.java).count()
+        assertTrue(nodeCount > 100, "Zipkin graph should have many nodes, got $nodeCount")
+
+        val callSiteCount = graph.nodes(CallSiteNode::class.java).count()
+        assertTrue(callSiteCount > 10, "Should have call sites, got $callSiteCount")
+    }
+
+    @Test
+    fun `round-trip Zipkin graph through WebGraph preserves node count`() {
+        val original = loadZipkinGraph()
+        val dir = Files.createTempDirectory("zipkin-webgraph")
+        try {
+            GraphStore.save(original, dir)
+            val loaded = GraphStore.load(dir)
+
+            val originalCount = original.nodes(Node::class.java).count()
+            val loadedCount = loaded.nodes(Node::class.java).count()
+            assertEquals(originalCount, loadedCount, "Node count should match after round-trip")
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves Zipkin annotations`() {
+        val original = loadZipkinGraph()
+        val dir = Files.createTempDirectory("zipkin-webgraph")
+        try {
+            GraphStore.save(original, dir)
+            val loaded = GraphStore.load(dir)
+
+            // Find a class with annotations in both
+            val fieldNodes = original.nodes(FieldNode::class.java).take(10).toList()
+            for (field in fieldNodes) {
+                val className = field.descriptor.declaringClass.className
+                val fieldName = field.descriptor.name
+                val originalAnnotations = original.memberAnnotations(className, fieldName)
+                val loadedAnnotations = loaded.memberAnnotations(className, fieldName)
+                assertEquals(originalAnnotations, loadedAnnotations,
+                    "Annotations for $className.$fieldName should match")
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves Zipkin methods`() {
+        val original = loadZipkinGraph()
+        val dir = Files.createTempDirectory("zipkin-webgraph")
+        try {
+            GraphStore.save(original, dir)
+            val loaded = GraphStore.load(dir)
+
+            val originalMethods = original.methods(MethodPattern()).count()
+            val loadedMethods = loaded.methods(MethodPattern()).count()
+            assertEquals(originalMethods, loadedMethods, "Method count should match")
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun loadZipkinGraph(): Graph {
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("zipkin2"),
+            buildCallGraph = false
+        ))
+        return loader.load(zipkinJar!!)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "graphite"
 
 include(":graphite-core")
 include(":graphite-sootup")
+include(":graphite-webgraph")
 include(":cli:find-args")
 include(":cli:find-endpoints")
 include(":cli:find-dead-code")


### PR DESCRIPTION
## Summary

Persist Graph to disk using WebGraph BVGraph compression. Enables save/load for large-scale analysis.

## Usage

```kotlin
val graph = JavaProjectLoader(config).load(jarPath)
GraphStore.save(graph, Path.of("/data/app-graph"))
val loaded = GraphStore.load(Path.of("/data/app-graph"))
```

## Test plan

- [x] 25+ round-trip tests (all node types, edge types, metadata)
- [x] Zipkin Server integration test (real Spring Boot fat JAR)
- [x] All modules >= 98% coverage