### PR TITLE
docs: bump version to 1.1.0 and record latest benchmarks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,10 +125,10 @@ Specify the version via command line property:
 
 ```bash
 # Publish alpha version
-./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=0.0.1-alpha.2
+./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.1.1-alpha.1
 
 # Publish release version
-./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.0.0
+./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.1.0
 ```
 
 ### Automated Publishing (GitHub Actions)
@@ -137,8 +137,8 @@ Publishing is triggered by creating a git tag. GitHub Actions automatically deri
 
 ```bash
 # Create and push a tag to trigger release
-git tag v1.0.0
-git push origin v1.0.0
+git tag v1.1.0
+git push origin v1.1.0
 ```
 
 ### Using Published Artifacts
@@ -157,8 +157,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:graphite-core:0.0.1-alpha.2")
-    implementation("io.johnsonlee.graphite:graphite-sootup:0.0.1-alpha.2")
+    implementation("io.johnsonlee.graphite:graphite-core:1.1.0")
+    implementation("io.johnsonlee.graphite:graphite-sootup:1.1.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:core:1.0.0-rc13")
-    implementation("io.johnsonlee.graphite:sootup:1.0.0-rc13")
+    implementation("io.johnsonlee.graphite:core:1.1.0")
+    implementation("io.johnsonlee.graphite:sootup:1.1.0")
     // Optional: Cypher query support (graph.query("MATCH ..."))
-    implementation("io.johnsonlee.graphite:cypher:1.0.0-rc13")
+    implementation("io.johnsonlee.graphite:cypher:1.1.0")
     // Optional: disk persistence (WebGraph format)
-    implementation("io.johnsonlee.graphite:webgraph:1.0.0-rc13")
+    implementation("io.johnsonlee.graphite:webgraph:1.1.0")
 }
 ```
 

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -131,8 +131,8 @@ Use both micro and end-to-end benchmarks. A change is not accepted based on synt
 
 ### Results Summary
 
-| PR | What | Synthetic save (10M, 4g) | Production (4.1M) | |
-|----|------|--------------------------|-------------------|-|
+| Version / PR | What | Synthetic save (10M, 4g) | Production (4.1M) | |
+|--------------|------|--------------------------|-------------------|-|
 | [#53](https://github.com/johnsonlee/graphite/pull/53) | Baseline (flat arrays for load) | 84s | real 15m57s | |
 | [#55](https://github.com/johnsonlee/graphite/pull/55) | Flat single-file format | no change | — | :x: closed |
 | [#56](https://github.com/johnsonlee/graphite/pull/56) | Inline nodeindex | **16s (-81%)** | **real 8m31s (-47%)** | :white_check_mark: |
@@ -141,6 +141,15 @@ Use both micro and end-to-end benchmarks. A change is not accepted based on synt
 | [#65](https://github.com/johnsonlee/graphite/pull/65) | Buffer MmapGraphBuilder I/O | — | **real 5m43s (-33%), sys -44%** | :white_check_mark: |
 | [#66](https://github.com/johnsonlee/graphite/pull/66) | MmapGraph reads via mmap | — | **real 4m04s (-29%), sys -43%** | :white_check_mark: |
 | [#67](https://github.com/johnsonlee/graphite/pull/67) | FastArchiveAnalysisInputLocation | — | real 9m41s (+138%), user +76% | :x: reverted |
+| `1.1.0` | Current release, same production benchmark | — | **real 1m58s, user 2m18s, sys 0m48s** | :white_check_mark: |
+
+Compared with the historical best published numbers, `1.1.0` improves:
+
+| Metric | Historical best | `1.1.0` | Change |
+|--------|-----------------|---------|--------|
+| real | 4m04s ([#66](https://github.com/johnsonlee/graphite/pull/66)) | **1m58s** | **-2m06s (-51.6%)** |
+| user | 8m00s ([#65](https://github.com/johnsonlee/graphite/pull/65)) | **2m18s** | **-5m42s (-71.3%)** |
+| sys | 2m46s ([#65](https://github.com/johnsonlee/graphite/pull/65)) | **0m48s** | **-1m58s (-71.1%)** |
 
 ### How Each Bottleneck Was Found and Fixed
 


### PR DESCRIPTION
## Summary
- bump README and release documentation examples to 1.1.0
- add the latest production benchmark result to docs/webgraph-storage.md
- summarize the improvement versus the previous best published numbers

## Benchmark
- production benchmark: real 1m58s, user 2m18s, sys 0m48s
- vs historical best published numbers:
  - real: 4m04s -> 1m58s (-51.6%)
  - user: 8m00s -> 2m18s (-71.3%)
  - sys: 2m46s -> 0m48s (-71.1%)

## Verification
- docs only; tests not run
