### PR TITLE
hotfix: version GraphStore writes as v2 and keep legacy v1 reads

### DIFF
--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -23,10 +23,12 @@ Backward adjacency is rebuilt from `forward.*` at load time — not stored on di
 
 | File | Magic | Header |
 |------|-------|--------|
-| graph.metadata | `GRM` | `0x47524D01` |
-| graph.nodedata | `GRN` | `0x47524E01` |
-| graph.nodeindex | `GRI` | `0x47524901` |
-| graph.comparisons | `GRC` | `0x47524301` |
+| graph.metadata | `GRM` | `0x47524D02` |
+| graph.nodedata | `GRN` | `0x47524E02` |
+| graph.nodeindex | `GRI` | `0x47524902` |
+| graph.comparisons | `GRC` | `0x47524302` |
+
+Current writers emit version `2`. Readers accept legacy version `1` data from stable releases and decode legacy annotation payloads, but any graph re-saved by a current build is upgraded to version `2`.
 
 ### Edge Label Encoding (8-bit)
 

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -145,10 +145,7 @@ private const val LABELS_FILE = "graph.labels"
             LoadMode.EAGER -> loadEager(dir)
             LoadMode.MAPPED -> { ensureNodeIndex(dir); loadMapped(dir) }
             LoadMode.AUTO -> {
-                val nodeCount = DataInputStream(BufferedInputStream(dir.resolve(NODE_DATA_FILE).toFile().inputStream())).use { dis ->
-                    NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA)
-                    dis.readInt()
-                }
+                val (_, nodeCount) = readNodeDataHeader(dir)
                 if (nodeCount < MAPPED_THRESHOLD) {
                     loadEager(dir)
                 } else {
@@ -174,6 +171,7 @@ private const val LABELS_FILE = "graph.labels"
      * Load all nodes eagerly into JVM heap. Best for graphs < 1M nodes.
      */
     private fun loadEager(dir: Path): Graph {
+        val (nodeDataVersion, _) = readNodeDataHeader(dir)
         val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
         val stringTableFuture = CompletableFuture.supplyAsync { StringTable.load(dir) }
         val labelsFuture = CompletableFuture.supplyAsync { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
@@ -194,7 +192,7 @@ private const val LABELS_FILE = "graph.labels"
             NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA)
             val count = dis.readInt()
             repeat(count) {
-                val node = NodeSerializer.readNode(dis, stringTable)
+                val node = NodeSerializer.readNode(dis, stringTable, nodeDataVersion)
                 nodesById[node.id.value] = node
             }
         }
@@ -217,6 +215,7 @@ private const val LABELS_FILE = "graph.labels"
     fun loadLazy(dir: Path): Graph {
         require(Files.isDirectory(dir)) { "Not a directory: $dir" }
 
+        val (nodeDataVersion, _) = readNodeDataHeader(dir)
         val nodeIndex = readNodeIndex(dir)
 
         val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
@@ -242,6 +241,7 @@ private const val LABELS_FILE = "graph.labels"
             forward = forward,
             backward = backward,
             nodeDataFile = dir.resolve(NODE_DATA_FILE).toFile(),
+            nodeDataVersion = nodeDataVersion,
             stringTable = stringTable,
             nodeOffsets = nodeIndex.nodeOffsets,
             nodeTypeIndex = nodeIndex.nodeTypeIndex,
@@ -263,6 +263,7 @@ private const val LABELS_FILE = "graph.labels"
     fun loadMapped(dir: Path): Graph {
         require(Files.isDirectory(dir)) { "Not a directory: $dir" }
 
+        val (nodeDataVersion, _) = readNodeDataHeader(dir)
         val nodeIndex = readNodeIndex(dir)
 
         val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
@@ -293,6 +294,7 @@ private const val LABELS_FILE = "graph.labels"
             forward = forward,
             backward = backward,
             mappedNodeData = mappedBuffer,
+            nodeDataVersion = nodeDataVersion,
             stringTable = stringTable,
             nodeOffsets = nodeIndex.nodeOffsets,
             nodeTypeIndex = nodeIndex.nodeTypeIndex,
@@ -546,7 +548,7 @@ private const val LABELS_FILE = "graph.labels"
     internal fun buildNodeIndex(nodeDataPath: Path, nodeIndexPath: Path, stringTable: StringTable) {
         // Stream directly: read nodedata, write nodeindex entry by entry (no intermediate list)
         RandomAccessFile(nodeDataPath.toFile(), "r").use { raf ->
-            NodeSerializer.readHeader(raf, NodeSerializer.MAGIC_NODEDATA)
+            val nodeDataVersion = NodeSerializer.readHeader(raf, NodeSerializer.MAGIC_NODEDATA)
             val count = raf.readInt()
             DataOutputStream(BufferedOutputStream(nodeIndexPath.toFile().outputStream())).use { dos ->
                 NodeSerializer.writeHeader(dos, NodeSerializer.MAGIC_NODEINDEX)
@@ -564,9 +566,16 @@ private const val LABELS_FILE = "graph.labels"
                         override fun read(): Int = raf.read()
                         override fun read(b: ByteArray, off: Int, len: Int): Int = raf.read(b, off, len)
                     }) {}
-                    NodeSerializer.readNode(dis, stringTable)
+                    NodeSerializer.readNode(dis, stringTable, nodeDataVersion)
                 }
             }
+        }
+    }
+
+    private fun readNodeDataHeader(dir: Path): Pair<Int, Int> {
+        return DataInputStream(BufferedInputStream(dir.resolve(NODE_DATA_FILE).toFile().inputStream())).use { dis ->
+            val version = NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA)
+            version to dis.readInt()
         }
     }
 

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -31,6 +31,7 @@ internal class LazyWebGraphBackedGraph(
     private val forward: ImmutableGraph,
     private val backward: ImmutableGraph,
     private val nodeDataFile: File,
+    private val nodeDataVersion: Int,
     private val stringTable: StringTable,
     private val nodeOffsets: LongArray,
     private val nodeTypeIndex: Map<Class<out Node>, List<Int>>,
@@ -165,7 +166,7 @@ internal class LazyWebGraphBackedGraph(
                 override fun read(): Int = raf.read()
                 override fun read(b: ByteArray, off: Int, len: Int): Int = raf.read(b, off, len)
             })
