### PR TITLE
fix: update project names in publish workflow + parallelize jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Sonatype Central
+name: Publish
 
 on:
   push:
@@ -8,23 +8,18 @@ on:
     types: [publish]
 
 jobs:
-  publish:
+  # ---- Maven Central (Sonatype) ----
+  maven:
     permissions:
-      contents: write
-      packages: write
+      contents: read
     runs-on: ubuntu-latest
     if: github.repository_owner == 'johnsonlee'
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup Java
-      uses: actions/setup-java@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
-
     - name: Publish to Sonatype Central
       run: |
         VERSION=${GITHUB_REF/refs\/tags\/v/}
@@ -49,14 +44,25 @@ jobs:
         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         OSSRH_PACKAGE_GROUP: ${{ secrets.OSSRH_PACKAGE_GROUP }}
 
+  # ---- GitHub Release + Homebrew tap ----
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'johnsonlee'
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - name: Build CLI shadow JARs
       run: |
         VERSION=${GITHUB_REF/refs\/tags\/v/}
-        ./gradlew :graphite-query:shadowJar :graphite-explore:shadowJar --no-daemon -Pversion=${VERSION}
+        ./gradlew :query:shadowJar :explore:shadowJar --no-daemon -Pversion=${VERSION}
         mkdir -p release-assets
         cp graphite-query/build/libs/graphite-query.jar release-assets/graphite-query.jar
         cp graphite-explore/build/libs/graphite-explore.jar release-assets/graphite-explore.jar
-
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
@@ -66,58 +72,6 @@ jobs:
         files: release-assets/*.jar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: johnsonlee
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Extract Docker metadata
-      id: docker_meta
-      uses: docker/metadata-action@v5
-      with:
-        images: |
-          ghcr.io/johnsonlee/graphite-explore
-          docker.io/johnsonlee/graphite-explore
-        tags: |
-          type=semver,pattern={{version}},value=${{ github.ref_name }}
-          type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }}
-          type=semver,pattern={{major}},value=${{ github.ref_name }}
-          type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-        labels: |
-          org.opencontainers.image.title=graphite-explore
-          org.opencontainers.image.description=Interactive web visualization for Graphite static analysis graphs
-          org.opencontainers.image.source=https://github.com/johnsonlee/graphite
-          org.opencontainers.image.licenses=Apache-2.0
-
-    - name: Build and push graphite-explore image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: graphite-explore/Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ steps.docker_meta.outputs.tags }}
-        labels: ${{ steps.docker_meta.outputs.labels }}
-        build-args: |
-          VERSION=${{ github.ref_name }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-
     - name: Update Homebrew tap
       env:
         HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -135,7 +89,6 @@ jobs:
         cd tap
         mkdir -p Formula
 
-        # remove legacy file if present
         rm -f Formula/graphite-query.rb
 
         cat > Formula/graphite.rb <<RUBY
@@ -195,3 +148,56 @@ jobs:
           git commit -m "graphite ${VERSION}"
           git push origin main
         fi
+
+  # ---- Docker image ----
+  docker:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'johnsonlee'
+    steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-buildx-action@v3
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: johnsonlee
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Extract Docker metadata
+      id: docker_meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ghcr.io/johnsonlee/graphite-explore
+          docker.io/johnsonlee/graphite-explore
+        tags: |
+          type=semver,pattern={{version}},value=${{ github.ref_name }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }}
+          type=semver,pattern={{major}},value=${{ github.ref_name }}
+          type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+        labels: |
+          org.opencontainers.image.title=graphite-explore
+          org.opencontainers.image.description=Interactive web visualization for Graphite static analysis graphs
+          org.opencontainers.image.source=https://github.com/johnsonlee/graphite
+          org.opencontainers.image.licenses=Apache-2.0
+    - name: Build and push graphite-explore image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: graphite-explore/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        build-args: |
+          VERSION=${{ github.ref_name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
Fixes publish failure: project names changed from `:graphite-query` to `:query` (settings.gradle.kts rename).

Also splits the single publish job into 3 parallel jobs:
- **maven**: Sonatype Central publish
- **release**: GitHub Release + Homebrew tap
- **docker**: Container image build + push

Generated with [Claude Code](https://claude.com/claude-code)