### PR TITLE
chore: suppress SLF4J warnings + clean up dependency syntax

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,9 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
 
     dependencies {
-        "implementation"(kotlin("stdlib"))
-        "testImplementation"(kotlin("test"))
-        "testImplementation"(kotlin("test-junit"))
+        add("implementation", kotlin("stdlib"))
+        add("runtimeOnly", "org.slf4j:slf4j-nop:2.0.13")
+        add("testImplementation", kotlin("test"))
+        add("testImplementation", kotlin("test-junit"))
     }
 }


### PR DESCRIPTION
- Add `slf4j-nop` as runtimeOnly to suppress `SLF4J(W): No SLF4J providers were found`
- Replace string-quoted configuration names with `add()` API

Generated with [Claude Code](https://claude.com/claude-code)