-            return NodeSerializer.readNode(dis, stringTable)
+            return NodeSerializer.readNode(dis, stringTable, nodeDataVersion)
         }
     }
 }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -38,6 +38,7 @@ internal class MappedWebGraphBackedGraph(
     private val forward: ImmutableGraph,
     private val backward: ImmutableGraph,
     private val mappedNodeData: MappedByteBuffer,
+    private val nodeDataVersion: Int,
     private val stringTable: StringTable,
     private val nodeOffsets: LongArray,
     private val nodeTypeIndex: Map<Class<out Node>, List<Int>>,
@@ -162,7 +163,7 @@ internal class MappedWebGraphBackedGraph(
         val buf = mappedNodeData.duplicate()
         buf.position(offset.toInt())
         val dis = DataInputStream(ByteBufferInputStream(buf))
-        return NodeSerializer.readNode(dis, stringTable)
+        return NodeSerializer.readNode(dis, stringTable, nodeDataVersion)
     }
 }
 

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
@@ -29,7 +29,8 @@ internal object NodeSerializer {
     internal const val MAGIC_COMPARISONS = 0x47524300  // "GRC"
 
     /** Current format version (occupies the low byte of the 4-byte header int). */
-    const val FORMAT_VERSION: Int = 1
+    const val FORMAT_VERSION: Int = 2
+    private const val LEGACY_FORMAT_VERSION: Int = 1
 
     /** Write a 4-byte file header: 3-byte magic prefix | 1-byte version. */
     fun writeHeader(dos: DataOutputStream, magic: Int) {
@@ -43,7 +44,9 @@ internal object NodeSerializer {
         require(prefix == expectedMagic) {
             "Invalid file magic: expected 0x${expectedMagic.toString(16)}, got 0x${prefix.toString(16)}"
         }
-        return h and 0xFF
+        val version = h and 0xFF
+        validateVersion(version, expectedMagic)
+        return version
     }
 
     /** Overload for [RandomAccessFile]. */
@@ -53,7 +56,16 @@ internal object NodeSerializer {
         require(prefix == expectedMagic) {
             "Invalid file magic: expected 0x${expectedMagic.toString(16)}, got 0x${prefix.toString(16)}"
         }
-        return h and 0xFF
+        val version = h and 0xFF
+        validateVersion(version, expectedMagic)
+        return version
+    }
+
+    private fun validateVersion(version: Int, expectedMagic: Int) {
+        require(version == LEGACY_FORMAT_VERSION || version == FORMAT_VERSION) {
+            "Unsupported GraphStore format version $version for 0x${expectedMagic.toString(16)}. " +
+                "This build supports versions $LEGACY_FORMAT_VERSION and $FORMAT_VERSION."
+        }
     }
 
     // Node type tags
@@ -329,7 +341,7 @@ internal object NodeSerializer {
         return tag
     }
 
-    fun readNode(dis: DataInputStream, strings: StringTable): Node {
+    fun readNode(dis: DataInputStream, strings: StringTable, formatVersion: Int = FORMAT_VERSION): Node {
         val id = NodeId(dis.readInt())
         return when (val tag = dis.readByte().toInt()) {
             TAG_INT_CONSTANT -> IntConstant(id, dis.readInt())
@@ -343,7 +355,7 @@ internal object NodeSerializer {
                 val enumType = TypeDescriptor(strings.get(dis.readInt()))
                 val enumName = strings.get(dis.readInt())
                 val argCount = dis.readInt()
-                val args = (0 until argCount).map { readAnyValue(dis, strings) }
+                val args = (0 until argCount).map { readAnyValue(dis, strings, formatVersion) }
                 EnumConstant(id, enumType, enumName, args)
             }
             TAG_LOCAL_VARIABLE -> {
@@ -388,7 +400,7 @@ internal object NodeSerializer {
                 val values = mutableMapOf<String, Any?>()
                 repeat(kvCount) {
                     val k = strings.get(dis.readInt())
-                    val v = readAnyValue(dis, strings)
+                    val v = readAnnotationValue(dis, strings, formatVersion)
                     values[k] = v
                 }
                 AnnotationNode(id, name, className, memberName, values)
@@ -463,7 +475,7 @@ internal object NodeSerializer {
     }
 
     fun loadMetadata(dis: DataInputStream, strings: StringTable): GraphMetadata {
-        readHeader(dis, MAGIC_METADATA)
+        val formatVersion = readHeader(dis, MAGIC_METADATA)
         // Methods
         val methodCount = dis.readInt()
         val methods = mutableMapOf<String, MethodDescriptor>()
@@ -496,7 +508,7 @@ internal object NodeSerializer {
         repeat(enumCount) {
             val key = strings.get(dis.readInt())
             val count = dis.readInt()
-            enumValues[key] = (0 until count).map { readAnyValue(dis, strings) }
+            enumValues[key] = (0 until count).map { readAnyValue(dis, strings, formatVersion) }
         }
 
         // Member annotations
@@ -512,7 +524,7 @@ internal object NodeSerializer {
                 val kv = mutableMapOf<String, Any?>()
                 repeat(kvCount) {
                     val k = strings.get(dis.readInt())
-                    val v = readAnyValue(dis, strings)
+                    val v = readAnnotationValue(dis, strings, formatVersion)
                     kv[k] = v
                 }
                 annotations[fqn] = kv
@@ -605,7 +617,7 @@ internal object NodeSerializer {
         }
     }
 
-    private fun readAnyValue(dis: DataInputStream, strings: StringTable): Any? = when (dis.readByte().toInt()) {
+    private fun readAnyValue(dis: DataInputStream, strings: StringTable, formatVersion: Int): Any? = when (dis.readByte().toInt()) {
         VAL_INT -> dis.readInt()
         VAL_LONG -> dis.readLong()
         VAL_STRING -> strings.get(dis.readInt())
@@ -614,8 +626,21 @@ internal object NodeSerializer {
         VAL_BOOLEAN -> dis.readBoolean()
         VAL_NULL -> null
         VAL_ENUM_REF -> EnumValueReference(strings.get(dis.readInt()), strings.get(dis.readInt()))
-        VAL_LIST -> List(dis.readInt()) { readAnyValue(dis, strings) }
+        VAL_LIST -> {
+            require(formatVersion >= FORMAT_VERSION) {
+                "Encountered list value in GraphStore format version $formatVersion. Re-save the graph with a current Graphite build."
+            }
+            List(dis.readInt()) { readAnyValue(dis, strings, formatVersion) }
+        }
         else -> strings.get(dis.readInt()) // fallback
+    }
+
+    private fun readAnnotationValue(dis: DataInputStream, strings: StringTable, formatVersion: Int): Any? {
+        return if (formatVersion == LEGACY_FORMAT_VERSION) {
+            strings.get(dis.readInt()).let { it.ifEmpty { null } }
+        } else {
+            readAnyValue(dis, strings, formatVersion)
+        }
     }
 }
 

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -1640,6 +1640,17 @@ class GraphStoreTest {
     }
 
     @Test
+    fun `readHeader with legacy version via DataInputStream succeeds`() {
+        val baos = ByteArrayOutputStream()
+        val dos = DataOutputStream(baos)
+        dos.writeInt(NodeSerializer.MAGIC_METADATA or 0x01)
+        dos.flush()
+        val dis = DataInputStream(ByteArrayInputStream(baos.toByteArray()))
+        val version = NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA)
+        assertEquals(1, version)
+    }
+
+    @Test
     fun `readHeader with invalid magic via RandomAccessFile throws`() {
         val tmpFile = Files.createTempFile("bad-magic", ".bin")
         try {
@@ -1673,6 +1684,35 @@ class GraphStoreTest {
         }
     }
 
+    @Test
+    fun `readHeader with legacy version via RandomAccessFile succeeds`() {
+        val tmpFile = Files.createTempFile("raf-unsupported-version", ".bin")
+        try {
+            DataOutputStream(tmpFile.toFile().outputStream()).use { dos ->
+                dos.writeInt(NodeSerializer.MAGIC_NODEDATA or 0x01)
+            }
+            RandomAccessFile(tmpFile.toFile(), "r").use { raf ->
+                val version = NodeSerializer.readHeader(raf, NodeSerializer.MAGIC_NODEDATA)
+                assertEquals(1, version)
+            }
+        } finally {
+            Files.deleteIfExists(tmpFile)
+        }
+    }
+
+    @Test
+    fun `readHeader with unknown version throws`() {
+        val baos = ByteArrayOutputStream()
+        val dos = DataOutputStream(baos)
+        dos.writeInt(NodeSerializer.MAGIC_METADATA or 0x03)
+        dos.flush()
+        val dis = DataInputStream(ByteArrayInputStream(baos.toByteArray()))
+        val error = assertFailsWith<IllegalArgumentException> {
+            NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA)
+        }
+        assertTrue(error.message!!.contains("Unsupported GraphStore format version 3"))
+    }
+
     // ========================================================================
     // Invalid magic in metadata file on load
     // ========================================================================
@@ -1693,6 +1733,120 @@ class GraphStoreTest {
             }
         } finally {
             dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `legacy v1 annotation node decodes as string values`() {
+        val dir = Files.createTempDirectory("legacy-node-strings")
+        try {
+            val strings = StringTable.build(
+                listOf("Lcom/example/Foo;", "com.example.Foo", "bar", "value", "hello"),
+                dir
+            )
+            val baos = ByteArrayOutputStream()
+            DataOutputStream(baos).use { dos ->
+                dos.writeInt(42)
+                dos.writeByte(13)
+                dos.writeInt(strings.indexOf("Lcom/example/Foo;"))
+                dos.writeInt(strings.indexOf("com.example.Foo"))
+                dos.writeInt(strings.indexOf("bar"))
+                dos.writeInt(1)
+                dos.writeInt(strings.indexOf("value"))
+                dos.writeInt(strings.indexOf("hello"))
+            }
+            val node = NodeSerializer.readNode(
+                DataInputStream(ByteArrayInputStream(baos.toByteArray())),
+                strings,
+                1
+            ) as AnnotationNode
+            assertEquals("hello", node.values["value"])
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `legacy v1 metadata decodes annotation values as strings`() {
+        val dir = Files.createTempDirectory("legacy-metadata-strings")
+        try {
+            val strings = StringTable.build(
+                listOf("com.example.Foo#bar", "javax.annotation.Nullable", "value", "hello"),
+                dir
+            )
+            val baos = ByteArrayOutputStream()
+            DataOutputStream(baos).use { dos ->
+                dos.writeInt(NodeSerializer.MAGIC_METADATA or 0x01)
+                dos.writeInt(0)
+                dos.writeInt(0)
+                dos.writeInt(0)
+                dos.writeInt(0)
+                dos.writeInt(1)
+                dos.writeInt(strings.indexOf("com.example.Foo#bar"))
+                dos.writeInt(1)
+                dos.writeInt(strings.indexOf("javax.annotation.Nullable"))
+                dos.writeInt(1)
+                dos.writeInt(strings.indexOf("value"))
+                dos.writeInt(strings.indexOf("hello"))
+                dos.writeInt(0)
+            }
+            val metadata = NodeSerializer.loadMetadata(
+                DataInputStream(ByteArrayInputStream(baos.toByteArray())),
+                strings
+            )
+            assertEquals(
+                "hello",
+                metadata.memberAnnotations["com.example.Foo#bar"]!!["javax.annotation.Nullable"]!!["value"]
+            )
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `legacy v1 graph directory migrates end to end`() {
+        val fixture = createLegacyV1GraphDir()
+        try {
+            val loaded = GraphStore.load(fixture.dir)
+            val loadedNode = loaded.node(fixture.annotationNode.id) as AnnotationNode
+            assertEquals("hello", loadedNode.values["value"])
+            assertEquals(
+                "hello",
+                loaded.memberAnnotations("com.example.Foo", "bar")["javax.annotation.Nullable"]!!["value"]
+            )
+
+            Files.deleteIfExists(fixture.dir.resolve("graph.nodeindex"))
+            val mapped = GraphStore.load(fixture.dir, GraphStore.LoadMode.MAPPED)
+            try {
+                val mappedNode = mapped.node(fixture.annotationNode.id) as AnnotationNode
+                assertEquals("hello", mappedNode.values["value"])
+            } finally {
+                (mapped as Closeable).close()
+            }
+
+            val migratedDir = Files.createTempDirectory("legacy-v2-migrated")
+            try {
+                GraphStore.save(loaded, migratedDir)
+
+                DataInputStream(migratedDir.resolve("graph.nodedata").toFile().inputStream()).use { dis ->
+                    assertEquals(2, NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA))
+                }
+                DataInputStream(migratedDir.resolve("graph.metadata").toFile().inputStream()).use { dis ->
+                    assertEquals(2, NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA))
+                }
+
+                val migrated = GraphStore.load(migratedDir)
+                val migratedNode = migrated.node(fixture.annotationNode.id) as AnnotationNode
+                assertEquals("hello", migratedNode.values["value"])
+                assertEquals(
+                    "hello",
+                    migrated.memberAnnotations("com.example.Foo", "bar")["javax.annotation.Nullable"]!!["value"]
+                )
+            } finally {
+                migratedDir.toFile().deleteRecursively()
+            }
+        } finally {
+            fixture.dir.toFile().deleteRecursively()
         }
     }
 
@@ -1929,5 +2083,163 @@ class GraphStoreTest {
         builder.addMemberAnnotation("com.example.Foo", "bar", "javax.annotation.Nullable", emptyMap())
 
         return builder.build()
+    }
+
+    private data class LegacyV1Fixture(
+        val dir: Path,
+        val method: MethodDescriptor,
+        val annotationNode: AnnotationNode
+    )
+
+    private fun createLegacyV1GraphDir(): LegacyV1Fixture {
+        val dir = Files.createTempDirectory("legacy-v1-graph")
+        val method = MethodDescriptor(
+            TypeDescriptor("com.example.Foo"),
+            "bar",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val returnNode = ReturnNode(NodeId(1), method)
+        val annotationNode = AnnotationNode(
+            NodeId(2),
+            "javax.annotation.Nullable",
+            "com.example.Foo",
+            "bar",
+            mapOf("value" to "hello")
+        )
+
+        val builder = DefaultGraph.Builder()
+        builder.addMethod(method)
+        builder.addNode(returnNode)
+        builder.addNode(annotationNode)
+        builder.addMemberAnnotation("com.example.Foo", "bar", "javax.annotation.Nullable", annotationNode.values)
+        GraphStore.save(builder.build(), dir)
+
+        val strings = StringTable.build(
+            setOf(
+                method.declaringClass.className,
+                method.name,
+                method.returnType.className,
+                annotationNode.name,
+                annotationNode.className,
+                annotationNode.memberName,
+                "com.example.Foo#bar",
+                "javax.annotation.Nullable",
+                "value",
+                "hello"
+            ),
+            dir
+        )
+        writeLegacyV1NodeData(dir, method, returnNode, annotationNode, strings)
+        writeLegacyV1Metadata(dir, method, strings)
+        writeLegacyV1NodeIndex(dir, method, returnNode, annotationNode, strings)
+        writeLegacyV1Comparisons(dir)
+
+        return LegacyV1Fixture(dir, method, annotationNode)
+    }
+
+    private fun writeLegacyV1NodeData(
+        dir: Path,
+        method: MethodDescriptor,
+        returnNode: ReturnNode,
+        annotationNode: AnnotationNode,
+        strings: StringTable
+    ) {
+        DataOutputStream(dir.resolve("graph.nodedata").toFile().outputStream()).use { dos ->
+            dos.writeInt(NodeSerializer.MAGIC_NODEDATA or 0x01)
+            dos.writeInt(2)
+            dos.write(legacyV1ReturnNodeBytes(returnNode, method, strings))
+            dos.write(legacyV1AnnotationNodeBytes(annotationNode, strings))
+        }
+    }
+
+    private fun legacyV1ReturnNodeBytes(
+        returnNode: ReturnNode,
+        method: MethodDescriptor,
+        strings: StringTable
+    ): ByteArray {
+        val baos = ByteArrayOutputStream()
+        DataOutputStream(baos).use { dos ->
+            dos.writeInt(returnNode.id.value)
+            dos.writeByte(11)
+            writeLegacyV1MethodDescriptor(dos, method, strings)
+            dos.writeBoolean(false)
+        }
+        return baos.toByteArray()
+    }
+
+    private fun legacyV1AnnotationNodeBytes(annotationNode: AnnotationNode, strings: StringTable): ByteArray {
+        val baos = ByteArrayOutputStream()
+        DataOutputStream(baos).use { dos ->
+            dos.writeInt(annotationNode.id.value)
+            dos.writeByte(13)
+            dos.writeInt(strings.indexOf(annotationNode.name))
+            dos.writeInt(strings.indexOf(annotationNode.className))
+            dos.writeInt(strings.indexOf(annotationNode.memberName))
+            dos.writeInt(annotationNode.values.size)
+            for ((k, v) in annotationNode.values) {
+                dos.writeInt(strings.indexOf(k))
+                dos.writeInt(strings.indexOf(v?.toString() ?: ""))
+            }
+        }
+        return baos.toByteArray()
+    }
+
+    private fun writeLegacyV1Metadata(dir: Path, method: MethodDescriptor, strings: StringTable) {
+        DataOutputStream(dir.resolve("graph.metadata").toFile().outputStream()).use { dos ->
+            dos.writeInt(NodeSerializer.MAGIC_METADATA or 0x01)
+            dos.writeInt(1)
+            writeLegacyV1MethodDescriptor(dos, method, strings)
+            dos.writeInt(0)
+            dos.writeInt(0)
+            dos.writeInt(0)
+            dos.writeInt(1)
+            dos.writeInt(strings.indexOf("com.example.Foo#bar"))
+            dos.writeInt(1)
+            dos.writeInt(strings.indexOf("javax.annotation.Nullable"))
+            dos.writeInt(1)
+            dos.writeInt(strings.indexOf("value"))
+            dos.writeInt(strings.indexOf("hello"))
+            dos.writeInt(0)
+        }
+    }
+
+    private fun writeLegacyV1NodeIndex(
+        dir: Path,
+        method: MethodDescriptor,
+        returnNode: ReturnNode,
+        annotationNode: AnnotationNode,
+        strings: StringTable
+    ) {
+        val returnNodeSize = legacyV1ReturnNodeBytes(returnNode, method, strings).size.toLong()
+        DataOutputStream(dir.resolve("graph.nodeindex").toFile().outputStream()).use { dos ->
+            dos.writeInt(NodeSerializer.MAGIC_NODEINDEX or 0x01)
+            dos.writeInt(2)
+            dos.writeInt(returnNode.id.value)
+            dos.writeByte(11)
+            dos.writeLong(8L)
+            dos.writeInt(annotationNode.id.value)
+            dos.writeByte(13)
+            dos.writeLong(8L + returnNodeSize)
+        }
+    }
+
+    private fun writeLegacyV1Comparisons(dir: Path) {
+        DataOutputStream(dir.resolve("graph.comparisons").toFile().outputStream()).use { dos ->
+            dos.writeInt(NodeSerializer.MAGIC_COMPARISONS or 0x01)
+            dos.writeInt(0)
+        }
+    }
+
+    private fun writeLegacyV1MethodDescriptor(
+        dos: DataOutputStream,
+        method: MethodDescriptor,
+        strings: StringTable
+    ) {
+        dos.writeInt(strings.indexOf(method.declaringClass.className))
+        dos.writeInt(strings.indexOf(method.name))
+        dos.writeInt(method.parameterTypes.size)
+        method.parameterTypes.forEach { dos.writeInt(strings.indexOf(it.className)) }
+        dos.writeInt(strings.indexOf(method.returnType.className))
     }
 }


### PR DESCRIPTION
## Summary
- bump GraphStore writers from format version 1 to 2
- keep readers compatible with legacy stable v1 GraphStore data
- preserve legacy annotation string decoding while upgrading re-saved graphs to v2
- pass node-data version through eager, lazy, mapped, and nodeindex rebuild paths
- document that current writers emit v2 while readers still accept legacy v1
- add directory-level migration regression coverage

## Verification
- ./gradlew :webgraph:test --tests "io.johnsonlee.graphite.webgraph.GraphStoreTest"

## Migration Coverage
- load a real legacy v1 graph directory via GraphStore.load()
- rebuild nodeindex from legacy v1 nodedata via LoadMode.MAPPED
- re-save the loaded graph and verify the new graph.nodedata / graph.metadata headers are v2
- reload the migrated directory and verify annotation payloads survive end to end