### PR TITLE
chore: standard JVM env vars + --profile + mmap graph reads + suppress SLF4J

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,31 @@ jobs:
             libexec.install "graphite-query.jar"
             (bin/"graphite").write <<~EOS
               #!/bin/bash
-              exec "#{Formula["openjdk@17"].opt_bin}/java" \${GRAPHITE_OPTS:--Xmx8g} -jar "#{libexec}/graphite-query.jar" "\$@"
+              export JAVA_TOOL_OPTIONS="\${JAVA_TOOL_OPTIONS:-\${JAVA_OPTS:--Xmx8g}}"
+              AGENT_ARGS=""
+              PASSTHROUGH_ARGS=()
+              for arg in "\$@"; do
+                if [ "\$arg" = "--profile" ]; then
+                  PROFILE_OUT="\${GRAPHITE_PROFILE:-profile.html}"
+                  AP_LIB=""
+                  ASPROF="\$(which asprof 2>/dev/null)"
+                  if [ -n "\$ASPROF" ]; then
+                    AP_DIR="\$(dirname "\$ASPROF")/../lib"
+                    for ext in dylib so; do
+                      [ -f "\$AP_DIR/libasyncProfiler.\$ext" ] && AP_LIB="\$AP_DIR/libasyncProfiler.\$ext" && break
+                    done
+                  fi
+                  if [ -n "\$AP_LIB" ]; then
+                    AGENT_ARGS="-agentpath:\$AP_LIB=start,event=cpu,file=\$PROFILE_OUT"
+                  else
+                    echo "async-profiler not found. Install: brew install async-profiler" >&2
+                    exit 1
+                  fi
+                else
+                  PASSTHROUGH_ARGS+=("\$arg")
+                fi
+              done
+              exec "#{Formula["openjdk@17"].opt_bin}/java" \$AGENT_ARGS -jar "#{libexec}/graphite-query.jar" "\${PASSTHROUGH_ARGS[@]}"
             EOS
           end
 
@@ -131,7 +155,31 @@ jobs:
             libexec.install "graphite-explore.jar"
             (bin/"graphite-explore").write <<~EOS
               #!/bin/bash
