### PR TITLE
feat: model annotations as first-class graph nodes

### DIFF
--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
@@ -179,6 +179,19 @@ data class CallSiteNode(
 ) : Node
 
 /**
+ * An annotation on a class, field, or method.
+ *
+ * Standalone node that makes annotations queryable via Cypher.
+ */
+data class AnnotationNode(
+    override val id: NodeId,
+    val name: String,              // annotation FQN, e.g. "org.springframework.web.bind.annotation.GetMapping"
+    val className: String,         // declaring class FQN
+    val memberName: String,        // method/field name, or "<class>" for class-level
+    val values: Map<String, Any?>  // annotation attributes
+) : Node
+
+/**
  * Descriptors for program elements
  */
 data class TypeDescriptor(

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
@@ -172,6 +172,7 @@ class MmapGraphBuilder(
         internal const val TAG_PARAMETER_NODE = 10
         internal const val TAG_RETURN_NODE = 11
         internal const val TAG_CALL_SITE_NODE = 12
+        internal const val TAG_ANNOTATION_NODE = 13
 
         // Edge type tags
         internal const val TAG_EDGE_DATAFLOW = 0
@@ -230,6 +231,19 @@ class MmapGraphBuilder(
                     val argCount = s.readInt()
                     val args = (0 until argCount).map { NodeId(s.readInt()) }
                     CallSiteNode(id, caller, callee, line, receiver, args)
+                }
+                TAG_ANNOTATION_NODE -> {
+                    val name = s.readUTF()
+                    val className = s.readUTF()
+                    val memberName = s.readUTF()
+                    val kvCount = s.readInt()
+                    val values = mutableMapOf<String, Any?>()
+                    repeat(kvCount) {
+                        val k = s.readUTF()
+                        val v = s.readUTF().let { str -> str.ifEmpty { null } }
+                        values[k] = v
+                    }
+                    AnnotationNode(id, name, className, memberName, values)
                 }
                 else -> throw IllegalStateException("Unknown node type tag: $tag")
             }
@@ -362,6 +376,17 @@ class MmapGraphBuilder(
                 dos.writeInt(node.receiver?.value ?: -1)
                 dos.writeInt(node.arguments.size)
                 node.arguments.forEach { dos.writeInt(it.value) }
+            }
+            is AnnotationNode -> {
+                dos.writeByte(TAG_ANNOTATION_NODE)
+                dos.writeUTF(node.name)
+                dos.writeUTF(node.className)
+                dos.writeUTF(node.memberName)
+                dos.writeInt(node.values.size)
+                for ((k, v) in node.values) {
+                    dos.writeUTF(k)
+                    dos.writeUTF(v?.toString() ?: "")
+                }
             }
         }
         dos.flush()

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilderTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilderTest.kt
@@ -179,6 +179,54 @@ class MmapGraphBuilderTest {
         assertEquals(node, graph.node(id))
     }
 
+    @Test
+    fun `round-trip AnnotationNode with values`() {
+        val id = NodeId.next()
+        val node = AnnotationNode(
+            id,
+            "org.springframework.web.bind.annotation.GetMapping",
+            "com.example.UserController",
+            "getUser",
+            mapOf("value" to "/api/users/{id}", "produces" to "application/json")
+        )
+        val graph = MmapGraphBuilder().addNode(node).build()
+        val restored = graph.node(id) as AnnotationNode
+        assertEquals(node.name, restored.name)
+        assertEquals(node.className, restored.className)
+        assertEquals(node.memberName, restored.memberName)
+        assertEquals(node.values, restored.values)
+    }
+
+    @Test
+    fun `round-trip AnnotationNode with empty values`() {
+        val id = NodeId.next()
+        val node = AnnotationNode(id, "javax.persistence.Id", "com.example.User", "id", emptyMap())
+        val graph = MmapGraphBuilder().addNode(node).build()
+        val restored = graph.node(id) as AnnotationNode
+        assertEquals(node, restored)
+    }
+
+    @Test
+    fun `round-trip AnnotationNode with null value serialized as empty string`() {
+        val id = NodeId.next()
+        val node = AnnotationNode(id, "com.example.MyAnnotation", "com.example.Foo", "bar", mapOf("key" to null))
+        val graph = MmapGraphBuilder().addNode(node).build()
+        val restored = graph.node(id) as AnnotationNode
+        assertEquals(node.name, restored.name)
+        // null values are serialized as empty string, deserialized as null
+        assertNull(restored.values["key"])
+    }
+
+    @Test
+    fun `round-trip AnnotationNode class-level annotation`() {
+        val id = NodeId.next()
+        val node = AnnotationNode(id, "org.springframework.stereotype.Controller", "com.example.MyController", "<class>", emptyMap())
+        val graph = MmapGraphBuilder().addNode(node).build()
+        val restored = graph.node(id) as AnnotationNode
+        assertEquals("<class>", restored.memberName)
+        assertEquals(node, restored)
+    }
+
     // ========================================================================
     // Round-trip: every edge type
     // ========================================================================

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
@@ -11,6 +11,7 @@ import io.johnsonlee.graphite.core.LocalVariable
 import io.johnsonlee.graphite.core.LongConstant
 import io.johnsonlee.graphite.core.NullConstant
 import io.johnsonlee.graphite.core.ParameterNode
