### PR TITLE
perf: FastArchiveAnalysisInputLocation + fix slf4j-nop in shadow JARs

### DIFF
--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -124,6 +124,7 @@ Every optimization must satisfy both simultaneously — trading one for the othe
 | [#61](https://github.com/johnsonlee/graphite/pull/61) | Merge passes (4→2) | **9s (-44%)** | — | :white_check_mark: |
 | [#62](https://github.com/johnsonlee/graphite/pull/62) | Parallelize step 3 | 3.8s (-59% synthetic) | real unchanged, sys +35% | :x: reverted |
 | [#65](https://github.com/johnsonlee/graphite/pull/65) | Buffer MmapGraphBuilder I/O | — | **real 5m43s (-33%), sys -44%** | :white_check_mark: |
+| [#66](https://github.com/johnsonlee/graphite/pull/66) | MmapGraph reads via mmap | — | **real 4m04s (-29%), sys -43%** | :white_check_mark: |
 
 ### How Each Bottleneck Was Found and Fixed
 
@@ -181,6 +182,18 @@ Fix (PR #65): wrap with `.buffered()`. Two lines changed.
 | sys | 4m56s | **2m46s** | **-44%** |
 
 user unchanged (same CPU work), sys halved (buffered writes consolidated millions of syscalls), real dropped because main thread no longer blocked on I/O.
+
+**PR #65 → #66: RAF reads → mmap reads**
+
+Save calls `graph.outgoing()` which on MmapGraph does per-edge `RandomAccessFile.seek()` + `read()`. Replaced with `MappedByteBuffer` — zero syscall per read.
+
+| Metric | PR #65 | PR #66 | Change |
+|--------|--------|--------|--------|
+| real | 5m43s | **4m04s** | **-29%** |
+| user | 8m | 7m47s | -3% |
+| sys | 2m46s | **1m34s** | **-43%** |
+
+Cumulative from baseline: real **15m57s → 4m04s (-74%)**, sys **24m11s → 1m34s (-94%)**.
 
 ### Rejected Approaches
 

--- a/graphite-explore/build.gradle.kts
+++ b/graphite-explore/build.gradle.kts
@@ -33,6 +33,7 @@ tasks.shadowJar {
         exclude(dependency("org.antlr:antlr4-runtime:.*"))
         exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib:.*"))
         exclude(dependency("org.jetbrains.kotlin:kotlin-reflect:.*"))
+        exclude(dependency("org.slf4j:slf4j-nop:.*"))
         exclude(dependency("io.javalin:.*:.*"))
         exclude(dependency("org.eclipse.jetty:.*:.*"))
         exclude(dependency("org.eclipse.jetty.websocket:.*:.*"))

--- a/graphite-query/build.gradle.kts
+++ b/graphite-query/build.gradle.kts
@@ -34,6 +34,7 @@ tasks.shadowJar {
         exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib:.*"))
         exclude(dependency("org.jetbrains.kotlin:kotlin-reflect:.*"))
         exclude(dependency("org.soot-oss:.*:.*"))
+        exclude(dependency("org.slf4j:slf4j-nop:.*"))
     }
 
     manifest {

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/FastArchiveAnalysisInputLocation.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/FastArchiveAnalysisInputLocation.kt
@@ -1,0 +1,48 @@
+package io.johnsonlee.graphite.sootup
+
+import sootup.core.model.SourceType
+import sootup.core.types.ClassType
+import sootup.core.views.View
+import sootup.java.bytecode.frontend.conversion.AsmJavaClassProvider
+import sootup.java.bytecode.frontend.inputlocation.ArchiveBasedAnalysisInputLocation
+import sootup.java.core.JavaSootClassSource
+import sootup.java.core.types.JavaClassType
+import java.nio.file.Path
+import java.util.Optional
+
+/**
+ * Drop-in replacement for [ArchiveBasedAnalysisInputLocation] that skips
+ * the `Files.exists()` check on ZipFileSystem paths.
+ *
+ * The parent class calls `Files.exists(pathToClass)` for every class lookup.
+ * On ZipFileSystem this triggers `ZipFileSystemProvider.checkAccess()` which
+ * throws and catches `NoSuchFileException` internally — the exception
+ * stack trace initialization is pure CPU waste (~3% of total build time).
+ *
+ * This class directly attempts to create the class source without any
+ * existence check. If the class doesn't exist, `createClassSource` returns
+ * empty.
+ */
+class FastArchiveAnalysisInputLocation(
+    path: Path,
+    srcType: SourceType
+) : ArchiveBasedAnalysisInputLocation(path, srcType) {
+
+    override fun getClassSource(type: ClassType, view: View): Optional<JavaSootClassSource> {
+        return try {
+            val fs = fileSystemCache.get(path)
+            val archiveRoot = fs.getPath("/")
+            val classType = type as JavaClassType
+            val provider = AsmJavaClassProvider(view)
+            val pathToClass = archiveRoot.resolve(
+                archiveRoot.fileSystem.getPath(
+                    classType.fullyQualifiedName.replace('.', '/') + ".class"
+                )
+            )
+            provider.createClassSource(this, pathToClass, classType)
+                .map { it as JavaSootClassSource }
+        } catch (_: Exception) {
+            Optional.empty()
+        }
+    }
+}

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
@@ -125,7 +125,7 @@ class JavaProjectLoader(
             isSpringBootJar(path) -> createSpringBootInputLocations(path)
             isWarFile(path) -> createWarInputLocations(path)
             else -> listOf(
-                PathBasedAnalysisInputLocation.create(path, SourceType.Application)
+                FastArchiveAnalysisInputLocation(path, SourceType.Application)
             )
         }
     }
@@ -195,7 +195,7 @@ class JavaProjectLoader(
                             }
                             // Only add JAR if it contains classes from included packages
                             if (jarContainsIncludedPackages(targetFile)) {
-                                locations.add(PathBasedAnalysisInputLocation.create(targetFile, SourceType.Library))
+                                locations.add(FastArchiveAnalysisInputLocation(targetFile, SourceType.Library))
                             }
                         }
                 }
@@ -272,7 +272,7 @@ class JavaProjectLoader(
 
                         // Only add JAR if it contains classes from included packages
                         if (jarContainsIncludedPackages(targetFile)) {
-                            locations.add(PathBasedAnalysisInputLocation.create(targetFile, SourceType.Library))
+                            locations.add(FastArchiveAnalysisInputLocation(targetFile, SourceType.Library))
                             loadedJarCount++
                             log("  + Loading JAR: $jarName")
                         } else {

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/FastArchiveAnalysisInputLocationTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/FastArchiveAnalysisInputLocationTest.kt
@@ -1,0 +1,173 @@
+package io.johnsonlee.graphite.sootup
+
+import sootup.core.model.SourceType
+import sootup.java.core.JavaIdentifierFactory
+import sootup.java.core.views.JavaView
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [FastArchiveAnalysisInputLocation] verifying that the optimized
+ * class lookup (bypassing `Files.exists()` on ZipFileSystem paths) behaves
+ * correctly for both present and absent classes.
+ */
+class FastArchiveAnalysisInputLocationTest {
+
+    @Test
+    fun `getClassSource returns class that exists in JAR`() {
+        val jarPath = buildTestJar("sample/simple/")
+        try {
+            val location = FastArchiveAnalysisInputLocation(jarPath, SourceType.Application)
+            val view = JavaView(listOf(location))
+
+            // First enumerate all classes so we know what is in the JAR
+            val allSources = location.getClassSources(view).toList()
+            assertTrue(allSources.isNotEmpty(), "JAR should contain at least one class")
+
+            // Look up the first class by its type
+            val knownType = allSources.first().classType
+            val result = location.getClassSource(knownType, view)
+            assertTrue(result.isPresent, "Should find class ${knownType.fullyQualifiedName} that exists in JAR")
+            assertEquals(knownType, result.get().classType,
+                "Returned class source should match the requested type")
+        } finally {
+            Files.deleteIfExists(jarPath)
+        }
+    }
+
+    @Test
+    fun `getClassSource returns empty for missing class`() {
+        val jarPath = buildTestJar("sample/simple/")
+        try {
+            val location = FastArchiveAnalysisInputLocation(jarPath, SourceType.Application)
+            val view = JavaView(listOf(location))
+            val factory = JavaIdentifierFactory.getInstance()
+            val missingType = factory.getClassType("com.does.not.Exist")
+
+            val result = location.getClassSource(missingType, view)
+            assertFalse(result.isPresent, "Should not find a class that does not exist in the JAR")
+        } finally {
+            Files.deleteIfExists(jarPath)
+        }
+    }
+
+    @Test
+    fun `getClassSources returns all classes from JAR`() {
+        val jarPath = buildTestJar("sample/simple/")
+        try {
+            val location = FastArchiveAnalysisInputLocation(jarPath, SourceType.Application)
+            val view = JavaView(listOf(location))
+
+            val classSources = location.getClassSources(view).toList()
+            assertTrue(classSources.isNotEmpty(), "Should return all classes from JAR")
+
+            // SimpleService should be among the classes
+            val classNames = classSources.map { it.classType.fullyQualifiedName }.toSet()
+            assertTrue(
+                classNames.contains("sample.simple.SimpleService"),
+                "Should contain SimpleService class; found: $classNames"
+            )
+        } finally {
+            Files.deleteIfExists(jarPath)
+        }
+    }
+
+    @Test
+    fun `getClassSource works with multiple packages in JAR`() {
+        // Build JAR containing classes from two different packages
+        val jarPath = buildTestJar("sample/simple/", "sample/enums/")
+        try {
+            val location = FastArchiveAnalysisInputLocation(jarPath, SourceType.Application)
+            val view = JavaView(listOf(location))
+            val factory = JavaIdentifierFactory.getInstance()
+
+            // Look up a class from the first package
+            val simpleType = factory.getClassType("sample.simple.SimpleService")
+            val simpleResult = location.getClassSource(simpleType, view)
+            assertTrue(simpleResult.isPresent, "Should find SimpleService from sample.simple package")
+
+            // Look up a class from the second package
+            val enumType = factory.getClassType("sample.enums.ComplexEnum")
+            val enumResult = location.getClassSource(enumType, view)
+            assertTrue(enumResult.isPresent, "Should find ComplexEnum from sample.enums package")
+
+            // Look up a class that is not in either package
+            val missingType = factory.getClassType("sample.controller.UserController")
+            val missingResult = location.getClassSource(missingType, view)
+            assertFalse(missingResult.isPresent, "Should not find class from a package not in the JAR")
+        } finally {
+            Files.deleteIfExists(jarPath)
+        }
+    }
+
+    @Test
+    fun `getClassSource returns empty for empty JAR`() {
+        val jarPath = buildEmptyJar()
+        try {
+            val location = FastArchiveAnalysisInputLocation(jarPath, SourceType.Application)
+            val view = JavaView(listOf(location))
+            val factory = JavaIdentifierFactory.getInstance()
+
+            val result = location.getClassSource(factory.getClassType("any.Class"), view)
+            assertFalse(result.isPresent, "Should return empty for any class lookup on an empty JAR")
+
+            val classSources = location.getClassSources(view).toList()
+            assertTrue(classSources.isEmpty(), "Empty JAR should yield no class sources")
+        } finally {
+            Files.deleteIfExists(jarPath)
+        }
+    }
+
+    // ========== Helper methods ==========
+
+    private fun buildTestJar(vararg classPathPrefixes: String): Path {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val jarPath = Files.createTempFile("fast-archive-test", ".jar")
+        JarOutputStream(Files.newOutputStream(jarPath), Manifest().apply {
+            mainAttributes.putValue("Manifest-Version", "1.0")
+        }).use { jos ->
+            val baseDir = testClassesDir.toFile()
+            for (prefix in classPathPrefixes) {
+                val prefixDir = File(baseDir, prefix)
+                if (prefixDir.exists()) {
+                    prefixDir.walk()
+                        .filter { it.isFile && it.name.endsWith(".class") }
+                        .forEach { classFile ->
+                            val entryName = classFile.relativeTo(baseDir).path
+                                .replace(File.separatorChar, '/')
+                            jos.putNextEntry(JarEntry(entryName))
+                            classFile.inputStream().use { it.copyTo(jos) }
+                            jos.closeEntry()
+                        }
+                }
+            }
+        }
+        return jarPath
+    }
+
+    private fun buildEmptyJar(): Path {
+        val jarPath = Files.createTempFile("fast-archive-empty", ".jar")
+        JarOutputStream(Files.newOutputStream(jarPath), Manifest().apply {
+            mainAttributes.putValue("Manifest-Version", "1.0")
+        }).use { /* no entries */ }
+        return jarPath
+    }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        return if (submodulePath.exists()) submodulePath else rootPath
+    }
+}


### PR DESCRIPTION
- `FastArchiveAnalysisInputLocation`: extends `ArchiveBasedAnalysisInputLocation`, overrides `getClassSource()` to skip `Files.exists()` on ZipFileSystem (~3% build CPU from `NoSuchFileException` stack trace init)
- Exclude `slf4j-nop` from shadow minimize in both query and explore modules (NOPServiceProvider class was being stripped)

Generated with [Claude Code](https://claude.com/claude-code)