-              exec "#{Formula["openjdk@17"].opt_bin}/java" \${GRAPHITE_OPTS:--Xmx8g} -jar "#{libexec}/graphite-explore.jar" "\$@"
+              export JAVA_TOOL_OPTIONS="\${JAVA_TOOL_OPTIONS:-\${JAVA_OPTS:--Xmx8g}}"
+              AGENT_ARGS=""
+              PASSTHROUGH_ARGS=()
+              for arg in "\$@"; do
+                if [ "\$arg" = "--profile" ]; then
+                  PROFILE_OUT="\${GRAPHITE_PROFILE:-profile.html}"
+                  AP_LIB=""
+                  ASPROF="\$(which asprof 2>/dev/null)"
+                  if [ -n "\$ASPROF" ]; then
+                    AP_DIR="\$(dirname "\$ASPROF")/../lib"
+                    for ext in dylib so; do
+                      [ -f "\$AP_DIR/libasyncProfiler.\$ext" ] && AP_LIB="\$AP_DIR/libasyncProfiler.\$ext" && break
+                    done
+                  fi
+                  if [ -n "\$AP_LIB" ]; then
+                    AGENT_ARGS="-agentpath:\$AP_LIB=start,event=cpu,file=\$PROFILE_OUT"
+                  else
+                    echo "async-profiler not found. Install: brew install async-profiler" >&2
+                    exit 1
+                  fi
+                else
+                  PASSTHROUGH_ARGS+=("\$arg")
+                fi
+              done
+              exec "#{Formula["openjdk@17"].opt_bin}/java" \$AGENT_ARGS -jar "#{libexec}/graphite-explore.jar" "\${PASSTHROUGH_ARGS[@]}"
             EOS
           end
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+.claude
 .gradle
 .idea
 build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,10 @@ allprojects {
 subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
 
+    configurations.all {
+        exclude(group = "ch.qos.logback")
+    }
+
     dependencies {
         add("implementation", kotlin("stdlib"))
         add("runtimeOnly", "org.slf4j:slf4j-nop:2.0.13")

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -122,9 +122,8 @@ Every optimization must satisfy both simultaneously — trading one for the othe
 | [#55](https://github.com/johnsonlee/graphite/pull/55) | Flat single-file format | no change | — | :x: closed |
 | [#56](https://github.com/johnsonlee/graphite/pull/56) | Inline nodeindex | **16s (-81%)** | **real 8m31s (-47%)** | :white_check_mark: |
 | [#61](https://github.com/johnsonlee/graphite/pull/61) | Merge passes (4→2) | **9s (-44%)** | — | :white_check_mark: |
-| [#62](https://github.com/johnsonlee/graphite/pull/62) | Parallelize step 3 | **3.8s (-59%)** | real unchanged, sys +35% | :x: reverted |
-
-Production total includes build (SootUpAdapter → DefaultGraph) which is 76% of wall time.
+| [#62](https://github.com/johnsonlee/graphite/pull/62) | Parallelize step 3 | 3.8s (-59% synthetic) | real unchanged, sys +35% | :x: reverted |
+| [#65](https://github.com/johnsonlee/graphite/pull/65) | Buffer MmapGraphBuilder I/O | — | **real 5m43s (-33%), sys -44%** | :white_check_mark: |
 
 ### How Each Bottleneck Was Found and Fixed
 
@@ -168,6 +167,20 @@ Fix (PR #62): `ForkJoinPool` parallelism for both passes.
 | 8 | 3,794 | -59% |
 
 Synthetic results looked promising, but production measurement (rc8, 4.1M nodes) showed real time unchanged and sys time +35% from ForkJoinPool thread management overhead. Reverted to sequential 2-pass structure from PR #61.
+
+**PR #62 → #65: unbuffered RAF → buffered streams**
+
+async-profiler flame graph on production showed `MmapGraphBuilder.addEdge → RandomAccessFile.write` as a major hotspot. Default `MmapGraphBuilder` wrote every node and edge directly to `RandomAccessFile` — millions of syscalls.
+
+Fix (PR #65): wrap with `.buffered()`. Two lines changed.
+
+| Metric | PR #56+#61 | PR #65 | Change |
+|--------|-----------|--------|--------|
+| real | 8m31s | **5m43s** | **-33%** |
+| user | 8m32s | 8m | -6% |
+| sys | 4m56s | **2m46s** | **-44%** |
+
+user unchanged (same CPU work), sys halved (buffered writes consolidated millions of syscalls), real dropped because main thread no longer blocked on I/O.
 
 ### Rejected Approaches
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraph.kt
@@ -4,8 +4,12 @@ import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import java.io.Closeable
-import java.io.RandomAccessFile
+import java.io.DataInputStream
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 
 /**
  * A [Graph] implementation backed by disk files.
@@ -36,16 +40,11 @@ class MmapGraph internal constructor(
     override val resources: ResourceAccessor
 ) : Graph, Closeable {
 
-    // Track all opened RAF handles for close()
-    private val openNodeRafs = java.util.Collections.synchronizedList(mutableListOf<RandomAccessFile>())
-    private val openEdgeRafs = java.util.Collections.synchronizedList(mutableListOf<RandomAccessFile>())
-
-    private val nodeRafLocal = ThreadLocal.withInitial {
-        RandomAccessFile(dataDir.resolve("nodes.dat").toFile(), "r").also { openNodeRafs.add(it) }
+    private val nodeMmap: ByteBuffer = FileChannel.open(dataDir.resolve("nodes.dat"), StandardOpenOption.READ).use {
+        it.map(FileChannel.MapMode.READ_ONLY, 0, it.size())
     }
-
-    private val edgeRafLocal = ThreadLocal.withInitial {
-        RandomAccessFile(dataDir.resolve("edges.dat").toFile(), "r").also { openEdgeRafs.add(it) }
+    private val edgeMmap: ByteBuffer = FileChannel.open(dataDir.resolve("edges.dat"), StandardOpenOption.READ).use {
+        it.map(FileChannel.MapMode.READ_ONLY, 0, it.size())
     }
 
     private val branchScopeIndex: Map<Int, List<BranchScope>> by lazy {
@@ -123,28 +122,32 @@ class MmapGraph internal constructor(
     override fun typeHierarchyTypes(): Set<String> = typeHierarchy.allKeys()
 
     override fun close() {
-        openNodeRafs.forEach { runCatching { it.close() } }
-        openEdgeRafs.forEach { runCatching { it.close() } }
-        openNodeRafs.clear()
-        openEdgeRafs.clear()
+        // MappedByteBuffer is unmapped by GC; no explicit unmap in standard API
     }
 
     private fun readNodeAt(offset: Long): Node {
-        val raf = nodeRafLocal.get()
-        synchronized(raf) {
-            raf.seek(offset)
-            val len = raf.readInt()
-            val bytes = ByteArray(len)
-            raf.readFully(bytes)
-            return MmapGraphBuilder.deserializeNode(bytes)
-        }
+        val buf = nodeMmap.duplicate()
+        buf.position(offset.toInt())
+        val len = buf.getInt()
+        val bytes = ByteArray(len)
+        buf.get(bytes)
+        return MmapGraphBuilder.deserializeNode(bytes)
     }
 
     private fun readEdgeAt(offset: Long): Edge {
-        val raf = edgeRafLocal.get()
-        synchronized(raf) {
-            raf.seek(offset)
-            return MmapGraphBuilder.deserializeEdge(raf)
+        val buf = edgeMmap.duplicate()
+        buf.position(offset.toInt())
+        val dis = DataInputStream(ByteBufferInputStream(buf))
+        return MmapGraphBuilder.deserializeEdge(dis)
+    }
+
+    internal class ByteBufferInputStream(private val buf: ByteBuffer) : InputStream() {
+        override fun read(): Int = if (buf.hasRemaining()) buf.get().toInt() and 0xFF else -1
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (!buf.hasRemaining()) return -1
+            val n = minOf(len, buf.remaining())
+            buf.get(b, off, n)
+            return n
         }
     }
 }

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
@@ -260,21 +260,21 @@ class MmapGraphBuilder(
          * Deserialize an edge from a [RandomAccessFile] at its current position.
          * The file pointer is advanced past the entire edge record.
          */
-        internal fun deserializeEdge(raf: RandomAccessFile): Edge {
-            val from = NodeId(raf.readInt())
-            val to = NodeId(raf.readInt())
-            return when (val tag = raf.readByte().toInt()) {
-                TAG_EDGE_DATAFLOW -> DataFlowEdge(from, to, DataFlowKind.entries[raf.readByte().toInt()])
+        internal fun deserializeEdge(input: java.io.DataInput): Edge {
+            val from = NodeId(input.readInt())
+            val to = NodeId(input.readInt())
+            return when (val tag = input.readByte().toInt()) {
+                TAG_EDGE_DATAFLOW -> DataFlowEdge(from, to, DataFlowKind.entries[input.readByte().toInt()])
                 TAG_EDGE_CALL -> {
-                    val flags = raf.readByte().toInt()
+                    val flags = input.readByte().toInt()
                     CallEdge(from, to, isVirtual = (flags and 1) != 0, isDynamic = (flags and 2) != 0)
                 }
-                TAG_EDGE_TYPE -> TypeEdge(from, to, TypeRelation.entries[raf.readByte().toInt()])
+                TAG_EDGE_TYPE -> TypeEdge(from, to, TypeRelation.entries[input.readByte().toInt()])
                 TAG_EDGE_CONTROL_FLOW -> {
-                    val kind = ControlFlowKind.entries[raf.readByte().toInt()]
-                    val hasComparison = raf.readByte().toInt() == 1
+                    val kind = ControlFlowKind.entries[input.readByte().toInt()]
+                    val hasComparison = input.readByte().toInt() == 1
                     val comparison = if (hasComparison) {
-                        BranchComparison(ComparisonOp.entries[raf.readByte().toInt()], NodeId(raf.readInt()))
+                        BranchComparison(ComparisonOp.entries[input.readByte().toInt()], NodeId(input.readInt()))
                     } else {
                         null
                     }

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphTest.kt
@@ -1,6 +1,7 @@
 package io.johnsonlee.graphite.graph
 
 import io.johnsonlee.graphite.core.*
+import java.nio.ByteBuffer
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -462,5 +463,100 @@ class MmapGraphTest {
         val callEdges = graph.incoming(n2, CallEdge::class.java).toList()
         assertEquals(1, callEdges.size)
         assertIs<CallEdge>(callEdges[0])
+    }
+
+    // ========================================================================
+    // ByteBufferInputStream tests
+    // ========================================================================
+
+    @Test
+    fun `ByteBufferInputStream read returns bytes as unsigned int`() {
+        val data = byteArrayOf(0x00, 0x7F, 0xFF.toByte(), 0x80.toByte())
+        val buf = ByteBuffer.wrap(data)
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        assertEquals(0x00, stream.read())
+        assertEquals(0x7F, stream.read())
+        assertEquals(0xFF, stream.read())
+        assertEquals(0x80, stream.read())
+    }
+
+    @Test
+    fun `ByteBufferInputStream read returns -1 when buffer is exhausted`() {
+        val buf = ByteBuffer.wrap(byteArrayOf(42))
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        assertEquals(42, stream.read())
+        assertEquals(-1, stream.read())
+        assertEquals(-1, stream.read())  // repeated calls still return -1
+    }
+
+    @Test
+    fun `ByteBufferInputStream read returns -1 for empty buffer`() {
+        val buf = ByteBuffer.wrap(byteArrayOf())
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        assertEquals(-1, stream.read())
+    }
+
+    @Test
+    fun `ByteBufferInputStream bulk read fills array`() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val buf = ByteBuffer.wrap(data)
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        val out = ByteArray(5)
+        val n = stream.read(out, 0, 5)
+        assertEquals(5, n)
+        assertTrue(data.contentEquals(out))
+    }
+
+    @Test
+    fun `ByteBufferInputStream bulk read with offset`() {
+        val data = byteArrayOf(10, 20, 30)
+        val buf = ByteBuffer.wrap(data)
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        val out = ByteArray(5)
+        val n = stream.read(out, 1, 3)
+        assertEquals(3, n)
+        assertEquals(0, out[0])
+        assertEquals(10, out[1])
+        assertEquals(20, out[2])
+        assertEquals(30, out[3])
+        assertEquals(0, out[4])
+    }
+
+    @Test
+    fun `ByteBufferInputStream bulk read returns fewer bytes when buffer has less than requested`() {
+        val data = byteArrayOf(1, 2, 3)
+        val buf = ByteBuffer.wrap(data)
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        val out = ByteArray(10)
+        val n = stream.read(out, 0, 10)
+        assertEquals(3, n)
+        assertEquals(1, out[0])
+        assertEquals(2, out[1])
+        assertEquals(3, out[2])
+    }
+
+    @Test
+    fun `ByteBufferInputStream bulk read returns -1 when buffer is exhausted`() {
+        val buf = ByteBuffer.wrap(byteArrayOf(1))
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        val out = ByteArray(5)
+        assertEquals(1, stream.read(out, 0, 5))  // reads the 1 byte
+        assertEquals(-1, stream.read(out, 0, 5))  // buffer exhausted
+    }
+
+    @Test
+    fun `ByteBufferInputStream bulk read returns -1 for empty buffer`() {
+        val buf = ByteBuffer.wrap(byteArrayOf())
+        val stream = MmapGraph.ByteBufferInputStream(buf)
+
+        val out = ByteArray(5)
+        assertEquals(-1, stream.read(out, 0, 5))
     }
 }


### PR DESCRIPTION
- Replace GRAPHITE_OPTS with standard JAVA_TOOL_OPTIONS / JAVA_OPTS
- Add `--profile` flag for async-profiler flame graph (auto-detect via `which asprof`)
- MmapGraph reads via mmap (MappedByteBuffer) instead of RandomAccessFile — zero syscall per read
- Exclude logback, keep slf4j-nop only
- deserializeEdge accepts DataInput interface (supports both RAF and DataInputStream)

Generated with [Claude Code](https://claude.com/claude-code)