+import io.johnsonlee.graphite.core.AnnotationNode
 import io.johnsonlee.graphite.core.ReturnNode
 import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.Node as GraphiteNode
@@ -152,6 +153,14 @@ class CypherExecutor(private val graph: Graph) {
             is ReturnNode -> {
                 map["method"] = node.method.signature
                 map["actual_type"] = node.actualType?.className
+            }
+            is AnnotationNode -> {
+                map["name"] = node.name
+                map["class"] = node.className
+                map["member"] = node.memberName
+                for ((k, v) in node.values) {
+                    map[k] = v
+                }
             }
         }
         return map

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
@@ -186,6 +186,7 @@ object CypherFunctions {
         is FieldNode -> listOf("FieldNode")
         is ParameterNode -> listOf("ParameterNode")
         is ReturnNode -> listOf("ReturnNode")
+        is AnnotationNode -> listOf("AnnotationNode", "Annotation")
         else -> emptyList()
     }
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
@@ -26,6 +26,7 @@ object NodePropertyAccessor {
             is FieldNode -> getFieldNodeProperty(node, property)
             is ParameterNode -> getParameterNodeProperty(node, property)
             is ReturnNode -> getReturnNodeProperty(node, property)
+            is AnnotationNode -> getAnnotationNodeProperty(node, property)
         }
         if (nodeSpecific != null) return nodeSpecific
 
