### PR TITLE
fix: use stable shadow JAR names for release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         VERSION=${GITHUB_REF/refs\/tags\/v/}
         ./gradlew :graphite-query:shadowJar :graphite-explore:shadowJar --no-daemon -Pversion=${VERSION}
         mkdir -p release-assets
-        cp graphite-query/build/libs/query.jar release-assets/graphite-query.jar
+        cp graphite-query/build/libs/graphite-query.jar release-assets/graphite-query.jar
         cp graphite-explore/build/libs/graphite-explore.jar release-assets/graphite-explore.jar
 
     - name: Create GitHub Release

--- a/graphite-explore/build.gradle.kts
+++ b/graphite-explore/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
 }
 
 tasks.shadowJar {
+    archiveBaseName.set("graphite-explore")
     archiveClassifier.set("")
+    archiveVersion.set("")
     mergeServiceFiles()
     manifest {
         attributes("Main-Class" to "io.johnsonlee.graphite.cli.MainKt")

--- a/graphite-query/build.gradle.kts
+++ b/graphite-query/build.gradle.kts
@@ -20,7 +20,9 @@ dependencies {
 }
 
 tasks.shadowJar {
+    archiveBaseName.set("graphite-query")
     archiveClassifier.set("")
+    archiveVersion.set("")
     mergeServiceFiles()
     manifest {
         attributes("Main-Class" to "io.johnsonlee.graphite.cli.MainKt")


### PR DESCRIPTION
The release workflow failed at v0.1.0-rc1 because the shadow JAR filename depended on archive base name + version (`query-1.0.0-SNAPSHOT.jar` etc.), not the expected `graphite-query.jar`.

Fix: set `archiveBaseName = 'graphite-query'` / `'graphite-explore'` and `archiveVersion = ''` so the output is always a predictable filename.