### PR TITLE
revert: remove parallelism from buildForwardData

### DIFF
--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -44,7 +44,7 @@ SootUpAdapter                  GraphStore.save()                 GraphStore.load
   → DefaultGraph                 1. String collection              1. BVGraph.load       ┐
                                  2. Metadata + StringTable         2. StringTable.load    ├ parallel
                                  3. Forward adjacency + labels     3. Labels + comparisons┘
-                                    (parallel, ForkJoinPool)       4. Build backward from forward
+                                                                   4. Build backward from forward
                                  4. BVGraph.store                  5. Read nodes + metadata
                                  5. Labels + comparisons write
                                  6. Nodedata + nodeindex write
@@ -59,7 +59,7 @@ graph TD
     B --> B1[Collect maxNodeId + nodeCount]
     B --> B2[Collect unique strings]
     B1 & B2 --> C[2. Collect metadata + build StringTable]
-    C --> D["3. Build forward adjacency + labels (parallel)"]
+    C --> D["3. Build forward adjacency + labels"]
     D --> D1["Pass 1: Count outdegree per node"]
     D --> D2["Pass 2: Fill sorted targets + encode labels"]
     D2 --> E["4. BVGraph.store(forward)"]
@@ -122,7 +122,7 @@ Every optimization must satisfy both simultaneously — trading one for the othe
 | [#55](https://github.com/johnsonlee/graphite/pull/55) | Flat single-file format | no change | — | :x: closed |
 | [#56](https://github.com/johnsonlee/graphite/pull/56) | Inline nodeindex | **16s (-81%)** | **real 8m31s (-47%)** | :white_check_mark: |
 | [#61](https://github.com/johnsonlee/graphite/pull/61) | Merge passes (4→2) | **9s (-44%)** | — | :white_check_mark: |
-| [#62](https://github.com/johnsonlee/graphite/pull/62) | Parallelize step 3 | **3.8s (-59%)** | _pending_ | :white_check_mark: |
+| [#62](https://github.com/johnsonlee/graphite/pull/62) | Parallelize step 3 | **3.8s (-59%)** | real unchanged, sys +35% | :x: reverted |
 
 Production total includes build (SootUpAdapter → DefaultGraph) which is 76% of wall time.
 
@@ -154,7 +154,7 @@ Fix (PR #61): merge into single `buildForwardData` with 2 passes.
 | PR #56 | 15,132 ms |
 | PR #61 | **9,090 ms (-40%)** |
 
-**PR #61 → #62: sequential → parallel**
+**PR #61 → #62: sequential → parallel (reverted)**
 
 Each node in step 3 is independent — `outgoing()` is read-only, array writes are non-overlapping. Only shared state is `comparisonMap` (switched to `ConcurrentHashMap`).
 
@@ -167,7 +167,7 @@ Fix (PR #62): `ForkJoinPool` parallelism for both passes.
 | 4 | 4,927 | -47% |
 | 8 | 3,794 | -59% |
 
-Default: `min(availableProcessors, 4)`. Diminishing returns beyond 4 — serial portions (BVGraph.store + nodedata write ~2s) cap parallel speedup.
+Synthetic results looked promising, but production measurement (rc8, 4.1M nodes) showed real time unchanged and sys time +35% from ForkJoinPool thread management overhead. Reverted to sequential 2-pass structure from PR #61.
 
 ### Rejected Approaches
 
@@ -178,8 +178,9 @@ Default: `min(availableProcessors, 4)`. Diminishing returns beyond 4 — serial 
 | Lazy SortedAdjacency | :x: OOM @4g | Delays but doesn't reduce allocation |
 | MmapGraph + disk adjacency | :x: 100s @6g | 10M random seeks for deserialization |
 | BVGraph thread tuning (1-4) | :x: < 1% change | Algorithm-bound (serial dependency) |
+| ForkJoinPool parallelism for step 3 ([#62](https://github.com/johnsonlee/graphite/pull/62)) | :x: real unchanged, sys +35% | Production: ForkJoinPool overhead outweighed parallel gains; synthetic benchmarks overstated benefit |
 
-### Production Phase Breakdown (PR #56 + #61, 4.1M nodes)
+### Production Phase Breakdown (rc8, PR #56 + #61, 4.1M nodes)
 
 | Step | Phase | Time | % |
 |------|-------|------|---|
@@ -204,4 +205,4 @@ Synthetic benchmarks (IntConstant) understate steps 1/2/6 because production use
 
 ### Key Lesson
 
-Adding precomputed caches to reduce time tends to increase memory — violating the constraint. The path that works: **eliminate redundant work** (fewer passes, no re-scans, parallelism). Both metrics improve simultaneously.
+Adding precomputed caches to reduce time tends to increase memory — violating the constraint. The path that works: **eliminate redundant work** (fewer passes, no re-scans). Both metrics improve simultaneously. Parallelism that shows gains in synthetic benchmarks can regress in production due to thread management overhead.

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
@@ -45,42 +45,20 @@ class JavaProjectLoader(
     )
 
     override fun load(path: Path): Graph {
-        val threadMx = java.lang.management.ManagementFactory.getThreadMXBean()
-        val buildWall = System.nanoTime()
-        val buildCpu = threadMx.currentThreadCpuTime
-
-        fun phase(name: String, wallStart: Long, cpuStart: Long) {
-            val wall = (System.nanoTime() - wallStart) / 1_000_000
-            val cpu = (threadMx.currentThreadCpuTime - cpuStart) / 1_000_000
-            System.err.println("[build] $name: ${wall}ms wall, ${cpu}ms cpu")
-        }
-
-        var t0 = System.nanoTime()
-        var c0 = threadMx.currentThreadCpuTime
         val inputLocations = createInputLocations(path)
         val view = JavaView(inputLocations)
-        phase("1. JavaView creation", t0, c0)
 
         // Load generic signatures from bytecode
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
         val signatureReader = BytecodeSignatureReader()
         loadSignatures(path, signatureReader)
-        phase("2. Signature loading", t0, c0)
 
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
         val resourceAccessor = ArchiveResourceAccessor.create(path)
         val adapter = SootUpAdapter(
             view, config, signatureReader,
             resourceAccessor = resourceAccessor,
             graphBuilder = graphBuilderFactory()
         )
-        val graph = adapter.buildGraph()
-        phase("3. Graph construction", t0, c0)
-        phase("Total", buildWall, buildCpu)
-
-        return graph
+        return adapter.buildGraph()
     }
 
     /**

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/GraphBuildPersistBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/GraphBuildPersistBenchmark.kt
@@ -9,7 +9,7 @@ import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
 // ============================================================================
-//  Save parallelism sweep at 10M scale, 4GB heap
+//  Save + load benchmark at 10M scale, 4GB heap
 //  Run with: ./gradlew :webgraph:jmh -Pjmh.filter='GraphBuildPersist'
 // ============================================================================
 
@@ -23,9 +23,6 @@ open class GraphBuildPersistBenchmark {
 
     @Param("10000000")
     var nodeCount: Int = 0
-
-    @Param("1", "2", "4", "8")
-    var parallelism: Int = 0
 
     private lateinit var graph: Graph
     private lateinit var savedDir: Path
@@ -57,14 +54,14 @@ open class GraphBuildPersistBenchmark {
         graph = builder.build()
 
         savedDir = Files.createTempDirectory("graphite-bench")
-        GraphStore.save(graph, savedDir, compressionThreads = 2, parallelism = 1)
+        GraphStore.save(graph, savedDir)
     }
 
     @Benchmark
     fun save() {
         val dir = Files.createTempDirectory("graphite-bench-save")
         try {
-            GraphStore.save(graph, dir, compressionThreads = 2, parallelism = parallelism)
+            GraphStore.save(graph, dir)
         } finally {
             dir.toFile().deleteRecursively()
         }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -62,10 +62,6 @@ private const val LABELS_FILE = "graph.labels"
     private const val METADATA_FILE = "graph.metadata"
 
     /**
-     * Get a [Future]'s result, unwrapping [ExecutionException] so that the
-     * original exception propagates with its real type.
-     */
-    /**
      * Save a graph to disk in WebGraph + native LAW format.
      *
      * Uses a streaming [ImmutableGraph] wrapper over the source [Graph] to avoid
@@ -74,22 +70,10 @@ private const val LABELS_FILE = "graph.labels"
      * For large graphs (millions of nodes) this eliminates the OOM caused by
      * duplicating the entire adjacency list in memory.
      */
-    fun save(graph: Graph, dir: Path, compressionThreads: Int = 2, parallelism: Int = Runtime.getRuntime().availableProcessors().coerceAtMost(4)) {
+    fun save(graph: Graph, dir: Path, compressionThreads: Int = 2) {
         Files.createDirectories(dir)
-        val threadMx = java.lang.management.ManagementFactory.getThreadMXBean()
-        val saveWall = System.nanoTime()
-        val saveCpu = threadMx.currentThreadCpuTime
-
-        fun phase(name: String, wallStart: Long, cpuStart: Long, detail: String = "") {
-            val wall = (System.nanoTime() - wallStart) / 1_000_000
-            val cpu = (threadMx.currentThreadCpuTime - cpuStart) / 1_000_000
-            val suffix = if (detail.isNotEmpty()) " ($detail)" else ""
-            System.err.println("[save] $name: ${wall}ms wall, ${cpu}ms cpu$suffix")
-        }
 
         // 1. Stream nodes: find maxNodeId, count nodes, collect strings
-        var t0 = System.nanoTime()
-        var c0 = threadMx.currentThreadCpuTime
         var maxNodeId = 0
         var nodeCount = 0
         val allStrings = mutableSetOf<String>()
@@ -98,28 +82,19 @@ private const val LABELS_FILE = "graph.labels"
             nodeCount++
             collectSingleNodeStrings(node, allStrings)
         }
-        phase("1. String collection", t0, c0, "$nodeCount nodes, ${allStrings.size} strings")
 
         // 2. Collect metadata
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
         val metadata = collectMetadata(graph)
         NodeSerializer.collectMetadataStrings(metadata, allStrings)
         val stringTable = StringTable.build(allStrings, dir)
         allStrings.clear()
-        phase("2. Metadata + StringTable", t0, c0)
 
-        // 3. Build forward adjacency + labels + comparisons (parallel)
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
+        // 3. Build forward adjacency + labels + comparisons
         val numNodes = maxNodeId + 1
         val comparisonMap = mutableMapOf<Long, BranchComparison>()
-        val (forwardAdj, labelArray) = buildForwardData(graph, numNodes, comparisonMap, parallelism)
-        phase("3. Forward adjacency + labels", t0, c0, "$numNodes nodes, ${labelArray.size} edges, $parallelism threads")
+        val (forwardAdj, labelArray) = buildForwardData(graph, numNodes, comparisonMap)
 
         // 4. Store BVGraph (forward only)
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
         val forwardGraph = PrecomputedImmutableGraph(forwardAdj)
         BVGraph.store(
             forwardGraph, dir.resolve(FORWARD_GRAPH).toString(),
@@ -127,20 +102,14 @@ private const val LABELS_FILE = "graph.labels"
             BVGraph.DEFAULT_MIN_INTERVAL_LENGTH, BVGraph.DEFAULT_ZETA_K,
             0, compressionThreads
         )
-        phase("4. BVGraph.store", t0, c0)
 
         // 5. Store labels + comparisons
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
         BinIO.storeBytes(labelArray, dir.resolve(LABELS_FILE).toString())
         DataOutputStream(BufferedOutputStream(dir.resolve(COMPARISONS_FILE).toFile().outputStream())).use { dos ->
             NodeSerializer.writeComparisons(dos, comparisonMap)
         }
-        phase("5. Labels + comparisons", t0, c0)
 
         // 6. Write nodedata + nodeindex simultaneously
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
         CountingOutputStream(BufferedOutputStream(dir.resolve(NODE_DATA_FILE).toFile().outputStream())).use { cos ->
             val dataDos = DataOutputStream(cos)
             DataOutputStream(BufferedOutputStream(dir.resolve(NODE_INDEX_FILE).toFile().outputStream())).use { idxDos ->
@@ -157,16 +126,11 @@ private const val LABELS_FILE = "graph.labels"
                 }
             }
         }
-        phase("6. Nodedata + nodeindex", t0, c0)
 
         // 7. Save metadata
-        t0 = System.nanoTime()
-        c0 = threadMx.currentThreadCpuTime
         DataOutputStream(BufferedOutputStream(dir.resolve(METADATA_FILE).toFile().outputStream())).use { dos ->
             NodeSerializer.saveMetadata(metadata, dos, stringTable)
         }
-        phase("7. Metadata write", t0, c0)
-        phase("Total", saveWall, saveCpu)
     }
 
     /**
@@ -177,31 +141,21 @@ private const val LABELS_FILE = "graph.labels"
      */
     fun load(dir: Path, mode: LoadMode = LoadMode.AUTO): Graph {
         require(Files.isDirectory(dir)) { "Not a directory: $dir" }
-        val threadMx = java.lang.management.ManagementFactory.getThreadMXBean()
-        val t0 = System.nanoTime()
-        val c0 = threadMx.currentThreadCpuTime
-
-        val resolvedMode: LoadMode
-        val graph = when (mode) {
-            LoadMode.EAGER -> { resolvedMode = LoadMode.EAGER; loadEager(dir) }
-            LoadMode.MAPPED -> { resolvedMode = LoadMode.MAPPED; ensureNodeIndex(dir); loadMapped(dir) }
+        return when (mode) {
+            LoadMode.EAGER -> loadEager(dir)
+            LoadMode.MAPPED -> { ensureNodeIndex(dir); loadMapped(dir) }
             LoadMode.AUTO -> {
                 val nodeCount = DataInputStream(BufferedInputStream(dir.resolve(NODE_DATA_FILE).toFile().inputStream())).use { dis ->
                     NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA)
                     dis.readInt()
                 }
                 if (nodeCount < MAPPED_THRESHOLD) {
-                    resolvedMode = LoadMode.EAGER; loadEager(dir)
+                    loadEager(dir)
                 } else {
-                    resolvedMode = LoadMode.MAPPED; ensureNodeIndex(dir); loadMapped(dir)
+                    ensureNodeIndex(dir); loadMapped(dir)
                 }
             }
         }
-
-        val wall = (System.nanoTime() - t0) / 1_000_000
-        val cpu = (threadMx.currentThreadCpuTime - c0) / 1_000_000
-        System.err.println("[load] ${wall}ms wall, ${cpu}ms cpu (mode=$resolvedMode)")
-        return graph
     }
 
     /**
@@ -350,50 +304,27 @@ private const val LABELS_FILE = "graph.labels"
     }
 
     /**
-     * Build label byte array directly in BVGraph successor order without
-     * an intermediate HashMap. For each node, collects outgoing edges,
-     * groups by target (dedup), sorts by target, and writes labels.
-     */
-    /**
-     * Build forward adjacency, labels, and comparisons in 2 parallel passes.
+     * Build forward adjacency, labels, and comparisons in 2 sequential passes.
      *
-     * Pass 1 (parallel): count unique outdegree per node.
-     * Pass 2 (parallel): fill sorted targets + encode labels + extract comparisons.
-     *
-     * Each node's work is independent: outgoing() is read-only, array writes
-     * are to non-overlapping ranges, comparisons go to ConcurrentHashMap.
-     *
-     * @param parallelism number of threads (1 = sequential, default = available processors)
+     * Pass 1: count unique outdegree per node.
+     * Pass 2: fill sorted targets + encode labels + extract comparisons.
      */
     private fun buildForwardData(
         graph: Graph,
         numNodes: Int,
-        comparisonMap: MutableMap<Long, BranchComparison>,
-        parallelism: Int = Runtime.getRuntime().availableProcessors()
+        comparisonMap: MutableMap<Long, BranchComparison>
     ): Pair<PrecomputedAdjacency, ByteArray> {
-        val pool = if (parallelism > 1) {
-            java.util.concurrent.ForkJoinPool(parallelism)
-        } else null
-
-        fun <T> runParallel(task: () -> T): T {
-            return if (pool != null) pool.submit(java.util.concurrent.Callable { task() }).get() else task()
-        }
-
-        // Pass 1: count outdegree (parallel)
+        // Pass 1: count outdegree
         val outdeg = IntArray(numNodes)
-        runParallel {
-            java.util.stream.IntStream.range(0, numNodes).let {
-                if (pool != null) it.parallel() else it
-            }.forEach { node ->
-                val targets = mutableSetOf<Int>()
-                for (edge in graph.outgoing(NodeId(node))) {
-                    targets.add(edge.to.value)
-                }
-                outdeg[node] = targets.size
+        for (node in 0 until numNodes) {
+            val targets = mutableSetOf<Int>()
+            for (edge in graph.outgoing(NodeId(node))) {
+                targets.add(edge.to.value)
             }
+            outdeg[node] = targets.size
         }
 
-        // Build offsets (sequential — O(N) prefix sum)
+        // Build offsets (prefix sum)
         val offsets = LongArray(numNodes + 1)
         for (i in 0 until numNodes) {
             offsets[i + 1] = offsets[i] + outdeg[i]
@@ -401,33 +332,26 @@ private const val LABELS_FILE = "graph.labels"
         val totalArcs = offsets[numNodes].toInt()
         val targets = IntArray(totalArcs)
         val labels = ByteArray(totalArcs)
-        val concurrentComparisons = java.util.concurrent.ConcurrentHashMap<Long, BranchComparison>()
 
-        // Pass 2: fill targets + labels + comparisons (parallel)
-        runParallel {
-            java.util.stream.IntStream.range(0, numNodes).let {
-                if (pool != null) it.parallel() else it
-            }.forEach { node ->
-                val edgesByTarget = mutableMapOf<Int, Edge>()
-                for (edge in graph.outgoing(NodeId(node))) {
-                    edgesByTarget[edge.to.value] = edge
-                }
-                val sorted = edgesByTarget.keys.sorted()
-                val start = offsets[node].toInt()
-                for ((i, to) in sorted.withIndex()) {
-                    targets[start + i] = to
-                    val edge = edgesByTarget[to]!!
-                    labels[start + i] = NodeSerializer.encodeEdge(edge).toByte()
-                    if (edge is ControlFlowEdge && edge.comparison != null) {
-                        val key = node.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
-                        concurrentComparisons[key] = edge.comparison!!
-                    }
+        // Pass 2: fill targets + labels + comparisons
+        for (node in 0 until numNodes) {
+            val edgesByTarget = mutableMapOf<Int, Edge>()
+            for (edge in graph.outgoing(NodeId(node))) {
+                edgesByTarget[edge.to.value] = edge
+            }
+            val sorted = edgesByTarget.keys.sorted()
+            val start = offsets[node].toInt()
+            for ((i, to) in sorted.withIndex()) {
+                targets[start + i] = to
+                val edge = edgesByTarget[to]!!
+                labels[start + i] = NodeSerializer.encodeEdge(edge).toByte()
+                if (edge is ControlFlowEdge && edge.comparison != null) {
+                    val key = node.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
+                    comparisonMap[key] = edge.comparison!!
                 }
             }
         }
 
-        pool?.shutdown()
-        comparisonMap.putAll(concurrentComparisons)
         return PrecomputedAdjacency(numNodes, targets, offsets) to labels
     }
 
@@ -483,17 +407,6 @@ private const val LABELS_FILE = "graph.labels"
         override fun successors(x: Int): LazyIntIterator = LazyIntIterators.wrap(successorArray(x))
         override fun copy(): ImmutableGraph = this
     }
-
-    /**
-     * Build forward sorted adjacency in two passes over the graph.
-     *
-     * Pass 1: count outdegree per node.
-     * Pass 2: fill target array and sort each node's successors.
-     *
-     * Backward adjacency is no longer precomputed at save time; it is
-     * rebuilt from the compressed forward BVGraph at load time via
-     * [buildBackwardFromForward].
-     */
 
     /** Build backward adjacency from forward BVGraph. */
     private fun loadBackward(forward: ImmutableGraph): ImmutableGraph =
@@ -618,10 +531,6 @@ private const val LABELS_FILE = "graph.labels"
         return NodeIndexData(nodeOffsets, nodeTypeIndex)
     }
 
-    /**
-     * Build `graph.nodeindex` by scanning `graph.nodedata` sequentially.
-     * Each entry: nodeId (4 bytes) + tag (1 byte) + offset in nodedata (8 bytes).
-     */
     /**
      * Ensure the `graph.nodeindex` file exists for the given graph directory.
      * If it doesn't exist, scans `graph.nodedata` to build it.


### PR DESCRIPTION
Production data showed parallelization was net negative (real unchanged, sys +35%). stderr timing replaced by async-profiler for flame graph profiling.

Also updates docs with production data and moves PR #62 to rejected approaches.

Generated with [Claude Code](https://claude.com/claude-code)