### PR TITLE
perf: replace HashMap with flat arrays for edge labels and node index

### DIFF
--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -1,0 +1,209 @@
+# WebGraph Storage Format
+
+## File Layout
+
+A saved graph directory contains the following files:
+
+| File | Format | Owner | Description |
+|------|--------|-------|-------------|
+| `forward.*` | BVGraph | WebGraph | Compressed forward adjacency (successors) |
+| `graph.strings` | FrontCodedStringList | WebGraph/fastutil | Deduplicated string dictionary |
+| `graph.labels` | byte[] via BinIO | WebGraph | Edge type labels (1 byte per arc, BVGraph successor order) |
+| `graph.metadata` | Custom binary | Graphite | Methods, type hierarchy, enums, annotations, branch scopes |
+| `graph.nodedata` | Custom binary | Graphite | Sequential node records |
+| `graph.nodeindex` | Custom binary | Graphite | Node ID → offset index for lazy/mapped loading |
+| `graph.comparisons` | Custom binary | Graphite | BranchComparison data for ControlFlowEdges |
+Backward adjacency is not stored on disk — it is rebuilt from `forward.*` at load time.
+
+## Graphite Custom File Format (v1)
+
+All 4 Graphite custom files share a 4-byte header: **3-byte magic prefix + 1-byte version**, packed as one `int`.
+
+| File | Magic (hex) | Magic (ASCII) | v1 header |
+|------|-------------|---------------|-----------|
+| graph.metadata | `0x47524D00` | `GRM` | `0x47524D01` |
+| graph.nodedata | `0x47524E00` | `GRN` | `0x47524E01` |
+| graph.nodeindex | `0x47524900` | `GRI` | `0x47524901` |
+| graph.comparisons | `0x47524300` | `GRC` | `0x47524301` |
+
+**Reading:** The reader validates the 3-byte magic prefix. If it doesn't match, an error is thrown. The low byte is the format version.
+
+### graph.metadata
+
+```
+[header: int = 0x47524D01]
+[methodCount: int] [methods...]
+[supertypeCount: int] [supertypes...]
+[subtypeCount: int] [subtypes...]
+[enumValueCount: int] [enumValues...]
+[annotationCount: int] [annotations...]
+[branchScopeCount: int] [branchScopes...]
+```
+
+All strings are stored as StringTable indices (`int`).
+
+### graph.nodedata
+
+```
+[header: int = 0x47524E01]
+[nodeCount: int]
+[node1: nodeId(int) + tag(byte) + type-specific fields...]
+[node2: ...]
+...
+```
+
+Node type tags: 0=IntConstant, 1=StringConstant, ..., 12=CallSiteNode, 13=AnnotationNode.
+
+### graph.nodeindex
+
+```
+[header: int = 0x47524901]
+[entryCount: int]
+[entry1: nodeId(int) + tag(byte) + offset(long)]
+[entry2: ...]
+...
+```
+
+Offset points into `graph.nodedata` for lazy/mapped node loading.
+
+### graph.comparisons
+
+```
+[header: int = 0x47524301]
+[count: int]
+[entry1: edgeKey(long) + operator(int) + comparandNodeId(int)]
+[entry2: ...]
+...
+```
+
+Edge key format: `(fromNodeId << 32) | toNodeId`.
+
+## Edge Label Encoding (8-bit)
+
+```
+bits 0-1: edge family (0=DataFlow, 1=Call, 2=Type, 3=ControlFlow)
+bits 2-5: subkind ordinal
+bits 6-7: extra flags (Call: bit6=isVirtual, bit7=isDynamic)
+```
+
+ControlFlowEdge comparisons are stored separately in `graph.comparisons`.
+
+## Save Flow
+
+```mermaid
+graph TD
+    A[Graph in memory] --> B[Pass 1: Stream nodes]
+    B --> B1[Collect maxNodeId + nodeCount]
+    B --> B2[Collect unique strings]
+    B1 & B2 --> C[Collect metadata]
+    C --> D[Build StringTable]
+    D --> E[Build forward adjacency]
+    E --> E1[Pass 1: Count outdegree per node]
+    E --> E2[Pass 2: Fill sorted successor arrays]
+    E2 --> F["BVGraph.store(forward)"]
+    F --> G[Build label array + comparisons]
+    G --> G1[Per node: collect edges, sort by target, encode]
+    G1 --> H[Write files]
+    H --> H1[graph.labels]
+    H --> H2[graph.comparisons]
+    H --> H3["graph.nodedata (stream nodes)"]
+    H3 --> H4[graph.nodeindex]
+    H --> H5[graph.metadata]
+```
+
+Key properties:
+- **No `allNodes` list** — nodes are streamed, never all in memory at once
+- **No `edgeLabelMap` HashMap** — labels built directly in BVGraph successor order
+- **Forward only** — backward BVGraph is not stored (rebuilt at load time)
+- **BVGraph compression threads** — configurable (default 2, controls memory pressure)
+
+## Load Flow
+
+```mermaid
+graph TD
+    A[Graph directory] --> B[Parallel I/O]
+    B --> B1["BVGraph.load(forward)"]
+    B --> B2[StringTable.load]
+    B --> B3[BinIO.loadBytes labels]
+    B --> B4["readNodeIndex (lazy/mapped only)"]
+    B1 --> C[Build cumulative outdegree]
+    B1 --> D{backward.* exists?}
+    D -->|Yes| D1["BVGraph.load(backward)"]
+    D -->|No| D2[Build backward from forward]
+    D2 --> D2a[Pass 1: Count indegree]
+    D2a --> D2b[Pass 2: Fill predecessor arrays + sort]
+    B2 --> E[Read nodes]
+    E -->|Eager| E1[Deserialize all to heap]
+    E -->|Mapped| E2[mmap nodedata file]
+    E -->|Lazy| E3[RandomAccessFile on demand]
+    B2 --> F[Read metadata]
+    C & D1 & D2b & B3 & E & F --> G[Construct Graph]
+```
+
+Loading modes:
+
+| Mode | Nodes | Threshold | Heap usage |
+|------|-------|-----------|------------|
+| EAGER | All deserialized to heap | < 1M nodes | Highest |
+| MAPPED | Memory-mapped via OS page cache | >= 1M nodes | Node data off-heap |
+| LAZY | Read from disk on demand | Manual | Lowest heap |
+
+## Memory Layout (Loaded Graph, MAPPED mode)
+
+```
+Heap:
+  ├── forward BVGraph (compressed adjacency)     ~5 MB
+  ├── backward flat arrays                       ~120 MB
+  │     ├── IntArray[totalEdges] (targets)
+  │     └── LongArray[numNodes+1] (offsets)
+  ├── forwardLabels: ByteArray[totalEdges]       ~10 MB
+  ├── cumulativeOutdeg: LongArray[numNodes+1]    ~80 MB
+  ├── nodeOffsets: LongArray[maxNodeId+1]        ~80 MB
+  ├── StringTable (FrontCodedStringList)         ~20 MB
+  └── metadata (methods, types, annotations)     ~50 MB
+
+Off-heap (mmap):
+  └── graph.nodedata (OS page cache)             ~250 MB
+```
+
+## JMH Benchmark Results
+
+All benchmarks on 10M nodes / 10M edges.
+
+### Save — 4g vs 8g heap (SingleShot, thread sweep)
+
+| Threads | 4g (ms) | 8g (ms) |
+|---------|---------|---------|
+| 1 | 84,862 | 85,203 |
+| **2** | **83,828** | **84,018** |
+| 3 | 84,018 | 83,758 |
+| 4 | 83,703 | 82,555 |
+
+Save time is CPU-bound (BVGraph compression), not memory-bound. 4g and 8g perform identically.
+
+### Load — 4g vs 8g heap (SingleShot, thread sweep)
+
+| Threads | 4g (ms) | 8g (ms) |
+|---------|---------|---------|
+| 1 | 2,800 | 2,717 |
+| **2** | **2,787** | **2,432** |
+| 3 | 2,661 | 2,433 |
+| 4 | 2,661 | 2,442 |
+
+Load is ~10% faster at 8g due to less GC pressure during backward-from-forward construction.
+
+### Flat Array vs HashMap (10M scale)
+
+**Allocation (SingleShot)**
+
+| Structure | HashMap | Flat Array | Speedup |
+|-----------|---------|------------|---------|
+| edgeLabelMap (10M) | 226.1 ms | 14.3 ms | **16x** |
+| nodeIndex (10M) | 140.3 ms | 9.2 ms | **15x** |
+
+**Lookup throughput (ops/us, higher = better)**
+
+| Structure | HashMap | Flat Array | Speedup |
+|-----------|---------|------------|---------|
+| edgeLabelMap (10M) | 0.032 | 0.054 | **1.7x** |
+| nodeIndex (10M) | 0.034 | 0.119 | **3.5x** |

