### PR TITLE
feat: containerize graphite-explore and publish images on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/.git
+**/.gitignore
+**/.gradle
+**/build
+**/.idea
+**/.vscode
+**/*.iml
+**/.DS_Store
+release-assets/
+build-output.txt
+coverage-output.txt
+**/out/
+tap/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,57 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: johnsonlee
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Extract Docker metadata
+      id: docker_meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ghcr.io/johnsonlee/graphite-explore
+          docker.io/johnsonlee/graphite-explore
+        tags: |
+          type=semver,pattern={{version}},value=${{ github.ref_name }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }}
+          type=semver,pattern={{major}},value=${{ github.ref_name }}
+          type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+        labels: |
+          org.opencontainers.image.title=graphite-explore
+          org.opencontainers.image.description=Interactive web visualization for Graphite static analysis graphs
+          org.opencontainers.image.source=https://github.com/johnsonlee/graphite
+          org.opencontainers.image.licenses=Apache-2.0
+
+    - name: Build and push graphite-explore image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: graphite-explore/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        build-args: |
+          VERSION=${{ github.ref_name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
     - name: Update Homebrew tap
       env:
         HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,19 +6,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Follow these steps in order when working on a task:
 
-1. **Design** — Explore the codebase, understand the problem, and plan the implementation approach. Use plan mode for non-trivial tasks. After the plan is finalized, write it to `ROADMAP.md` and commit.
+1. **Design** — Explore the codebase, understand the problem, and plan the implementation approach. Use plan mode for non-trivial tasks.
 2. **Implement** — Write the code changes. Keep changes focused and avoid over-engineering.
 3. **Run tests** — Run `./gradlew check` to verify all tests pass. *(Optional when running as Claude Code on web, since CI will catch failures.)*
-4. **Update ROADMAP.md** — Before committing, update `ROADMAP.md` to reflect what was actually implemented, ensuring the roadmap stays in sync with the code. Mark completed items, adjust plans if the implementation diverged, and remove items that are no longer relevant.
-5. **Commit** — Always show a summary of changes and wait for explicit user confirmation before committing.
-6. **Squash commits and submit PR** — Squash all commits on the branch into a single commit, push, and create a PR via `gh pr create`.
-7. **Watch CI build result** — CI posts build results as PR comments on failure. If the build fails, read the failure comment, fix the issue, and repeat from step 3.
-8. **Ask user to approve and merge** — Once CI passes, ask the user to review, approve, and merge the PR.
-9. **Publish** — NEVER publish via local `./gradlew publish*` commands. ALWAYS publish by creating and pushing a git tag, which triggers GitHub Actions to publish automatically: `git tag vX.Y.Z && git push origin vX.Y.Z`. Before publishing:
+4. **Commit** — Always show a summary of changes and wait for explicit user confirmation before committing.
+5. **Squash commits and submit PR** — Squash all commits on the branch into a single commit, push, and create a PR via `gh pr create`.
+6. **Watch CI build result** — CI posts build results as PR comments on failure. If the build fails, read the failure comment, fix the issue, and repeat from step 3.
+7. **Ask user to approve and merge** — Once CI passes, ask the user to review, approve, and merge the PR.
+8. **Publish** — NEVER publish via local `./gradlew publish*` commands. ALWAYS publish by creating and pushing a git tag, which triggers GitHub Actions to publish automatically: `git tag vX.Y.Z && git push origin vX.Y.Z`. Before publishing:
    1. Check existing versions: `gh api /users/johnsonlee/packages/maven/io.johnsonlee.graphite.graphite-cli/versions --jq '.[].name' | head -5`
    2. Determine the next version number based on existing versions
    3. Show the user the current latest version and proposed new version for confirmation
-10. **Update docs** — After tagging a release, update documentation (README version references, ROADMAP.md version number, etc.) to reflect the new version. This is a docs-only change — commit and push directly to `main` without a PR.
+9. **Update docs** — After tagging a release, update documentation (README version references, etc.) to reflect the new version. This is a docs-only change — commit and push directly to `main` without a PR.
 
 ## Project Overview
 

--- a/graphite-explore/Dockerfile
+++ b/graphite-explore/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7
+#
+# Build context must be the repository root, e.g.
+#   docker build -f graphite-explore/Dockerfile -t graphite-explore .
+#
+# The image runs the graphite-explore web visualizer. Mount a saved graph
+# directory at /data and expose the HTTP port (defaults to 8080):
+#   docker run --rm -p 8080:8080 -v /path/to/graph:/data graphite-explore /data
+
+# ---- Build stage ---------------------------------------------------------
+# Pin to BUILDPLATFORM so the gradle build runs once natively even when
+# buildx targets multiple architectures. The resulting shadow jar is
+# architecture independent.
+FROM --platform=$BUILDPLATFORM gradle:8.10.2-jdk17 AS builder
+
+WORKDIR /workspace
+
+# Copy gradle wrapper and root build scripts first for better layer caching.
+COPY gradlew gradlew.bat ./
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts gradle.properties ./
+
+# settings.gradle.kts references every module, so all of them must exist in
+# the build context even though :graphite-explore only depends on a subset.
+COPY graphite-core graphite-core
+COPY graphite-cypher graphite-cypher
+COPY graphite-sootup graphite-sootup
+COPY graphite-webgraph graphite-webgraph
+COPY graphite-query graphite-query
+COPY graphite-explore graphite-explore
+
+ARG VERSION=0.0.0-dev
+RUN ./gradlew :graphite-explore:shadowJar --no-daemon -Pversion=${VERSION}
+
+# ---- Runtime stage -------------------------------------------------------
+FROM eclipse-temurin:17-jre-jammy AS runtime
+
+ARG VERSION=0.0.0-dev
+
+LABEL org.opencontainers.image.title="graphite-explore" \
+      org.opencontainers.image.description="Interactive web visualization for Graphite static analysis graphs" \
+      org.opencontainers.image.source="https://github.com/johnsonlee/graphite" \
+      org.opencontainers.image.url="https://github.com/johnsonlee/graphite" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}"
+
+# Run as a non-root user.
+RUN groupadd --system --gid 1000 graphite \
+ && useradd  --system --uid 1000 --gid graphite --home /home/graphite --create-home graphite
+
+WORKDIR /app
+COPY --from=builder /workspace/graphite-explore/build/libs/graphite-explore.jar /app/graphite-explore.jar
+
+USER graphite:graphite
+
+# Override at runtime, e.g. -e JAVA_TOOL_OPTIONS="-Xmx8g"
+ENV JAVA_TOOL_OPTIONS="-Xmx4g"
+
+EXPOSE 8080
+VOLUME ["/data"]
+
+ENTRYPOINT ["java", "-jar", "/app/graphite-explore.jar"]
+# Default to loading the graph from the /data volume. Override by passing
+# different args, e.g. `docker run graphite-explore --help`.
+CMD ["/data"]


### PR DESCRIPTION
Add a multi-stage Dockerfile for graphite-explore so it can be distributed
as an OCI image. The builder stage is pinned to $BUILDPLATFORM so the
gradle shadow jar build runs once natively even when buildx targets
multiple architectures, since the resulting jar is platform independent.

Extend the publish workflow to log into GitHub Container Registry (using
the workflow GITHUB_TOKEN) and Docker Hub (account `johnsonlee`, with the
DOCKERHUB_TOKEN secret), derive semver tags via docker/metadata-action,
and push a multi-arch (linux/amd64, linux/arm64) image to both registries
on every v* tag.
