### PR TITLE
docs: update version references for 1.1.0-alpha.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Specify the version via command line property:
 
 ```bash
 # Publish alpha version
-./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=0.0.1-alpha.2
+./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.1.0-alpha.1
 
 # Publish release version
 ./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.0.0
@@ -137,8 +137,8 @@ Publishing is triggered by creating a git tag. GitHub Actions automatically deri
 
 ```bash
 # Create and push a tag to trigger release
-git tag v1.0.0
-git push origin v1.0.0
+git tag v1.1.0-alpha.1
+git push origin v1.1.0-alpha.1
 ```
 
 ### Using Published Artifacts
@@ -157,8 +157,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:graphite-core:0.0.1-alpha.2")
-    implementation("io.johnsonlee.graphite:graphite-sootup:0.0.1-alpha.2")
+    implementation("io.johnsonlee.graphite:graphite-core:1.1.0-alpha.1")
+    implementation("io.johnsonlee.graphite:graphite-sootup:1.1.0-alpha.1")
 }
 ```
 
@@ -175,7 +175,7 @@ Follow this progression when releasing versions:
 
 Example version progression:
 ```
-0.0.1-alpha.2 → 0.0.1-beta.1 → 0.0.1-rc.1 → 0.0.1
+1.1.0-alpha.1 → 1.1.0-beta.1 → 1.1.0-rc.1 → 1.1.0
 ```
 
 ## Implementation Learnings

--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:core:1.0.0-rc13")
-    implementation("io.johnsonlee.graphite:sootup:1.0.0-rc13")
+    implementation("io.johnsonlee.graphite:core:1.1.0-alpha.1")
+    implementation("io.johnsonlee.graphite:sootup:1.1.0-alpha.1")
     // Optional: Cypher query support (graph.query("MATCH ..."))
-    implementation("io.johnsonlee.graphite:cypher:1.0.0-rc13")
+    implementation("io.johnsonlee.graphite:cypher:1.1.0-alpha.1")
     // Optional: disk persistence (WebGraph format)
-    implementation("io.johnsonlee.graphite:webgraph:1.0.0-rc13")
+    implementation("io.johnsonlee.graphite:webgraph:1.1.0-alpha.1")
 }
 ```
 


### PR DESCRIPTION
Summary:
- update README installation examples to 1.1.0-alpha.1
- update CLAUDE publishing examples to 1.1.0-alpha.1

Context:
- release tag v1.1.0-alpha.1 has already been pushed to trigger publishing
- direct push to main was blocked by required status checks, so this docs-only follow-up goes through a PR