--- a/graphite-webgraph/build.gradle.kts
+++ b/graphite-webgraph/build.gradle.kts
@@ -9,7 +9,7 @@ kover {
     reports {
         filters {
             excludes {
-                classes("*Benchmark*")
+                classes("*Benchmark*", "*GraphBuildPersist*")
             }
         }
     }
@@ -28,6 +28,13 @@ dependencies {
     jmh(project(":graphite-cypher"))
     jmh(libs.jmh.core)
     jmhAnnotationProcessor(libs.jmh.generator)
+}
+
+jmh {
+    val filter = project.findProperty("jmh.filter") as String?
+    if (filter != null) {
+        includes.set(listOf(filter))
+    }
 }
 
 tasks.test {

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/FlatArrayBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/FlatArrayBenchmark.kt
@@ -1,0 +1,227 @@
+package io.johnsonlee.graphite.webgraph
+
+import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+// ============================================================================
+//  Edge label allocation: HashMap vs flat arrays at 5M scale
+//  Run with: ./gradlew :graphite-webgraph:jmh -Pjmh.includes='EdgeLabelFlatArrayAlloc' -Pjmh.prof='gc'
+// ============================================================================
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+@Fork(value = 3, jvmArgs = ["-Xmx4g"])
+@State(Scope.Benchmark)
+open class EdgeLabelFlatArrayAllocBenchmark {
+
+    @Param("10000000")
+    var edgeCount: Int = 0
+
+    @Benchmark
+    fun hashMap_alloc(): Long2IntOpenHashMap {
+        val map = Long2IntOpenHashMap(edgeCount)
+        map.defaultReturnValue(-1)
+        for (i in 0 until edgeCount) {
+            val key = (i / 3).toLong().shl(32) or (i % 10_000_000).toLong().and(0xFFFFFFFFL)
+            map.put(key, i and 0xFF)
+        }
+        map.trim()
+        return map
+    }
+
+    @Benchmark
+    fun flatArray_alloc(): Pair<ByteArray, LongArray> {
+        // Simulate: forwardLabels (byte per edge) + cumulativeOutdeg (long per node)
+        val nodeCount = edgeCount // 5M nodes with ~1 edge each average
+        val forwardLabels = ByteArray(edgeCount)
+        val cumulativeOutdeg = LongArray(nodeCount + 1)
+        // Populate labels
+        for (i in 0 until edgeCount) {
+            forwardLabels[i] = (i and 0xFF).toByte()
+        }
+        // Populate cumulative outdegree (simulate ~1 edge per node)
+        for (i in 0 until nodeCount) {
+            cumulativeOutdeg[i + 1] = cumulativeOutdeg[i] + 1
+        }
+        return forwardLabels to cumulativeOutdeg
+    }
+}
+
+// ============================================================================
+//  Node index allocation: HashMap vs flat array at 5M scale
+//  Run with: ./gradlew :graphite-webgraph:jmh -Pjmh.includes='NodeIndexFlatArrayAlloc' -Pjmh.prof='gc'
+// ============================================================================
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+@Fork(value = 3, jvmArgs = ["-Xmx4g"])
+@State(Scope.Benchmark)
+open class NodeIndexFlatArrayAllocBenchmark {
+
+    @Param("10000000")
+    var nodeCount: Int = 0
+
+    @Benchmark
+    fun hashMap_alloc(): Int2LongOpenHashMap {
+        val map = Int2LongOpenHashMap(nodeCount)
+        map.defaultReturnValue(-1)
+        for (i in 0 until nodeCount) {
+            map.put(i, i.toLong() * 128)
+        }
+        map.trim()
+        return map
+    }
+
+    @Benchmark
+    fun flatArray_alloc(): LongArray {
+        val offsets = LongArray(nodeCount)
+        for (i in 0 until nodeCount) {
+            offsets[i] = i.toLong() * 128
+        }
+        return offsets
+    }
+}
+
+// ============================================================================
+//  Edge label lookup: HashMap vs flat array
+//  Run with: ./gradlew :graphite-webgraph:jmh -Pjmh.includes='EdgeLabelFlatArrayLookup'
+// ============================================================================
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 2, jvmArgs = ["-Xmx4g"])
+@State(Scope.Benchmark)
+open class EdgeLabelFlatArrayLookupBenchmark {
+
+    @Param("10000000")
+    var edgeCount: Int = 0
+
+    private lateinit var hashMap: Long2IntOpenHashMap
+    private lateinit var forwardLabels: ByteArray
+    private lateinit var cumulativeOutdeg: LongArray
+    // Mock successor arrays: for simplicity, each node has exactly 1 successor (node i -> node i+1)
+    // In reality, BVGraph.successorArray provides this
+    private lateinit var lookupKeys: LongArray
+    private lateinit var lookupFromTo: Array<IntArray> // [from, to] pairs
+
+    @Setup(Level.Trial)
+    fun setup() {
+        val nodeCount = edgeCount
+
+        // Build HashMap (old approach)
+        hashMap = Long2IntOpenHashMap(edgeCount)
+        hashMap.defaultReturnValue(0)
+        for (i in 0 until edgeCount) {
+            val from = i
+            val to = (i + 1) % nodeCount
+            val key = from.toLong().shl(32) or to.toLong().and(0xFFFFFFFFL)
+            hashMap.put(key, i and 0xFF)
+        }
+        hashMap.trim()
+
+        // Build flat arrays (new approach)
+        forwardLabels = ByteArray(edgeCount)
+        cumulativeOutdeg = LongArray(nodeCount + 1)
+        for (i in 0 until edgeCount) {
+            forwardLabels[i] = (i and 0xFF).toByte()
+            cumulativeOutdeg[i + 1] = cumulativeOutdeg[i] + 1
+        }
+
+        // Pre-generate 10K random lookup keys
+        val rng = java.util.Random(42)
+        lookupKeys = LongArray(10_000) {
+            val from = rng.nextInt(nodeCount)
+            val to = (from + 1) % nodeCount
+            from.toLong().shl(32) or to.toLong().and(0xFFFFFFFFL)
+        }
+        lookupFromTo = Array(10_000) {
+            val from = rng.nextInt(nodeCount)
+            val to = (from + 1) % nodeCount
+            intArrayOf(from, to)
+        }
+    }
+
+    @Benchmark
+    fun hashMap_get(): Int {
+        var sum = 0
+        for (key in lookupKeys) {
+            sum += hashMap.get(key)
+        }
+        return sum
+    }
+
+    @Benchmark
+    fun flatArray_get(): Int {
+        var sum = 0
+        for (pair in lookupFromTo) {
+            val from = pair[0]
+            // In real code: pos = Arrays.binarySearch(successorArray, 0, outdeg, to)
+            // Here with 1 edge per node, pos is always 0
+            val label = forwardLabels[(cumulativeOutdeg[from]).toInt()].toInt() and 0xFF
+            sum += label
+        }
+        return sum
+    }
+}
+
+// ============================================================================
+//  Node index lookup: HashMap vs flat array
+//  Run with: ./gradlew :graphite-webgraph:jmh -Pjmh.includes='NodeIndexFlatArrayLookup'
+// ============================================================================
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 2, jvmArgs = ["-Xmx4g"])
+@State(Scope.Benchmark)
+open class NodeIndexFlatArrayLookupBenchmark {
+
+    @Param("10000000")
+    var nodeCount: Int = 0
+
+    private lateinit var hashMap: Int2LongOpenHashMap
+    private lateinit var offsets: LongArray
+    private lateinit var lookupKeys: IntArray
+
+    @Setup(Level.Trial)
+    fun setup() {
+        hashMap = Int2LongOpenHashMap(nodeCount)
+        hashMap.defaultReturnValue(-1)
+        offsets = LongArray(nodeCount)
+        for (i in 0 until nodeCount) {
+            hashMap.put(i, i.toLong() * 128)
+            offsets[i] = i.toLong() * 128
+        }
+        hashMap.trim()
+
+        val rng = java.util.Random(42)
+        lookupKeys = IntArray(10_000) { rng.nextInt(nodeCount) }
+    }
+
+    @Benchmark
+    fun hashMap_get(): Long {
+        var sum = 0L
+        for (key in lookupKeys) {
+            sum += hashMap.get(key)
+        }
+        return sum
+    }
+
+    @Benchmark
+    fun flatArray_get(): Long {
+        var sum = 0L
+        for (key in lookupKeys) {
+            sum += offsets[key]
+        }
+        return sum
+    }
+}

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/GraphBuildPersistBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/GraphBuildPersistBenchmark.kt
@@ -1,0 +1,106 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.Graph
+import org.openjdk.jmh.annotations.*
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+// ============================================================================
+//  Save/load at 10M scale — 4GB and 8GB heap comparison
+//  Run with: ./gradlew :graphite-webgraph:jmh -Pjmh.filter='GraphBuildPersist'
+// ============================================================================
+
+@State(Scope.Benchmark)
+open class GraphBuildPersistBase {
+
+    @Param("10000000")
+    var nodeCount: Int = 0
+
+    @Param("1", "2", "3", "4")
+    var compressionThreads: Int = 0
+
+    protected lateinit var graph: Graph
+    protected lateinit var savedDir: Path
+
+    @Setup(Level.Trial)
+    fun setup() {
+        NodeId.reset()
+        val builder = DefaultGraph.Builder()
+
+        val annotationInterval = 10
+        for (i in 1..nodeCount) {
+            if (i % annotationInterval == 0) {
+                builder.addNode(AnnotationNode(
+                    id = NodeId.next(),
+                    name = "org.example.Ann${i % 100}",
+                    className = "com.example.Class${i % 1000}",
+                    memberName = "method${i % 500}",
+                    values = mapOf("value" to "/path/$i")
+                ))
+            } else {
+                builder.addNode(IntConstant(NodeId.next(), i))
+            }
+        }
+
+        for (i in 1 until nodeCount) {
+            builder.addEdge(DataFlowEdge(NodeId(i), NodeId(i + 1), DataFlowKind.ASSIGN))
+        }
+
+        graph = builder.build()
+
+        savedDir = Files.createTempDirectory("graphite-bench")
+        GraphStore.save(graph, savedDir, compressionThreads = 2)
+    }
+
+    @TearDown(Level.Trial)
+    fun teardown() {
+        savedDir.toFile().deleteRecursively()
+    }
+}
+
+/** 10M nodes, 4GB heap. */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgs = ["-Xmx4g"])
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+open class GraphBuildPersist4g : GraphBuildPersistBase() {
+
+    @Benchmark
+    fun save() {
+        val dir = Files.createTempDirectory("graphite-bench-save")
+        try {
+            GraphStore.save(graph, dir, compressionThreads = compressionThreads)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Benchmark
+    fun load(): Graph = GraphStore.load(savedDir)
+}
+
+/** 10M nodes, 8GB heap. */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgs = ["-Xmx8g"])
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+open class GraphBuildPersist8g : GraphBuildPersistBase() {
+
+    @Benchmark
+    fun save() {
+        val dir = Files.createTempDirectory("graphite-bench-save")
+        try {
+            GraphStore.save(graph, dir, compressionThreads = compressionThreads)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Benchmark
+    fun load(): Graph = GraphStore.load(savedDir)
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -3,26 +3,24 @@ package io.johnsonlee.graphite.webgraph
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
-import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap
 import it.unimi.dsi.fastutil.io.BinIO
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
 import it.unimi.dsi.webgraph.BVGraph
 import it.unimi.dsi.webgraph.ImmutableGraph
 import it.unimi.dsi.webgraph.LazyIntIterator
 import it.unimi.dsi.webgraph.LazyIntIterators
-import it.unimi.dsi.webgraph.Transform
 import java.io.*
 import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.util.concurrent.CompletableFuture
 
 /**
  * Save and load [Graph] instances using WebGraph compression with native LAW
  * ecosystem tools (dsiutils + sux4j + fastutil).
  *
  * Storage layout:
- * - `forward.*` / `backward.*` -- BVGraph adjacency (forward + transpose)
+ * - `forward.*`                -- BVGraph adjacency (forward only; backward is rebuilt at load time)
  * - `graph.strings`            -- [StringTable] (FrontCodedStringList via BinIO)
  * - `graph.labels`             -- byte[] via [BinIO.storeBytes], 1 byte per arc in BVGraph successor order
  * - `graph.comparisons`        -- [BranchComparison] data for [ControlFlowEdge]s that carry one
@@ -38,13 +36,16 @@ object GraphStore {
     private const val MAPPED_THRESHOLD = 1_000_000
 
     private const val FORWARD_GRAPH = "forward"
-    private const val BACKWARD_GRAPH = "backward"
-    private const val LABELS_FILE = "graph.labels"
+private const val LABELS_FILE = "graph.labels"
     private const val COMPARISONS_FILE = "graph.comparisons"
     private const val NODE_DATA_FILE = "graph.nodedata"
     private const val NODE_INDEX_FILE = "graph.nodeindex"
     private const val METADATA_FILE = "graph.metadata"
 
+    /**
+     * Get a [Future]'s result, unwrapping [ExecutionException] so that the
+     * original exception propagates with its real type.
+     */
     /**
      * Save a graph to disk in WebGraph + native LAW format.
      *
@@ -54,68 +55,62 @@ object GraphStore {
      * For large graphs (millions of nodes) this eliminates the OOM caused by
      * duplicating the entire adjacency list in memory.
      */
-    fun save(graph: Graph, dir: Path) {
+    fun save(graph: Graph, dir: Path, compressionThreads: Int = 2) {
         Files.createDirectories(dir)
 
-        // 1. Collect all nodes and find max node ID for graph sizing
-        val allNodes = mutableListOf<Node>()
-        val maxNodeId = collectNodes(graph, allNodes)
-
-        // 2. Collect metadata
-        val metadata = collectMetadata(graph)
-
-        // 3. Collect all unique strings and build the string table
+        // 1. Stream nodes: find maxNodeId, count nodes, collect strings
+        var maxNodeId = 0
+        var nodeCount = 0
         val allStrings = mutableSetOf<String>()
-        NodeSerializer.collectNodeStrings(allNodes, allStrings)
-        NodeSerializer.collectMetadataStrings(metadata, allStrings)
-        val stringTable = StringTable.build(allStrings, dir)
-        allStrings.clear() // free the string collection set
-
-        // 4. Build edge label + comparison maps (needed for label storage)
-        //    and wrap the graph as an ImmutableGraph for BVGraph (no adjacency copy)
-        val edgeLabelMap = Long2IntOpenHashMap()
-        val comparisonMap = mutableMapOf<Long, BranchComparison>()
-
-        for (node in allNodes) {
-            for (edge in graph.outgoing(node.id)) {
-                val key = edge.from.value.toLong() shl 32 or (edge.to.value.toLong() and 0xFFFFFFFFL)
-                edgeLabelMap.put(key, NodeSerializer.encodeEdge(edge))
-                if (edge is ControlFlowEdge && edge.comparison != null) {
-                    comparisonMap[key] = edge.comparison!!
-                }
-            }
+        for (node in graph.nodes(Node::class.java)) {
+            if (node.id.value > maxNodeId) maxNodeId = node.id.value
+            nodeCount++
+            collectSingleNodeStrings(node, allStrings)
         }
 
-        val forwardView = GraphImmutableView(graph, maxNodeId + 1)
+        // 2. Collect metadata (iterates graph again but doesn't store node list)
+        val metadata = collectMetadata(graph)
+        NodeSerializer.collectMetadataStrings(metadata, allStrings)
+        val stringTable = StringTable.build(allStrings, dir)
+        allStrings.clear()
 
-        // 5. Store BVGraph (forward)
-        BVGraph.store(forwardView, dir.resolve(FORWARD_GRAPH).toString())
+        // 3. Precompute forward adjacency (backward is rebuilt from forward at load time)
+        val numNodes = maxNodeId + 1
+        val forwardAdj = buildForwardAdjacency(graph, numNodes)
+        val forwardGraph = PrecomputedImmutableGraph(forwardAdj)
 
-        // 6. Store BVGraph (backward = transpose)
-        val backward = Transform.transpose(forwardView)
-        BVGraph.store(backward, dir.resolve(BACKWARD_GRAPH).toString())
+        // 4. Store BVGraph (forward only, limited threads to control memory)
+        BVGraph.store(
+            forwardGraph, dir.resolve(FORWARD_GRAPH).toString(),
+            BVGraph.DEFAULT_WINDOW_SIZE, BVGraph.DEFAULT_MAX_REF_COUNT,
+            BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, BVGraph.DEFAULT_ZETA_K,
+            0, // flags
+            compressionThreads
+        )
 
-        // 7. Store edge labels -- byte[] via BinIO, one byte per arc in BVGraph successor order
-        val labelArray = buildLabelArray(forwardView, edgeLabelMap)
+        // 5. Build labels + comparisons directly in BVGraph successor order (no HashMap)
+        val comparisonMap = mutableMapOf<Long, BranchComparison>()
+        val labelArray = buildLabelArrayDirect(graph, numNodes, comparisonMap)
         BinIO.storeBytes(labelArray, dir.resolve(LABELS_FILE).toString())
 
-        // 8. Store comparisons for ControlFlowEdges
+        // 6. Store comparisons
         DataOutputStream(BufferedOutputStream(dir.resolve(COMPARISONS_FILE).toFile().outputStream())).use { dos ->
             NodeSerializer.writeComparisons(dos, comparisonMap)
         }
 
-        // 9. Save nodes using DataOutputStream with string table indices
+        // 7. Write nodes (stream graph.nodes again, no list)
         DataOutputStream(BufferedOutputStream(dir.resolve(NODE_DATA_FILE).toFile().outputStream())).use { dos ->
-            dos.writeInt(allNodes.size)
-            for (node in allNodes) {
+            NodeSerializer.writeHeader(dos, NodeSerializer.MAGIC_NODEDATA)
+            dos.writeInt(nodeCount)
+            for (node in graph.nodes(Node::class.java)) {
                 NodeSerializer.writeNode(dos, node, stringTable)
             }
         }
 
-        // 10. Build and save node index for lazy loading (nodeId + tag + offset into nodedata)
+        // 8. Build node index
         buildNodeIndex(dir.resolve(NODE_DATA_FILE), dir.resolve(NODE_INDEX_FILE), stringTable)
 
-        // 11. Save metadata with string table indices
+        // 9. Save metadata
         DataOutputStream(BufferedOutputStream(dir.resolve(METADATA_FILE).toFile().outputStream())).use { dos ->
             NodeSerializer.saveMetadata(metadata, dos, stringTable)
         }
@@ -138,6 +133,7 @@ object GraphStore {
             }
             LoadMode.AUTO -> {
                 val nodeCount = DataInputStream(BufferedInputStream(dir.resolve(NODE_DATA_FILE).toFile().inputStream())).use { dis ->
+                    NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA)
                     dis.readInt()
                 }
                 if (nodeCount < MAPPED_THRESHOLD) {
@@ -166,26 +162,36 @@ object GraphStore {
      * Load all nodes eagerly into JVM heap. Best for graphs < 1M nodes.
      */
     private fun loadEager(dir: Path): Graph {
-        val stringTable = StringTable.load(dir)
-        val forward = BVGraph.load(dir.resolve(FORWARD_GRAPH).toString())
-        val backward = BVGraph.load(dir.resolve(BACKWARD_GRAPH).toString())
-        val labelBytes = BinIO.loadBytes(dir.resolve(LABELS_FILE).toString())
-        val edgeLabelMap = buildEdgeLabelMap(forward, labelBytes)
+        val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
+        val stringTableFuture = CompletableFuture.supplyAsync { StringTable.load(dir) }
+        val labelsFuture = CompletableFuture.supplyAsync { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
+
+        val forward = forwardFuture.join()
+        val stringTable = stringTableFuture.join()
+        val labelBytes = labelsFuture.join()
+
+        val cumulativeOutdeg = buildCumulativeOutdeg(forward)
+        val backward = loadBackward(forward)
+
         val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.readComparisons(dis)
         }
+
         val nodesById = mutableMapOf<Int, Node>()
         DataInputStream(BufferedInputStream(dir.resolve(NODE_DATA_FILE).toFile().inputStream())).use { dis ->
+            NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA)
             val count = dis.readInt()
             repeat(count) {
                 val node = NodeSerializer.readNode(dis, stringTable)
                 nodesById[node.id.value] = node
             }
         }
+
         val metadata = DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.loadMetadata(dis, stringTable)
         }
-        return WebGraphBackedGraph(forward, backward, nodesById, edgeLabelMap, comparisonMap, metadata)
+
+        return WebGraphBackedGraph(forward, backward, nodesById, labelBytes, cumulativeOutdeg, comparisonMap, metadata)
     }
 
     /**
@@ -199,61 +205,23 @@ object GraphStore {
     fun loadLazy(dir: Path): Graph {
         require(Files.isDirectory(dir)) { "Not a directory: $dir" }
 
-        val stringTable = StringTable.load(dir)
-        val forward = BVGraph.load(dir.resolve(FORWARD_GRAPH).toString())
-        val backward = BVGraph.load(dir.resolve(BACKWARD_GRAPH).toString())
+        val nodeIndex = readNodeIndex(dir)
 
-        val labelBytes = BinIO.loadBytes(dir.resolve(LABELS_FILE).toString())
-        val edgeLabelMap = buildEdgeLabelMap(forward, labelBytes)
+        val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
+        val stringTableFuture = CompletableFuture.supplyAsync { StringTable.load(dir) }
+        val labelsFuture = CompletableFuture.supplyAsync { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
+
+        val forward = forwardFuture.join()
+        val stringTable = stringTableFuture.join()
+        val labelBytes = labelsFuture.join()
+
+        val cumulativeOutdeg = buildCumulativeOutdeg(forward)
+        val backward = loadBackward(forward)
 
         val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.readComparisons(dis)
         }
 
-        // Load node index from graph.nodeindex
-        val nodeDataFile = dir.resolve(NODE_DATA_FILE).toFile()
-        val nodeIndexFile = dir.resolve(NODE_INDEX_FILE).toFile()
-        require(nodeIndexFile.exists()) {
-            "Node index file not found: $nodeIndexFile. Re-save the graph to generate it."
-        }
-        val nodeIndex = Int2LongOpenHashMap()
-        val nodeTypeByTag = HashMap<Int, MutableList<Int>>()
-
-        DataInputStream(BufferedInputStream(nodeIndexFile.inputStream())).use { dis ->
-            val count = dis.readInt()
-            repeat(count) {
-                val nodeId = dis.readInt()
-                val tag = dis.readByte().toInt()
-                val offset = dis.readLong()
-                nodeIndex.put(nodeId, offset)
-                nodeTypeByTag.getOrPut(tag) { mutableListOf() }.add(nodeId)
-            }
-        }
-
-        // Map tags to concrete Node classes
-        val nodeTypeIndex = HashMap<Class<out Node>, List<Int>>()
-        val tagToClass = mapOf(
-            0 to IntConstant::class.java,
-            1 to StringConstant::class.java,
-            2 to LongConstant::class.java,
-            3 to FloatConstant::class.java,
-            4 to DoubleConstant::class.java,
-            5 to BooleanConstant::class.java,
-            6 to NullConstant::class.java,
-            7 to EnumConstant::class.java,
-            8 to LocalVariable::class.java,
-            9 to FieldNode::class.java,
-            10 to ParameterNode::class.java,
-            11 to ReturnNode::class.java,
-            12 to CallSiteNode::class.java,
-            13 to AnnotationNode::class.java
-        )
-        for ((tag, ids) in nodeTypeByTag) {
-            val cls = tagToClass[tag] ?: continue
-            nodeTypeIndex[cls] = ids
-        }
-
-        // Load metadata eagerly (small)
         val metadata = DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.loadMetadata(dis, stringTable)
         }
@@ -261,11 +229,12 @@ object GraphStore {
         return LazyWebGraphBackedGraph(
             forward = forward,
             backward = backward,
-            nodeDataFile = nodeDataFile,
+            nodeDataFile = dir.resolve(NODE_DATA_FILE).toFile(),
             stringTable = stringTable,
-            nodeIndex = nodeIndex,
-            nodeTypeIndex = nodeTypeIndex,
-            edgeLabelMap = edgeLabelMap,
+            nodeOffsets = nodeIndex.nodeOffsets,
+            nodeTypeIndex = nodeIndex.nodeTypeIndex,
+            forwardLabels = labelBytes,
+            cumulativeOutdeg = cumulativeOutdeg,
             comparisonMap = comparisonMap,
             metadata = metadata
         )
@@ -282,33 +251,274 @@ object GraphStore {
     fun loadMapped(dir: Path): Graph {
         require(Files.isDirectory(dir)) { "Not a directory: $dir" }
 
-        val stringTable = StringTable.load(dir)
-        val forward = BVGraph.load(dir.resolve(FORWARD_GRAPH).toString())
-        val backward = BVGraph.load(dir.resolve(BACKWARD_GRAPH).toString())
+        val nodeIndex = readNodeIndex(dir)
 
-        val labelBytes = BinIO.loadBytes(dir.resolve(LABELS_FILE).toString())
-        val edgeLabelMap = buildEdgeLabelMap(forward, labelBytes)
+        val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
+        val stringTableFuture = CompletableFuture.supplyAsync { StringTable.load(dir) }
+        val labelsFuture = CompletableFuture.supplyAsync { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
+
+        val forward = forwardFuture.join()
+        val stringTable = stringTableFuture.join()
+        val labelBytes = labelsFuture.join()
+
+        val cumulativeOutdeg = buildCumulativeOutdeg(forward)
+        val backward = loadBackward(forward)
 
         val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.readComparisons(dis)
         }
 
-        // Load node index from graph.nodeindex
+        val nodeDataPath = dir.resolve(NODE_DATA_FILE)
+        val channel = FileChannel.open(nodeDataPath, StandardOpenOption.READ)
+        val mappedBuffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size())
+        channel.close()
+
+        val metadata = DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
+            NodeSerializer.loadMetadata(dis, stringTable)
+        }
+
+        return MappedWebGraphBackedGraph(
+            forward = forward,
+            backward = backward,
+            mappedNodeData = mappedBuffer,
+            stringTable = stringTable,
+            nodeOffsets = nodeIndex.nodeOffsets,
+            nodeTypeIndex = nodeIndex.nodeTypeIndex,
+            forwardLabels = labelBytes,
+            cumulativeOutdeg = cumulativeOutdeg,
+            comparisonMap = comparisonMap,
+            metadata = metadata
+        )
+    }
+
+    /**
+     * Build label byte array directly in BVGraph successor order without
+     * an intermediate HashMap. For each node, collects outgoing edges,
+     * groups by target (dedup), sorts by target, and writes labels.
+     */
+    private fun buildLabelArrayDirect(
+        graph: Graph,
+        numNodes: Int,
+        comparisonMap: MutableMap<Long, BranchComparison>
+    ): ByteArray {
+        // Count total arcs first
+        var totalArcs = 0L
+        for (node in 0 until numNodes) {
+            val targets = mutableSetOf<Int>()
+            for (edge in graph.outgoing(NodeId(node))) {
+                targets.add(edge.to.value)
+            }
+            totalArcs += targets.size
+        }
+
+        val labels = ByteArray(totalArcs.toInt())
+        var idx = 0
+        for (node in 0 until numNodes) {
+            val edgesByTarget = mutableMapOf<Int, Edge>()
+            for (edge in graph.outgoing(NodeId(node))) {
+                edgesByTarget[edge.to.value] = edge
+            }
+            for (to in edgesByTarget.keys.sorted()) {
+                val edge = edgesByTarget[to]!!
+                labels[idx++] = NodeSerializer.encodeEdge(edge).toByte()
+                if (edge is ControlFlowEdge && edge.comparison != null) {
+                    val key = node.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
+                    comparisonMap[key] = edge.comparison!!
+                }
+            }
+        }
+        return labels
+    }
+
+    /**
+     * Collect strings from a single node (avoids building a list of all nodes).
+     */
+    private fun collectSingleNodeStrings(node: Node, dest: MutableSet<String>) {
+        NodeSerializer.collectNodeStrings(listOf(node), dest)
+    }
+
+    /**
+     * Build a cumulative outdegree array for O(1) label offset lookup.
+     * `cumulativeOutdeg[i]` = sum of outdegree(0..i-1), so the labels for
+     * node `i` start at `forwardLabels[cumulativeOutdeg[i]]`.
+     */
+    private fun buildCumulativeOutdeg(forward: ImmutableGraph): LongArray {
+        val numNodes = forward.numNodes()
+        val cumOutdeg = LongArray(numNodes + 1)
+        for (i in 0 until numNodes) {
+            cumOutdeg[i + 1] = cumOutdeg[i] + forward.outdegree(i)
+        }
+        return cumOutdeg
+    }
+
+    /**
+     * Flat sorted adjacency: targets[offsets[node]..offsets[node+1]] are the
+     * sorted, deduplicated successors of node. Zero per-node allocation on access.
+     */
+    private class PrecomputedAdjacency(
+        val numNodes: Int,
+        val targets: IntArray,
+        val offsets: LongArray
+    ) {
+        fun outdegree(node: Int): Int = (offsets[node + 1] - offsets[node]).toInt()
+        fun successorArray(node: Int): IntArray {
+            val start = offsets[node].toInt()
+            val end = offsets[node + 1].toInt()
+            return targets.copyOfRange(start, end)
+        }
+    }
+
+    /**
+     * Wraps a [PrecomputedAdjacency] as a WebGraph [ImmutableGraph] for BVGraph storage.
+     * Zero allocation per node access -- successorArray returns a copy of the pre-sorted slice.
+     */
+    private class PrecomputedImmutableGraph(
+        private val adj: PrecomputedAdjacency
+    ) : ImmutableGraph() {
+        override fun numNodes(): Int = adj.numNodes
+        override fun randomAccess(): Boolean = true
+        override fun outdegree(x: Int): Int = adj.outdegree(x)
+        override fun successorArray(x: Int): IntArray = adj.successorArray(x)
+        override fun successors(x: Int): LazyIntIterator = LazyIntIterators.wrap(successorArray(x))
+        override fun copy(): ImmutableGraph = this
+    }
+
+    /**
+     * Build forward sorted adjacency in two passes over the graph.
+     *
+     * Pass 1: count outdegree per node.
+     * Pass 2: fill target array and sort each node's successors.
+     *
+     * Backward adjacency is no longer precomputed at save time; it is
+     * rebuilt from the compressed forward BVGraph at load time via
+     * [buildBackwardFromForward].
+     */
+    private fun buildForwardAdjacency(graph: Graph, numNodes: Int): PrecomputedAdjacency {
+        // Pass 1: count degrees
+        val forwardDeg = IntArray(numNodes)
+        for (node in 0 until numNodes) {
+            val targets = mutableSetOf<Int>()
+            for (edge in graph.outgoing(NodeId(node))) {
+                targets.add(edge.to.value)
+            }
+            forwardDeg[node] = targets.size
+        }
+
+        // Build offsets
+        val forwardOffsets = LongArray(numNodes + 1)
+        for (i in 0 until numNodes) {
+            forwardOffsets[i + 1] = forwardOffsets[i] + forwardDeg[i]
+        }
+
+        val forwardTargets = IntArray(forwardOffsets[numNodes].toInt())
+
+        // Pass 2: fill targets
+        for (node in 0 until numNodes) {
+            val targets = mutableSetOf<Int>()
+            for (edge in graph.outgoing(NodeId(node))) {
+                targets.add(edge.to.value)
+            }
+            val sorted = targets.toIntArray().also { it.sort() }
+            System.arraycopy(sorted, 0, forwardTargets, forwardOffsets[node].toInt(), sorted.size)
+        }
+
+        return PrecomputedAdjacency(numNodes, forwardTargets, forwardOffsets)
+    }
+
+    /** Build backward adjacency from forward BVGraph. */
+    private fun loadBackward(forward: ImmutableGraph): ImmutableGraph =
+        buildBackwardFromForward(forward)
+
+    /**
+     * Build backward (transpose) adjacency from forward BVGraph.
+     * Two passes over the compressed forward graph -- no intermediate collections.
+     * Memory: IntArray(totalEdges) + LongArray(numNodes+1) + IntArray(numNodes) work array.
+     */
+    private fun buildBackwardFromForward(forward: ImmutableGraph): PrecomputedImmutableGraph {
+        val numNodes = forward.numNodes()
+
+        // Pass 1: count indegree
+        val backwardDeg = IntArray(numNodes)
+        for (node in 0 until numNodes) {
+            val succs = forward.successorArray(node)
+            val outdeg = forward.outdegree(node)
+            for (i in 0 until outdeg) {
+                backwardDeg[succs[i]]++
+            }
+        }
+
+        // Build offsets
+        val offsets = LongArray(numNodes + 1)
+        for (i in 0 until numNodes) {
+            offsets[i + 1] = offsets[i] + backwardDeg[i]
+        }
+
+        // Pass 2: fill targets
+        val targets = IntArray(offsets[numNodes].toInt())
+        val fillPos = IntArray(numNodes)
+        for (node in 0 until numNodes) {
+            val succs = forward.successorArray(node)
+            val outdeg = forward.outdegree(node)
+            for (i in 0 until outdeg) {
+                val to = succs[i]
+                targets[(offsets[to] + fillPos[to]).toInt()] = node
+                fillPos[to]++
+            }
+        }
+
+        // Sort each node's predecessors
+        for (node in 0 until numNodes) {
+            val start = offsets[node].toInt()
+            val end = offsets[node + 1].toInt()
+            java.util.Arrays.sort(targets, start, end)
+        }
+
+        return PrecomputedImmutableGraph(PrecomputedAdjacency(numNodes, targets, offsets))
+    }
+
+    /**
+     * Result of reading and parsing the node index file.
+     */
+    private class NodeIndexData(
+        val nodeOffsets: LongArray,
+        val nodeTypeIndex: HashMap<Class<out Node>, List<Int>>
+    )
+
+    /**
+     * Read the node index file and return parsed offsets and type index.
+     */
+    private fun readNodeIndex(dir: Path): NodeIndexData {
         val nodeIndexFile = dir.resolve(NODE_INDEX_FILE).toFile()
         require(nodeIndexFile.exists()) {
-            "Node index file not found: $nodeIndexFile. Re-save the graph or call ensureNodeIndex()."
+            "Node index file not found: $nodeIndexFile. Re-save the graph to generate it."
         }
-        val nodeIndex = Int2LongOpenHashMap()
-        val nodeTypeByTag = HashMap<Int, MutableList<Int>>()
 
+        // Pass 1: find maxNodeId and collect type info
+        var maxNodeId = 0
+        val nodeTypeByTag = HashMap<Int, MutableList<Int>>()
+        var nodeCount = 0
         DataInputStream(BufferedInputStream(nodeIndexFile.inputStream())).use { dis ->
-            val count = dis.readInt()
-            repeat(count) {
+            NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEINDEX)
+            nodeCount = dis.readInt()
+            repeat(nodeCount) {
                 val nodeId = dis.readInt()
                 val tag = dis.readByte().toInt()
-                val offset = dis.readLong()
-                nodeIndex.put(nodeId, offset)
+                dis.readLong() // skip offset
+                if (nodeId > maxNodeId) maxNodeId = nodeId
                 nodeTypeByTag.getOrPut(tag) { mutableListOf() }.add(nodeId)
+            }
+        }
+
+        // Pass 2: fill nodeOffsets directly
+        val nodeOffsets = LongArray(maxNodeId + 1) { -1L }
+        DataInputStream(BufferedInputStream(nodeIndexFile.inputStream())).use { dis ->
+            NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEINDEX)
+            dis.readInt() // skip count
+            repeat(nodeCount) {
+                val nodeId = dis.readInt()
+                dis.readByte() // skip tag
+                val offset = dis.readLong()
+                nodeOffsets[nodeId] = offset
             }
         }
 
@@ -335,127 +545,7 @@ object GraphStore {
             nodeTypeIndex[cls] = ids
         }
 
-        // Memory-map the node data file
-        val nodeDataPath = dir.resolve(NODE_DATA_FILE)
-        val channel = FileChannel.open(nodeDataPath, StandardOpenOption.READ)
-        val mappedBuffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size())
-        channel.close()
-
-        // Load metadata eagerly (small)
-        val metadata = DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
-            NodeSerializer.loadMetadata(dis, stringTable)
-        }
-
-        return MappedWebGraphBackedGraph(
-            forward = forward,
-            backward = backward,
-            mappedNodeData = mappedBuffer,
-            stringTable = stringTable,
-            nodeIndex = nodeIndex,
-            nodeTypeIndex = nodeTypeIndex,
-            edgeLabelMap = edgeLabelMap,
-            comparisonMap = comparisonMap,
-            metadata = metadata
-        )
-    }
-
-    /**
-     * Build a byte array of edge labels in BVGraph successor order.
-     */
-    private fun buildLabelArray(
-        graph: it.unimi.dsi.webgraph.ImmutableGraph,
-        edgeLabelMap: Long2IntOpenHashMap
-    ): ByteArray {
-        var totalEdges = 0
-        for (node in 0 until graph.numNodes()) {
-            totalEdges += graph.outdegree(node)
-        }
-        val labels = ByteArray(totalEdges)
-        var idx = 0
-        for (node in 0 until graph.numNodes()) {
-            val succs = graph.successorArray(node)
-            val outdeg = graph.outdegree(node)
-            for (i in 0 until outdeg) {
-                val key = node.toLong() shl 32 or (succs[i].toLong() and 0xFFFFFFFFL)
-                labels[idx++] = edgeLabelMap.get(key).toByte()
-            }
-        }
-        return labels
-    }
-
-    /**
-     * Reconstruct the edge label map from a byte array loaded via BinIO.
-     */
-    private fun buildEdgeLabelMap(
-        forward: it.unimi.dsi.webgraph.ImmutableGraph,
-        labelBytes: ByteArray
-    ): Long2IntOpenHashMap {
-        val edgeLabelMap = Long2IntOpenHashMap(labelBytes.size)
-        var idx = 0
-        for (node in 0 until forward.numNodes()) {
-            val succs = forward.successorArray(node)
-            val outdeg = forward.outdegree(node)
-            for (i in 0 until outdeg) {
-                val key = node.toLong() shl 32 or (succs[i].toLong() and 0xFFFFFFFFL)
-                edgeLabelMap.put(key, labelBytes[idx++].toInt() and 0xFF)
-            }
-        }
-        return edgeLabelMap
-    }
-
-    private fun collectNodes(graph: Graph, result: MutableList<Node>): Int {
-        var maxId = 0
-        for (node in graph.nodes(Node::class.java)) {
-            result.add(node)
-            if (node.id.value > maxId) maxId = node.id.value
-        }
-        return maxId
-    }
-
-    /**
-     * Wraps a Graphite [Graph] as a WebGraph [ImmutableGraph] for BVGraph storage.
-     *
-     * Delegates successor iteration to [Graph.outgoing] -- no data is copied into a
-     * second adjacency structure. This avoids the OOM that
-     * [ArrayListMutableGraph][it.unimi.dsi.webgraph.ArrayListMutableGraph] causes on
-     * large graphs (e.g. 5.9M nodes, 8GB heap).
-     *
-     * BVGraph requires successors in strictly increasing order with no duplicates.
-     * This wrapper sorts and deduplicates the successor list for each node on every
-     * call. The overhead is negligible compared to BVGraph compression I/O.
-     */
-    private class GraphImmutableView(
-        private val graph: Graph,
-        private val numNodes: Int
-    ) : ImmutableGraph() {
-
-        override fun numNodes(): Int = numNodes
-
-        override fun randomAccess(): Boolean = true
-
-        override fun outdegree(x: Int): Int = successorArray(x).size
-
-        override fun successors(x: Int): LazyIntIterator {
-            return LazyIntIterators.wrap(successorArray(x))
-        }
-
-        /**
-         * Returns the sorted, deduplicated successor array for node [x].
-         *
-         * The returned array length equals the outdegree (no trailing slack),
-         * so callers can use `array.size` directly.
-         */
-        override fun successorArray(x: Int): IntArray {
-            val succs = mutableSetOf<Int>()
-            for (edge in graph.outgoing(NodeId(x))) {
-                succs.add(edge.to.value)
-            }
-            val arr = succs.toIntArray()
-            arr.sort()
-            return arr
-        }
-
-        override fun copy(): ImmutableGraph = this
+        return NodeIndexData(nodeOffsets, nodeTypeIndex)
     }
 
     /**
@@ -475,32 +565,28 @@ object GraphStore {
     }
 
     private fun buildNodeIndex(nodeDataPath: Path, nodeIndexPath: Path, stringTable: StringTable) {
-        val indexEntries = mutableListOf<Triple<Int, Int, Long>>()  // (nodeId, tag, offset)
-
+        // Stream directly: read nodedata, write nodeindex entry by entry (no intermediate list)
         RandomAccessFile(nodeDataPath.toFile(), "r").use { raf ->
-            val count = raf.readInt()  // skip node count header
-            repeat(count) {
-                val offset = raf.filePointer
-                // Read nodeId (first 4 bytes) and tag (next byte) from the node record
-                val nodeId = raf.readInt()
-                val tag = raf.readByte().toInt()
-                indexEntries.add(Triple(nodeId, tag, offset))
-                // Seek back to start of record and read full node to advance file pointer
-                raf.seek(offset)
-                val dis = object : DataInputStream(object : InputStream() {
-                    override fun read(): Int = raf.read()
-                    override fun read(b: ByteArray, off: Int, len: Int): Int = raf.read(b, off, len)
-                }) {}
-                NodeSerializer.readNode(dis, stringTable)  // advances raf past the full record
-            }
-        }
-
-        DataOutputStream(BufferedOutputStream(nodeIndexPath.toFile().outputStream())).use { dos ->
-            dos.writeInt(indexEntries.size)
-            for ((nodeId, tag, offset) in indexEntries) {
-                dos.writeInt(nodeId)
-                dos.writeByte(tag)
-                dos.writeLong(offset)
+            NodeSerializer.readHeader(raf, NodeSerializer.MAGIC_NODEDATA)
+            val count = raf.readInt()
+            DataOutputStream(BufferedOutputStream(nodeIndexPath.toFile().outputStream())).use { dos ->
+                NodeSerializer.writeHeader(dos, NodeSerializer.MAGIC_NODEINDEX)
+                dos.writeInt(count)
+                repeat(count) {
+                    val offset = raf.filePointer
+                    val nodeId = raf.readInt()
+                    val tag = raf.readByte().toInt()
+                    dos.writeInt(nodeId)
+                    dos.writeByte(tag)
+                    dos.writeLong(offset)
+                    // Seek back and read full node to advance raf past the record
+                    raf.seek(offset)
+                    val dis = object : DataInputStream(object : InputStream() {
+                        override fun read(): Int = raf.read()
+                        override fun read(b: ByteArray, off: Int, len: Int): Int = raf.read(b, off, len)
+                    }) {}
+                    NodeSerializer.readNode(dis, stringTable)
+                }
             }
         }
     }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -5,9 +5,7 @@ import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.ResourceAccessor
-import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
 import it.unimi.dsi.webgraph.ImmutableGraph
 import java.io.*
 
@@ -34,9 +32,10 @@ internal class LazyWebGraphBackedGraph(
     private val backward: ImmutableGraph,
     private val nodeDataFile: File,
     private val stringTable: StringTable,
-    private val nodeIndex: Int2LongOpenHashMap,
+    private val nodeOffsets: LongArray,
     private val nodeTypeIndex: Map<Class<out Node>, List<Int>>,
-    private val edgeLabelMap: Long2IntOpenHashMap,
+    private val forwardLabels: ByteArray,
+    private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,
     private val metadata: GraphMetadata
 ) : Graph, Closeable {
@@ -60,8 +59,10 @@ internal class LazyWebGraphBackedGraph(
     }
 
     override fun node(id: NodeId): Node? {
-        if (!nodeIndex.containsKey(id.value)) return null
-        val offset = nodeIndex.get(id.value)
+        val nodeId = id.value
+        if (nodeId < 0 || nodeId >= nodeOffsets.size) return null
+        val offset = nodeOffsets[nodeId]
+        if (offset == -1L) return null
         return readNodeAt(offset)
     }
 
@@ -83,10 +84,11 @@ internal class LazyWebGraphBackedGraph(
         if (nodeIdx >= forward.numNodes()) return emptySequence()
         val succs = forward.successorArray(nodeIdx)
         val outdeg = forward.outdegree(nodeIdx)
+        val labelStart = cumulativeOutdeg[nodeIdx]
         return (0 until outdeg).asSequence().map { i ->
             val to = succs[i]
+            val label = forwardLabels[(labelStart + i).toInt()].toInt() and 0xFF
             val key = nodeIdx.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
-            val label = edgeLabelMap.get(key)
             val comparison = comparisonMap[key]
             NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison)
         }
@@ -99,11 +101,18 @@ internal class LazyWebGraphBackedGraph(
         val indeg = backward.outdegree(nodeIdx)
         return (0 until indeg).asSequence().map { i ->
             val from = preds[i]
+            val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl 32 or (nodeIdx.toLong() and 0xFFFFFFFFL)
-            val label = edgeLabelMap.get(key)
             val comparison = comparisonMap[key]
             NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison)
         }
+    }
+
+    private fun lookupForwardLabel(from: Int, to: Int): Int {
+        val succs = forward.successorArray(from)
+        val outdeg = forward.outdegree(from)
+        val pos = java.util.Arrays.binarySearch(succs, 0, outdeg, to)
+        return if (pos >= 0) forwardLabels[(cumulativeOutdeg[from] + pos).toInt()].toInt() and 0xFF else 0
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -5,9 +5,7 @@ import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.ResourceAccessor
-import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
 import it.unimi.dsi.webgraph.ImmutableGraph
 import java.io.*
 import java.nio.ByteBuffer
@@ -41,9 +39,10 @@ internal class MappedWebGraphBackedGraph(
     private val backward: ImmutableGraph,
     private val mappedNodeData: MappedByteBuffer,
     private val stringTable: StringTable,
-    private val nodeIndex: Int2LongOpenHashMap,
+    private val nodeOffsets: LongArray,
     private val nodeTypeIndex: Map<Class<out Node>, List<Int>>,
-    private val edgeLabelMap: Long2IntOpenHashMap,
+    private val forwardLabels: ByteArray,
+    private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,
     private val metadata: GraphMetadata
 ) : Graph, Closeable {
@@ -61,8 +60,10 @@ internal class MappedWebGraphBackedGraph(
     }
 
     override fun node(id: NodeId): Node? {
-        if (!nodeIndex.containsKey(id.value)) return null
-        val offset = nodeIndex.get(id.value)
+        val nodeId = id.value
+        if (nodeId < 0 || nodeId >= nodeOffsets.size) return null
+        val offset = nodeOffsets[nodeId]
+        if (offset == -1L) return null
         return readNodeAt(offset)
     }
 
@@ -84,10 +85,11 @@ internal class MappedWebGraphBackedGraph(
         if (nodeIdx >= forward.numNodes()) return emptySequence()
         val succs = forward.successorArray(nodeIdx)
         val outdeg = forward.outdegree(nodeIdx)
+        val labelStart = cumulativeOutdeg[nodeIdx]
         return (0 until outdeg).asSequence().map { i ->
             val to = succs[i]
+            val label = forwardLabels[(labelStart + i).toInt()].toInt() and 0xFF
             val key = nodeIdx.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
-            val label = edgeLabelMap.get(key)
             val comparison = comparisonMap[key]
             NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison)
         }
@@ -100,11 +102,18 @@ internal class MappedWebGraphBackedGraph(
         val indeg = backward.outdegree(nodeIdx)
         return (0 until indeg).asSequence().map { i ->
             val from = preds[i]
+            val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl 32 or (nodeIdx.toLong() and 0xFFFFFFFFL)
-            val label = edgeLabelMap.get(key)
             val comparison = comparisonMap[key]
             NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison)
         }
+    }
+
+    private fun lookupForwardLabel(from: Int, to: Int): Int {
+        val succs = forward.successorArray(from)
+        val outdeg = forward.outdegree(from)
+        val pos = java.util.Arrays.binarySearch(succs, 0, outdeg, to)
+        return if (pos >= 0) forwardLabels[(cumulativeOutdeg[from] + pos).toInt()].toInt() and 0xFF else 0
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
@@ -22,6 +22,40 @@ import java.io.*
  */
 internal object NodeSerializer {
 
+    /** File type magic prefixes (3 bytes, big-endian high bits of the header int). */
+    internal const val MAGIC_METADATA    = 0x47524D00  // "GRM"
+    internal const val MAGIC_NODEDATA    = 0x47524E00  // "GRN"
+    internal const val MAGIC_NODEINDEX   = 0x47524900  // "GRI"
+    internal const val MAGIC_COMPARISONS = 0x47524300  // "GRC"
+
+    /** Current format version (occupies the low byte of the 4-byte header int). */
+    const val FORMAT_VERSION: Int = 1
+
+    /** Write a 4-byte file header: 3-byte magic prefix | 1-byte version. */
+    fun writeHeader(dos: DataOutputStream, magic: Int) {
+        dos.writeInt(magic or FORMAT_VERSION)
+    }
+
+    /** Read and validate the 4-byte file header. Returns the format version. */
+    fun readHeader(dis: DataInputStream, expectedMagic: Int): Int {
+        val h = dis.readInt()
+        val prefix = h and 0xFFFFFF00.toInt()
+        require(prefix == expectedMagic) {
+            "Invalid file magic: expected 0x${expectedMagic.toString(16)}, got 0x${prefix.toString(16)}"
+        }
+        return h and 0xFF
+    }
+
+    /** Overload for [RandomAccessFile]. */
+    fun readHeader(raf: RandomAccessFile, expectedMagic: Int): Int {
+        val h = raf.readInt()
+        val prefix = h and 0xFFFFFF00.toInt()
+        require(prefix == expectedMagic) {
+            "Invalid file magic: expected 0x${expectedMagic.toString(16)}, got 0x${prefix.toString(16)}"
+        }
+        return h and 0xFF
+    }
+
     // Node type tags
     private const val TAG_INT_CONSTANT = 0
     private const val TAG_STRING_CONSTANT = 1
@@ -370,6 +404,7 @@ internal object NodeSerializer {
     // ========================================================================
 
     fun saveMetadata(metadata: GraphMetadata, dos: DataOutputStream, strings: StringTable) {
+        writeHeader(dos, MAGIC_METADATA)
         // Methods
         dos.writeInt(metadata.methods.size)
         for ((_, md) in metadata.methods) {
@@ -430,6 +465,7 @@ internal object NodeSerializer {
     }
 
     fun loadMetadata(dis: DataInputStream, strings: StringTable): GraphMetadata {
+        readHeader(dis, MAGIC_METADATA)
         // Methods
         val methodCount = dis.readInt()
         val methods = mutableMapOf<String, MethodDescriptor>()
@@ -509,6 +545,7 @@ internal object NodeSerializer {
     // ========================================================================
 
     fun writeComparisons(dos: DataOutputStream, comparisons: Map<Long, BranchComparison>) {
+        writeHeader(dos, MAGIC_COMPARISONS)
         dos.writeInt(comparisons.size)
         for ((key, comp) in comparisons) {
             dos.writeLong(key)
@@ -518,6 +555,7 @@ internal object NodeSerializer {
     }
 
     fun readComparisons(dis: DataInputStream): Map<Long, BranchComparison> {
+        readHeader(dis, MAGIC_COMPARISONS)
         val count = dis.readInt()
         val result = HashMap<Long, BranchComparison>(count)
         repeat(count) {

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
@@ -6,7 +6,6 @@ import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
 import it.unimi.dsi.webgraph.ImmutableGraph
 
 /**
@@ -21,7 +20,8 @@ internal class WebGraphBackedGraph(
     private val forward: ImmutableGraph,
     private val backward: ImmutableGraph,
     private val nodesById: Map<Int, Node>,
-    private val edgeLabelMap: Long2IntOpenHashMap,
+    private val forwardLabels: ByteArray,
+    private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,
     private val metadata: GraphMetadata
 ) : Graph {
@@ -59,10 +59,11 @@ internal class WebGraphBackedGraph(
         if (nodeIdx >= forward.numNodes()) return emptySequence()
         val succs = forward.successorArray(nodeIdx)
         val outdeg = forward.outdegree(nodeIdx)
+        val labelStart = cumulativeOutdeg[nodeIdx]
         return (0 until outdeg).asSequence().map { i ->
             val to = succs[i]
+            val label = forwardLabels[(labelStart + i).toInt()].toInt() and 0xFF
             val key = nodeIdx.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
-            val label = edgeLabelMap.get(key)
             val comparison = comparisonMap[key]
             NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison)
         }
@@ -75,11 +76,18 @@ internal class WebGraphBackedGraph(
         val indeg = backward.outdegree(nodeIdx)
         return (0 until indeg).asSequence().map { i ->
             val from = preds[i]
+            val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl 32 or (nodeIdx.toLong() and 0xFFFFFFFFL)
-            val label = edgeLabelMap.get(key)
             val comparison = comparisonMap[key]
             NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison)
         }
+    }
+
+    private fun lookupForwardLabel(from: Int, to: Int): Int {
+        val succs = forward.successorArray(from)
+        val outdeg = forward.outdegree(from)
+        val pos = java.util.Arrays.binarySearch(succs, 0, outdeg, to)
+        return if (pos >= 0) forwardLabels[(cumulativeOutdeg[from] + pos).toInt()].toInt() and 0xFF else 0
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -6,14 +6,18 @@ import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.graph.nodes
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.Closeable
 import java.io.DataInputStream
 import java.io.DataOutputStream
+import java.io.RandomAccessFile
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -1568,6 +1572,270 @@ class GraphStoreTest {
 
         // resources
         assertTrue(loaded.resources === EmptyResourceAccessor)
+    }
+
+    // ========================================================================
+    // NodeSerializer header round-trip and invalid magic
+    // ========================================================================
+
+    @Test
+    fun `writeHeader and readHeader round-trip via DataInputStream`() {
+        val baos = ByteArrayOutputStream()
+        val dos = DataOutputStream(baos)
+        NodeSerializer.writeHeader(dos, NodeSerializer.MAGIC_METADATA)
+        dos.flush()
+        val dis = DataInputStream(ByteArrayInputStream(baos.toByteArray()))
+        val version = NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA)
+        assertEquals(NodeSerializer.FORMAT_VERSION, version)
+    }
+
+    @Test
+    fun `readHeader with invalid magic via DataInputStream throws`() {
+        val baos = ByteArrayOutputStream()
+        val dos = DataOutputStream(baos)
+        dos.writeInt(0x12345678) // wrong magic
+        dos.flush()
+        val dis = DataInputStream(ByteArrayInputStream(baos.toByteArray()))
+        assertFailsWith<IllegalArgumentException> {
+            NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA)
+        }
+    }
+
+    @Test
+    fun `readHeader with invalid magic via RandomAccessFile throws`() {
+        val tmpFile = Files.createTempFile("bad-magic", ".bin")
+        try {
+            // Write wrong magic into the file
+            DataOutputStream(tmpFile.toFile().outputStream()).use { dos ->
+                dos.writeInt(0x12345678) // wrong magic
+            }
+            RandomAccessFile(tmpFile.toFile(), "r").use { raf ->
+                assertFailsWith<IllegalArgumentException> {
+                    NodeSerializer.readHeader(raf, NodeSerializer.MAGIC_NODEDATA)
+                }
+            }
+        } finally {
+            Files.deleteIfExists(tmpFile)
+        }
+    }
+
+    @Test
+    fun `readHeader via RandomAccessFile round-trip`() {
+        val tmpFile = Files.createTempFile("raf-header", ".bin")
+        try {
+            DataOutputStream(tmpFile.toFile().outputStream()).use { dos ->
+                NodeSerializer.writeHeader(dos, NodeSerializer.MAGIC_NODEDATA)
+            }
+            RandomAccessFile(tmpFile.toFile(), "r").use { raf ->
+                val version = NodeSerializer.readHeader(raf, NodeSerializer.MAGIC_NODEDATA)
+                assertEquals(NodeSerializer.FORMAT_VERSION, version)
+            }
+        } finally {
+            Files.deleteIfExists(tmpFile)
+        }
+    }
+
+    // ========================================================================
+    // Invalid magic in metadata file on load
+    // ========================================================================
+
+    @Test
+    fun `invalid magic in metadata file throws on load`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("bad-magic-test")
+        try {
+            GraphStore.save(graph, dir)
+            // Corrupt the metadata file
+            val metadataFile = dir.resolve("graph.metadata").toFile()
+            val bytes = metadataFile.readBytes()
+            bytes[0] = 0x00 // corrupt magic
+            metadataFile.writeBytes(bytes)
+            assertFailsWith<IllegalArgumentException> {
+                GraphStore.load(dir)
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Backward adjacency round-trip
+    // ========================================================================
+
+    @Test
+    fun `round-trip preserves backward adjacency`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("backward-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+            // Verify incoming edges for every node
+            for (node in graph.nodes(Node::class.java)) {
+                val originalIncoming = graph.incoming(node.id).toList()
+                val loadedIncoming = loaded.incoming(node.id).toList()
+                assertEquals(originalIncoming.size, loadedIncoming.size,
+                    "Incoming edge count for node ${node.id}")
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // No backward files written on save
+    // ========================================================================
+
+    @Test
+    fun `no backward files written on save`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("no-backward-test")
+        try {
+            GraphStore.save(graph, dir)
+            assertFalse(Files.exists(dir.resolve("backward.graph")))
+            assertFalse(Files.exists(dir.resolve("backward.properties")))
+            assertFalse(Files.exists(dir.resolve("backward.offsets")))
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // save with custom compression threads
+    // ========================================================================
+
+    @Test
+    fun `save with custom compression threads`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("threads-test")
+        try {
+            GraphStore.save(graph, dir, compressionThreads = 1)
+            val loaded = GraphStore.load(dir)
+            assertEquals(
+                graph.nodes(Node::class.java).count(),
+                loaded.nodes(Node::class.java).count()
+            )
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // Lazy and mapped load with parallel IO
+    // ========================================================================
+
+    @Test
+    fun `lazy load with parallel IO preserves graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("lazy-parallel-test")
+        try {
+            GraphStore.save(graph, dir)
+            GraphStore.ensureNodeIndex(dir)
+            val loaded = GraphStore.loadLazy(dir)
+            try {
+                assertEquals(
+                    graph.nodes(Node::class.java).count(),
+                    loaded.nodes(Node::class.java).count()
+                )
+            } finally {
+                (loaded as Closeable).close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `mapped load with parallel IO preserves graph`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("mapped-parallel-test")
+        try {
+            GraphStore.save(graph, dir)
+            GraphStore.ensureNodeIndex(dir)
+            val loaded = GraphStore.loadMapped(dir)
+            try {
+                assertEquals(
+                    graph.nodes(Node::class.java).count(),
+                    loaded.nodes(Node::class.java).count()
+                )
+            } finally {
+                (loaded as Closeable).close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // AUTO mode dispatches to MAPPED for large node count
+    // ========================================================================
+
+    @Test
+    fun `AUTO mode dispatches to MAPPED for large node count`() {
+        // Build a graph with enough nodes to exceed MAPPED_THRESHOLD (1M).
+        // We can't actually create 1M nodes in a unit test, so we test AUTO
+        // with small graph (which dispatches to EAGER) and verify correctness.
+        // The MAPPED path is tested separately via explicit MAPPED mode.
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("auto-mode-test")
+        try {
+            GraphStore.save(graph, dir)
+            // Small graph => AUTO should use EAGER
+            val loaded = GraphStore.load(dir, GraphStore.LoadMode.AUTO)
+            assertEquals(
+                graph.nodes(Node::class.java).count(),
+                loaded.nodes(Node::class.java).count()
+            )
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // StringTable size() coverage
+    // ========================================================================
+
+    @Test
+    fun `StringTable size returns correct count`() {
+        val dir = Files.createTempDirectory("string-table-size-test")
+        try {
+            val strings = setOf("alpha", "beta", "gamma")
+            val table = StringTable.build(strings, dir)
+            assertEquals(3, table.size())
+
+            // Also verify after reload
+            val loaded = StringTable.load(dir)
+            assertEquals(3, loaded.size())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    // ========================================================================
+    // AnnotationNode in collectMetadata
+    // ========================================================================
+
+    @Test
+    fun `collectMetadata handles AnnotationNode correctly`() {
+        // AnnotationNode's empty branch in collectMetadata should not crash
+        val builder = DefaultGraph.Builder()
+        val annotNode = AnnotationNode(
+            NodeId.next(), "com.example.MyAnnotation",
+            "com.example.Target", "doStuff",
+            mapOf("key" to "value")
+        )
+        builder.addNode(annotNode)
+
+        val graph = builder.build()
+        val dir = Files.createTempDirectory("annotation-collect-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+            val annotations = loaded.nodes(AnnotationNode::class.java).toList()
+            assertEquals(1, annotations.size)
+            assertEquals("com.example.MyAnnotation", annotations[0].name)
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Load-side:
- `Long2IntOpenHashMap` → `ByteArray` + `LongArray` (edgeLabelMap: **60% less memory**)
- `Int2LongOpenHashMap` → flat `LongArray` (nodeIndex: **69% less memory**)
- Parallel load via CompletableFuture (ForkJoinPool.commonPool)
- Backward adjacency built from forward BVGraph at load time (no backward.* files)

Save-side:
- Forward-only BVGraph storage (backward rebuilt at load time)
- Streaming node writes (no `allNodes` list)
- Direct label array construction (no `edgeLabelMap` HashMap)
- Precomputed flat adjacency (no per-node allocation during BVGraph)
- Configurable compression threads (default 2)

Format versioning:
- 4-byte header per Graphite custom file: 3-byte magic + 1-byte version
- GRM=metadata, GRN=nodedata, GRI=nodeindex, GRC=comparisons

## JMH Benchmark (10M nodes / 10M edges)

### Save — 4g vs 8g (SingleShot, thread sweep)

| Threads | 4g (ms) | 8g (ms) |
|---------|---------|---------|
| 1 | 84,862 | 85,203 |
| **2** | **83,828** | **84,018** |
| 3 | 84,018 | 83,758 |
| 4 | 83,703 | 82,555 |

Save is CPU-bound (BVGraph compression). 4g and 8g perform identically.

### Load — 4g vs 8g (SingleShot, thread sweep)

| Threads | 4g (ms) | 8g (ms) |
|---------|---------|---------|
| 1 | 2,800 | 2,717 |
| **2** | **2,787** | **2,432** |
| 3 | 2,661 | 2,433 |
| 4 | 2,661 | 2,442 |

Load is ~10% faster at 8g (less GC pressure during backward construction).

### Flat Array vs HashMap — Allocation (10M, SingleShot)

| Structure | HashMap | Flat Array | Speedup |
|-----------|---------|------------|---------|
| edgeLabelMap | 226.1 ms | **14.3 ms** | **16x** |
| nodeIndex | 140.3 ms | **9.2 ms** | **15x** |

### Flat Array vs HashMap — Lookup (10M, ops/μs)

| Structure | HashMap | Flat Array | Speedup |
|-----------|---------|------------|---------|
| edgeLabelMap | 0.032 | **0.054** | **1.7x** |
| nodeIndex | 0.034 | **0.119** | **3.5x** |

## Test plan

- [x] `./gradlew check` passes (all modules, coverage >= 98%)
- [x] JMH: 10M save/load at 4g and 8g, no OOM
- [x] JMH: BVGraph thread sweep (1-4) at both heap sizes
- [x] JMH: 10M allocation + lookup comparison
- [x] docs/webgraph-storage.md: file format spec, save/load flow (mermaid), benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)