@@ -50,6 +51,7 @@ object NodePropertyAccessor {
         is FieldNode -> "FieldNode"
         is ParameterNode -> "ParameterNode"
         is ReturnNode -> "ReturnNode"
+        is AnnotationNode -> "AnnotationNode"
     }
 
     private fun getCallSiteProperty(node: CallSiteNode, prop: String) = when (prop) {
@@ -128,6 +130,14 @@ object NodePropertyAccessor {
         else -> null
     }
 
+    private fun getAnnotationNodeProperty(node: AnnotationNode, prop: String) = when (prop) {
+        "name" -> node.name
+        "class" -> node.className
+        "member" -> node.memberName
+        "values" -> node.values.toString()
+        else -> node.values[prop]
+    }
+
     /**
      * Returns all properties of a node as a map.
      */
@@ -179,6 +189,12 @@ object NodePropertyAccessor {
             "method" to node.method.signature,
             "actual_type" to node.actualType?.className
         )
+        is AnnotationNode -> mutableMapOf<String, Any?>(
+            "id" to node.id.value,
+            "name" to node.name,
+            "class" to node.className,
+            "member" to node.memberName
+        ).also { map -> node.values.forEach { (k, v) -> map[k] = v } }
     }
 
     /**
@@ -199,6 +215,7 @@ object NodePropertyAccessor {
         "parameternode", "parameter" -> ParameterNode::class.java
         "returnnode", "return" -> ReturnNode::class.java
         "localvariable", "local" -> LocalVariable::class.java
+        "annotationnode", "annotation" -> AnnotationNode::class.java
         "node" -> Node::class.java
         else -> Node::class.java
     }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -99,6 +99,22 @@ class CypherExecutorTest {
         nullConst = NodeId.next()
         builder.addNode(NullConstant(nullConst))
 
+        // Annotation nodes
+        builder.addNode(AnnotationNode(
+            NodeId.next(),
+            "org.springframework.web.bind.annotation.GetMapping",
+            "com.example.UserController",
+            "getUser",
+            mapOf("value" to "/api/users/{id}")
+        ))
+        builder.addNode(AnnotationNode(
+            NodeId.next(),
+            "org.springframework.web.bind.annotation.PostMapping",
+            "com.example.UserController",
+            "createUser",
+            mapOf("value" to "/api/users")
+        ))
+
         // Create edges
         // intConst42 -> param1 (dataflow)
         builder.addEdge(DataFlowEdge(intConst42, param1, DataFlowKind.PARAMETER_PASS))
@@ -1466,5 +1482,52 @@ class CypherExecutorTest {
         val result = executor.execute("MATCH (n:IntConstant) WHERE n.value >= 42 RETURN n.value")
         assertEquals(1, result.rows.size)
         assertEquals(42, result.rows[0]["n.value"])
+    }
+
+    // --- AnnotationNode Tests ---
+
+    @Test
+    fun `query AnnotationNode by label`() {
+        val result = executor.execute("MATCH (a:Annotation) RETURN a.name, a.class, a.member")
+        assertEquals(2, result.rows.size)
+        val names = result.rows.map { it["a.name"] }.toSet()
+        assertTrue(names.contains("org.springframework.web.bind.annotation.GetMapping"))
+        assertTrue(names.contains("org.springframework.web.bind.annotation.PostMapping"))
+    }
+
+    @Test
+    fun `query AnnotationNode with CONTAINS filter`() {
+        val result = executor.execute("MATCH (a:Annotation) WHERE a.name CONTAINS 'GetMapping' RETURN a.class, a.member")
+        assertEquals(1, result.rows.size)
+        assertEquals("com.example.UserController", result.rows[0]["a.class"])
+        assertEquals("getUser", result.rows[0]["a.member"])
+    }
+
+    @Test
+    fun `query AnnotationNode by AnnotationNode label`() {
+        val result = executor.execute("MATCH (a:AnnotationNode) RETURN a.name")
+        assertEquals(2, result.rows.size)
+    }
+
+    @Test
+    fun `query AnnotationNode with custom annotation value property`() {
+        val result = executor.execute("MATCH (a:Annotation) WHERE a.value = '/api/users/{id}' RETURN a.name, a.member")
+        assertEquals(1, result.rows.size)
+        assertEquals("getUser", result.rows[0]["a.member"])
+    }
+
+    @Test
+    fun `return full AnnotationNode materializes to map`() {
+        val result = executor.execute("MATCH (a:Annotation) WHERE a.name CONTAINS 'GetMapping' RETURN a")
+        assertEquals(1, result.rows.size)
+        val nodeMap = result.rows[0]["a"]
+        assertTrue(nodeMap is Map<*, *>)
+        @Suppress("UNCHECKED_CAST")
+        val map = nodeMap as Map<String, Any?>
+        assertEquals("AnnotationNode", map["type"])
+        assertEquals("org.springframework.web.bind.annotation.GetMapping", map["name"])
+        assertEquals("com.example.UserController", map["class"])
+        assertEquals("getUser", map["member"])
+        assertEquals("/api/users/{id}", map["value"])
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
@@ -511,6 +511,12 @@ class CypherFunctionsTest {
     }
 
     @Test
+    fun `labels returns correct labels for AnnotationNode`() {
+        val node = AnnotationNode(NodeId.next(), "com.example.MyAnnotation", "com.example.Foo", "bar", emptyMap())
+        assertEquals(listOf("AnnotationNode", "Annotation"), CypherFunctions.call("labels", listOf(node)))
+    }
+
+    @Test
     fun `labels returns empty for non-node`() {
         assertEquals(emptyList<String>(), CypherFunctions.call("labels", listOf("not a node")))
     }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
@@ -160,6 +160,97 @@ class NodePropertyAccessorTest {
     }
 
     @Test
+    fun `AnnotationNode properties`() {
+        val node = AnnotationNode(
+            NodeId(100),
+            "org.springframework.web.bind.annotation.GetMapping",
+            "com.example.UserController",
+            "getUser",
+            mapOf("value" to "/api/users/{id}")
+        )
+        assertEquals("org.springframework.web.bind.annotation.GetMapping", NodePropertyAccessor.getProperty(node, "name"))
+        assertEquals("com.example.UserController", NodePropertyAccessor.getProperty(node, "class"))
+        assertEquals("getUser", NodePropertyAccessor.getProperty(node, "member"))
+        assertEquals("/api/users/{id}", NodePropertyAccessor.getProperty(node, "value"))
+        assertNull(NodePropertyAccessor.getProperty(node, "nonexistent"))
+    }
+
+    @Test
+    fun `AnnotationNode values property returns map toString`() {
+        val node = AnnotationNode(
+            NodeId(101),
+            "com.example.MyAnnotation",
+            "com.example.Foo",
+            "bar",
+            mapOf("key1" to "val1", "key2" to "val2")
+        )
+        val valuesStr = NodePropertyAccessor.getProperty(node, "values") as String
+        assertTrue(valuesStr.contains("key1"))
+        assertTrue(valuesStr.contains("val1"))
+    }
+
+    @Test
+    fun `AnnotationNode custom annotation value accessed via property name`() {
+        val node = AnnotationNode(
+            NodeId(102),
+            "com.example.MyAnnotation",
+            "com.example.Foo",
+            "bar",
+            mapOf("path" to "/api/test", "method" to "GET")
+        )
+        assertEquals("/api/test", NodePropertyAccessor.getProperty(node, "path"))
+        assertEquals("GET", NodePropertyAccessor.getProperty(node, "method"))
+    }
+
+    @Test
+    fun `AnnotationNode unknown property returns null from values map`() {
+        val node = AnnotationNode(
+            NodeId(103),
+            "com.example.MyAnnotation",
+            "com.example.Foo",
+            "bar",
+            mapOf("key" to "value")
+        )
+        assertNull(NodePropertyAccessor.getProperty(node, "nonexistent_key"))
+    }
+
+    @Test
+    fun `nodeTypeName returns AnnotationNode for AnnotationNode`() {
+        val node = AnnotationNode(NodeId(200), "com.example.Ann", "com.example.Cls", "m", emptyMap())
+        assertEquals("AnnotationNode", NodePropertyAccessor.nodeTypeName(node))
+    }
+
+    @Test
+    fun `getAllProperties for AnnotationNode includes base and annotation values`() {
+        val node = AnnotationNode(
+            NodeId(300),
+            "org.springframework.web.bind.annotation.GetMapping",
+            "com.example.UserController",
+            "getUser",
+            mapOf("value" to "/api/users/{id}", "produces" to "application/json")
+        )
+        val props = NodePropertyAccessor.getAllProperties(node)
+        assertEquals(300, props["id"])
+        assertEquals("org.springframework.web.bind.annotation.GetMapping", props["name"])
+        assertEquals("com.example.UserController", props["class"])
+        assertEquals("getUser", props["member"])
+        assertEquals("/api/users/{id}", props["value"])
+        assertEquals("application/json", props["produces"])
+    }
+
+    @Test
+    fun `getAllProperties for AnnotationNode with empty values`() {
+        val node = AnnotationNode(NodeId(301), "javax.persistence.Id", "com.example.User", "id", emptyMap())
+        val props = NodePropertyAccessor.getAllProperties(node)
+        assertEquals(301, props["id"])
+        assertEquals("javax.persistence.Id", props["name"])
+        assertEquals("com.example.User", props["class"])
+        assertEquals("id", props["member"])
+        // Only base properties, no annotation values
+        assertEquals(4, props.size)
+    }
+
+    @Test
     fun `resolveNodeLabel maps standard names`() {
         assertEquals(CallSiteNode::class.java, NodePropertyAccessor.resolveNodeLabel("CallSiteNode"))
         assertEquals(CallSiteNode::class.java, NodePropertyAccessor.resolveNodeLabel("callsite"))
@@ -183,6 +274,12 @@ class NodePropertyAccessorTest {
         assertEquals(LocalVariable::class.java, NodePropertyAccessor.resolveNodeLabel("local"))
         assertEquals(Node::class.java, NodePropertyAccessor.resolveNodeLabel("node"))
         assertEquals(Node::class.java, NodePropertyAccessor.resolveNodeLabel("Node"))
+    }
+
+    @Test
+    fun `resolveNodeLabel maps annotation labels`() {
+        assertEquals(AnnotationNode::class.java, NodePropertyAccessor.resolveNodeLabel("Annotation"))
+        assertEquals(AnnotationNode::class.java, NodePropertyAccessor.resolveNodeLabel("AnnotationNode"))
     }
 
     @Test

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/Helpers.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/Helpers.kt
@@ -26,6 +26,7 @@ internal fun formatNode(node: Node): String = when (node) {
     is ParameterNode -> "Parameter[${node.id}] ${node.method.name}#${node.index}: ${node.type.simpleName}"
     is ReturnNode -> "Return[${node.id}] ${node.method.name}"
     is LocalVariable -> "Local[${node.id}] ${node.name}: ${node.type.simpleName}"
+    is AnnotationNode -> "Annotation[${node.id}] @${node.name.substringAfterLast('.')} on ${node.className.substringAfterLast('.')}.${node.memberName}"
 }
 
 internal fun nodeToMap(node: Node): Map<String, Any?> = when (node) {
@@ -42,6 +43,7 @@ internal fun nodeToMap(node: Node): Map<String, Any?> = when (node) {
     is ParameterNode -> mapOf("type" to "ParameterNode", "id" to node.id.value, "index" to node.index, "paramType" to node.type.className, "method" to node.method.signature, "label" to "param#${node.index}")
     is ReturnNode -> mapOf("type" to "ReturnNode", "id" to node.id.value, "method" to node.method.signature, "label" to "return")
     is LocalVariable -> mapOf("type" to "LocalVariable", "id" to node.id.value, "name" to node.name, "varType" to node.type.className, "method" to node.method.signature, "label" to node.name)
+    is AnnotationNode -> mutableMapOf<String, Any?>("type" to "AnnotationNode", "id" to node.id.value, "name" to node.name, "class" to node.className, "member" to node.memberName, "label" to "@${node.name.substringAfterLast('.')}").also { map -> node.values.forEach { (k, v) -> map[k] = v } }
 }
 
 internal fun edgeToMap(edge: Edge): Map<String, Any?> = when (edge) {

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/HelpersTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/HelpersTest.kt
@@ -294,6 +294,58 @@ class HelpersTest {
         assertEquals("null", map["label"])
     }
 
+    @Test
+    fun `formatNode formats AnnotationNode`() {
+        val node = AnnotationNode(
+            NodeId.next(),
+            "org.springframework.web.bind.annotation.GetMapping",
+            "com.example.UserController",
+            "getUser",
+            mapOf("value" to "/api/users/{id}")
+        )
+        val result = formatNode(node)
+        assertTrue(result.startsWith("Annotation["), "Should start with 'Annotation[', got: $result")
+        assertTrue(result.contains("@GetMapping"), "Should contain short annotation name, got: $result")
+        assertTrue(result.contains("UserController.getUser"), "Should contain class.member, got: $result")
+    }
+
+    @Test
+    fun `nodeToMap for AnnotationNode includes correct fields`() {
+        val node = AnnotationNode(
+            NodeId.next(),
+            "org.springframework.web.bind.annotation.GetMapping",
+            "com.example.UserController",
+            "getUser",
+            mapOf("value" to "/api/users/{id}", "produces" to "application/json")
+        )
+        val map = nodeToMap(node)
+        assertEquals("AnnotationNode", map["type"])
+        assertEquals(node.id.value, map["id"])
+        assertEquals("org.springframework.web.bind.annotation.GetMapping", map["name"])
+        assertEquals("com.example.UserController", map["class"])
+        assertEquals("getUser", map["member"])
+        assertEquals("@GetMapping", map["label"])
+        assertEquals("/api/users/{id}", map["value"])
+        assertEquals("application/json", map["produces"])
+    }
+
+    @Test
+    fun `nodeToMap for AnnotationNode with empty values`() {
+        val node = AnnotationNode(
+            NodeId.next(),
+            "javax.persistence.Id",
+            "com.example.User",
+            "id",
+            emptyMap()
+        )
+        val map = nodeToMap(node)
+        assertEquals("AnnotationNode", map["type"])
+        assertEquals("javax.persistence.Id", map["name"])
+        assertEquals("com.example.User", map["class"])
+        assertEquals("id", map["member"])
+        assertEquals("@Id", map["label"])
+    }
+
     // ========================================================================
     // edgeToMap
     // ========================================================================

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -1503,6 +1503,13 @@ class SootUpAdapter(
                 }
             }
             graphBuilder.addMemberAnnotation(className, memberName, fullName, cleanValues)
+            graphBuilder.addNode(AnnotationNode(
+                id = NodeId.next(),
+                name = fullName,
+                className = className,
+                memberName = memberName,
+                values = cleanValues
+            ))
         }
     }
 

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/EndpointExtractionTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/EndpointExtractionTest.kt
@@ -1,5 +1,6 @@
 package io.johnsonlee.graphite.sootup
 
+import io.johnsonlee.graphite.core.AnnotationNode
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.input.LoaderConfig
 import java.nio.file.Path
@@ -123,6 +124,26 @@ class EndpointExtractionTest {
 
         println("Methods with annotations: ${methodsWithAnnotations.size}")
         assertTrue(methodsWithAnnotations.isNotEmpty(), "Should find methods with annotations")
+    }
+
+    @Test
+    fun `AnnotationNodes are created from sample controllers`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val loader = JavaProjectLoader(LoaderConfig(
+            includePackages = listOf("sample.api"),
+            buildCallGraph = false
+        ))
+
+        val graph = loader.load(testClassesDir)
+
+        val annotations = graph.nodes(AnnotationNode::class.java).toList()
+        assertTrue(annotations.isNotEmpty(), "Should have AnnotationNodes")
+
+        // Check that GetMapping annotations are present
+        val getMappings = annotations.filter { it.name.contains("GetMapping") }
+        assertTrue(getMappings.isNotEmpty(), "Should have @GetMapping annotations")
     }
 
     private fun findTestClassesDir(): Path {

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AnnotationNodeSerializationBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AnnotationNodeSerializationBenchmark.kt
@@ -1,0 +1,81 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.AnnotationNode
+import io.johnsonlee.graphite.core.IntConstant
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.Graph
+import org.openjdk.jmh.annotations.*
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+// ============================================================================
+//  AnnotationNode serialization: measures GraphStore save/load throughput
+//  for graphs containing AnnotationNodes mixed with regular nodes.
+//  Run with: ./gradlew :graphite-webgraph:jmh -Pjmh.includes='AnnotationNodeSerialization'
+// ============================================================================
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(value = 2, jvmArgs = ["-Xmx4g"])
+@State(Scope.Benchmark)
+open class AnnotationNodeSerializationBenchmark {
+
+    @Param("1000", "10000", "50000")
+    var annotationCount: Int = 0
+
+    private lateinit var graph: Graph
+    private lateinit var savedDir: Path
+
+    @Setup(Level.Trial)
+    fun setup() {
+        NodeId.reset()
+
+        val builder = DefaultGraph.Builder()
+
+        // Add 1000 regular nodes as baseline
+        for (i in 1..1000) {
+            builder.addNode(IntConstant(NodeId.next(), i))
+        }
+
+        // Add N AnnotationNodes
+        for (i in 1..annotationCount) {
+            builder.addNode(AnnotationNode(
+                id = NodeId.next(),
+                name = "org.example.Annotation$i",
+                className = "com.example.Class${i % 100}",
+                memberName = "method${i % 50}",
+                values = mapOf("value" to "/api/path/$i")
+            ))
+        }
+
+        graph = builder.build()
+
+        // Pre-save for load benchmark
+        savedDir = Files.createTempDirectory("annotation-bench")
+        GraphStore.save(graph, savedDir)
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        savedDir.toFile().deleteRecursively()
+    }
+
+    @Benchmark
+    fun save() {
+        val dir = Files.createTempDirectory("annotation-bench-save")
+        try {
+            GraphStore.save(graph, dir)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Benchmark
+    fun load(): Graph {
+        return GraphStore.load(savedDir)
+    }
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -245,7 +245,8 @@ object GraphStore {
             9 to FieldNode::class.java,
             10 to ParameterNode::class.java,
             11 to ReturnNode::class.java,
-            12 to CallSiteNode::class.java
+            12 to CallSiteNode::class.java,
+            13 to AnnotationNode::class.java
         )
         for ((tag, ids) in nodeTypeByTag) {
             val cls = tagToClass[tag] ?: continue
@@ -326,7 +327,8 @@ object GraphStore {
             9 to FieldNode::class.java,
             10 to ParameterNode::class.java,
             11 to ReturnNode::class.java,
-            12 to CallSiteNode::class.java
+            12 to CallSiteNode::class.java,
+            13 to AnnotationNode::class.java
         )
         for ((tag, ids) in nodeTypeByTag) {
             val cls = tagToClass[tag] ?: continue
@@ -535,6 +537,7 @@ object GraphStore {
                     allTypes.add(node.caller.declaringClass)
                 }
                 is EnumConstant -> allTypes.add(node.enumType)
+                is AnnotationNode -> {}
                 else -> {}
             }
         }
@@ -579,6 +582,7 @@ object GraphStore {
                 is CallSiteNode -> classMembers.add(node.callee.declaringClass.className to node.callee.name)
                 is ParameterNode -> classMembers.add(node.method.declaringClass.className to node.method.name)
                 is ReturnNode -> classMembers.add(node.method.declaringClass.className to node.method.name)
+                is AnnotationNode -> {}
                 else -> {}
             }
         }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
@@ -36,6 +36,7 @@ internal object NodeSerializer {
     private const val TAG_PARAMETER_NODE = 10
     private const val TAG_RETURN_NODE = 11
     private const val TAG_CALL_SITE_NODE = 12
+    private const val TAG_ANNOTATION_NODE = 13
 
     // Value type tags (for heterogeneous value lists like enum constructor args)
     private const val VAL_INT = 0
@@ -128,6 +129,15 @@ internal object NodeSerializer {
                 is CallSiteNode -> {
                     collectMethodDescriptorStrings(node.caller, dest)
                     collectMethodDescriptorStrings(node.callee, dest)
+                }
+                is AnnotationNode -> {
+                    dest.add(node.name)
+                    dest.add(node.className)
+                    dest.add(node.memberName)
+                    for ((k, v) in node.values) {
+                        dest.add(k)
+                        dest.add(v?.toString() ?: "")
+                    }
                 }
                 else -> {} // IntConstant, LongConstant, FloatConstant, DoubleConstant, BooleanConstant, NullConstant
             }
@@ -273,6 +283,17 @@ internal object NodeSerializer {
                 dos.writeInt(node.arguments.size)
                 for (arg in node.arguments) dos.writeInt(arg.value)
             }
+            is AnnotationNode -> {
+                dos.writeByte(TAG_ANNOTATION_NODE)
+                dos.writeInt(strings.indexOf(node.name))
+                dos.writeInt(strings.indexOf(node.className))
+                dos.writeInt(strings.indexOf(node.memberName))
+                dos.writeInt(node.values.size)
+                for ((k, v) in node.values) {
+                    dos.writeInt(strings.indexOf(k))
+                    dos.writeInt(strings.indexOf(v?.toString() ?: ""))
+                }
+            }
         }
     }
 
@@ -326,6 +347,19 @@ internal object NodeSerializer {
                 val argCount = dis.readInt()
                 val arguments = (0 until argCount).map { NodeId(dis.readInt()) }
                 CallSiteNode(id, caller, callee, lineNumber, receiver, arguments)
+            }
+            TAG_ANNOTATION_NODE -> {
+                val name = strings.get(dis.readInt())
+                val className = strings.get(dis.readInt())
+                val memberName = strings.get(dis.readInt())
+                val kvCount = dis.readInt()
+                val values = mutableMapOf<String, Any?>()
+                repeat(kvCount) {
+                    val k = strings.get(dis.readInt())
+                    val v = strings.get(dis.readInt()).let { s -> s.ifEmpty { null } }
+                    values[k] = v
+                }
+                AnnotationNode(id, name, className, memberName, values)
             }
             else -> throw IllegalArgumentException("Unknown node tag: $tag")
         }

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -133,6 +133,25 @@ class GraphStoreTest {
     }
 
     @Test
+    fun `round-trip preserves AnnotationNode`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val annotations = loaded.nodes(AnnotationNode::class.java).toList()
+            assertEquals(1, annotations.size)
+            assertEquals("javax.annotation.Nullable", annotations[0].name)
+            assertEquals("com.example.Foo", annotations[0].className)
+            assertEquals("bar", annotations[0].memberName)
+            assertEquals("true", annotations[0].values["value"])
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `round-trip preserves type hierarchy`() {
         val graph = buildTestGraph()
         val dir = Files.createTempDirectory("webgraph-test")
@@ -1332,7 +1351,7 @@ class GraphStoreTest {
 
                 // Node is the ultimate supertype
                 val allNodes = loaded.nodes(Node::class.java).toList()
-                assertEquals(7, allNodes.size)
+                assertEquals(8, allNodes.size)
             } finally {
                 (loaded as Closeable).close()
             }
@@ -1353,7 +1372,7 @@ class GraphStoreTest {
                 assertTrue(constants.size >= 2, "Should find at least IntConstant and EnumConstant")
 
                 val allNodes = loaded.nodes(Node::class.java).toList()
-                assertEquals(7, allNodes.size)
+                assertEquals(8, allNodes.size)
             } finally {
                 (loaded as Closeable).close()
             }
@@ -1580,6 +1599,9 @@ class GraphStoreTest {
         builder.addNode(callSite)
         builder.addNode(enumConst)
         builder.addNode(field)
+
+        val annotNode = AnnotationNode(NodeId.next(), "javax.annotation.Nullable", "com.example.Foo", "bar", mapOf("value" to "true"))
+        builder.addNode(annotNode)
 
         // Edges
         builder.addEdge(DataFlowEdge(param.id, local.id, DataFlowKind.ASSIGN))


### PR DESCRIPTION
## Summary

- Add `AnnotationNode` as a direct `Node` subtype with `name`, `className`, `memberName`, `values` properties
- Serialization support (tag 13) in NodeSerializer and MmapGraphBuilder
- `SootUpAdapter` creates AnnotationNodes during annotation extraction
- Full Cypher support: `MATCH (a:Annotation) WHERE a.name CONTAINS 'GetMapping' RETURN a.class, a.member`
- Annotation attribute values accessible as node properties (e.g., `a.value` for `@GetMapping("/api/users")`)
- Existing `memberAnnotations` metadata preserved for backward compatibility
- JMH benchmark for AnnotationNode serialization

## Design

Standalone node, no new edge type. The graph has no MethodDeclarationNode — creating edges to usage-level nodes (CallSiteNode) would be semantically wrong. AnnotationNode is self-descriptive and queryable by properties, following standard Cypher conventions.

## JMH Benchmark — AnnotationNode Serialization

Graph with 1000 baseline nodes + N AnnotationNodes, 2 forks × 3 iterations:

| Operation | 1K annotations | 10K annotations | 50K annotations |
|-----------|---------------|-----------------|-----------------|
| `save` | 30.5 ± 4.0 ms | 176.3 ± 9.9 ms | 812.8 ± 19.0 ms |
| `load` | 3.5 ± 0.7 ms | 11.0 ± 5.5 ms | 40.2 ± 12.6 ms |

A typical Spring Boot app has ~3K annotations. Save overhead: ~90ms, load overhead: ~10ms — negligible relative to graph build time.

## Test plan

- [x] `./gradlew check` passes (all modules, coverage >= 98%)
- [x] GraphStoreTest: round-trip AnnotationNode save/load
- [x] MmapGraphBuilderTest: 4 round-trip tests (with values, empty, null, class-level)
- [x] NodePropertyAccessorTest: property resolution, label resolution, getAllProperties
- [x] CypherExecutorTest: `MATCH (a:Annotation)` queries with CONTAINS filtering, property access
- [x] CypherFunctionsTest: labels() returns ["AnnotationNode", "Annotation"]
- [x] HelpersTest: formatNode + nodeToMap for AnnotationNode
- [x] EndpointExtractionTest: AnnotationNodes created from sample Spring controllers
- [x] JMH: AnnotationNode serialization at 1K/10K/50K scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)