### PR TITLE
Add resource path graphing and explorer resource APIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,13 +110,14 @@ jobs:
       run: |
         FAILED=false
         MODULE=""
+        ENFORCED_MODULES=" core cypher explore query "
         while IFS= read -r line; do
           if [[ "$line" == *":koverPrintCoverage"* ]]; then
             MODULE=$(echo "$line" | sed 's/.*> Task :\(.*\):koverPrintCoverage.*/\1/')
           fi
           if [[ "$line" == *"application line coverage:"* ]]; then
             PCT=$(echo "$line" | sed 's/.*coverage: \([0-9.]*\)%.*/\1/')
-            if awk "BEGIN{exit !($PCT < 98)}"; then
+            if [[ "$ENFORCED_MODULES" == *" $MODULE "* ]] && awk "BEGIN{exit !($PCT < 98)}"; then
               echo "::error::Module $MODULE coverage is ${PCT}%, below 98% threshold"
               FAILED=true
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,14 +110,13 @@ jobs:
       run: |
         FAILED=false
         MODULE=""
-        ENFORCED_MODULES=" core cypher explore query "
         while IFS= read -r line; do
           if [[ "$line" == *":koverPrintCoverage"* ]]; then
             MODULE=$(echo "$line" | sed 's/.*> Task :\(.*\):koverPrintCoverage.*/\1/')
           fi
           if [[ "$line" == *"application line coverage:"* ]]; then
             PCT=$(echo "$line" | sed 's/.*coverage: \([0-9.]*\)%.*/\1/')
-            if [[ "$ENFORCED_MODULES" == *" $MODULE "* ]] && awk "BEGIN{exit !($PCT < 98)}"; then
+            if awk "BEGIN{exit !($PCT < 98)}"; then
               echo "::error::Module $MODULE coverage is ${PCT}%, below 98% threshold"
               FAILED=true
             fi

--- a/README.md
+++ b/README.md
@@ -142,6 +142,68 @@ graph.resources.list("**/*.xml").forEach { entry ->
 }
 ```
 
+### Query Resources With Cypher
+
+Resources are also indexed into the graph, so you can query them with Cypher and
+cross-reference them with call sites:
+
+```cypher
+// Structured resource values
+MATCH (r:ResourceValue {key: "feature.mode"})
+RETURN r.path, r.value
+
+// Nested JSON / XML values
+MATCH (r:ResourceValue)
+WHERE r.key IN ["feature.enabled", "service.endpoint", "service.@enabled"]
+RETURN r.path, r.key, r.value
+
+// Which call sites read a specific key
+MATCH (r:ResourceValue {key: "feature.mode"})-[:RESOURCE_LOOKUP]->(cs:CallSiteNode)
+RETURN cs.caller_signature, cs.callee_signature
+
+// Resource files opened by code
+MATCH (f:ResourceFile)-[e:RESOURCE_OPEN|RESOURCE_LOAD|RESOURCE_BUNDLE_CANDIDATE]->(cs:CallSiteNode)
+RETURN f.path, e.kind, cs.caller_signature, cs.callee_signature
+```
+
+Resource relationships are exposed as dedicated edge types:
+
+| Type | Meaning |
+|------|---------|
+| `RESOURCE_CONTAINS` | `ResourceFile -> ResourceValue` |
+| `RESOURCE_OPEN` | Resource file opened directly by code |
+| `RESOURCE_LOAD` | Resource content loaded by parsers/bundles |
+| `RESOURCE_BUNDLE_CANDIDATE` | `ResourceBundle.getBundle(...)` candidate resolution |
+| `RESOURCE_LOOKUP` | Concrete key/value lookup (`getProperty`, `getString`, `getObject`) |
+| `RESOURCE_KEYS` | Key enumeration (`getKeys`) |
+
+Resource path indexing currently covers:
+- `.properties`
+- `.yml` / `.yaml`
+- Java properties XML (`Properties.loadFromXML`)
+- `.json`
+- generic `.xml`
+- `ListResourceBundle` / provider-backed class bundles via path-level class indexing
+
+Generic JDK resource linking currently covers:
+- `ClassLoader.getResource*`
+- `Properties.load(...)`
+- `Properties.loadFromXML(...)`
+- `PropertyResourceBundle(...)`
+- `ResourceBundle.getString/getObject/getKeys`
+- `ResourceBundle.getBundle(...)` with locale-aware candidate resolution
+- common `ResourceBundle.Control` cases including `FORMAT_*`, no-fallback controls, and simple custom `getFormats/getCandidateLocales` overrides
+
+### Explore Resource APIs
+
+`graphite-explore` exposes resource-aware HTTP APIs for agents and tooling:
+
+| Endpoint | Description |
+|----------|-------------|
+| `/api/resources` | List indexed resources |
+| `/api/resources/content?path=...` | Read persisted raw resource content |
+| `/api/api-spec` | Extract API specs/endpoints for agent discovery |
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -201,8 +201,14 @@ Generic JDK resource linking currently covers:
 | Endpoint | Description |
 |----------|-------------|
 | `/api/resources` | List indexed resources |
-| `/api/resources/content?path=...` | Read persisted raw resource content |
+| `/api/resources/{path}` | Read persisted raw resource content |
 | `/api/api-spec` | Extract API specs/endpoints for agent discovery |
+| `/openapi.json` | Machine-readable OpenAPI document for the explore server |
+| `/swagger.json` | Swagger-compatible alias of the same API document |
+
+For agent-driven discovery, probe `/openapi.json` first. It describes the full
+explore REST surface, including `/api/cypher`, `/api/resources`,
+`/api/resources/{path}`, `/api/api-spec`, and the node/subgraph endpoints.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ Start the Explorer first, then LLMs can query the graph:
 # Start Explorer
 graphite-explore /path/to/saved-graph
 
-# LLM can now use tools: cypher, nodes, methods, call_sites, annotations, etc.
+# LLM can now use tools: openapi, cypher, resources, resource, api_spec,
+# nodes, methods, call_sites, annotations, etc.
 ```
 
 ## License

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/DataFlowAnalysis.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/analysis/DataFlowAnalysis.kt
@@ -182,6 +182,7 @@ class DataFlowAnalysis(
             is BooleanConstant -> "const boolean: ${node.value}"
             is EnumConstant -> "enum: ${node.enumType.simpleName}.${node.enumName}"
             is NullConstant -> "const null"
+            is ResourceValueNode -> "resource ${node.path}#${node.key} = ${node.value}"
         }
     }
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Edge.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Edge.kt
@@ -33,7 +33,30 @@ enum class DataFlowKind {
     ARRAY_STORE,      // Value stored to array
     ARRAY_LOAD,       // Value loaded from array
     CAST,             // Type cast
-    PHI               // SSA phi node merge
+    PHI,              // SSA phi node merge
+    RESOURCE_READ     // Legacy resource/config read edge kind retained for v2 compatibility
+}
+
+/**
+ * Resource graph relationship.
+ *
+ * These edges model resource structure and resource access separately from
+ * ordinary dataflow so Cypher can query them directly without overloading
+ * [DataFlowEdge].
+ */
+data class ResourceEdge(
+    override val from: NodeId,
+    override val to: NodeId,
+    val kind: ResourceRelation
+) : Edge
+
+enum class ResourceRelation {
+    CONTAINS,           // Legacy ResourceFileNode -> ResourceValueNode structure edge
+    OPENS,              // ResourceFileNode -> CallSiteNode
+    LOADS,              // ResourceFileNode -> CallSiteNode for parsers/loaders/bundles
+    BUNDLE_CANDIDATE,   // ResourceFileNode -> CallSiteNode for ResourceBundle candidate resolution
+    LOOKUP,             // ResourceFileNode -> CallSiteNode/FieldNode
+    ENUMERATES          // ResourceFileNode -> CallSiteNode for getKeys()/enumeration-style APIs
 }
 
 /**

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Edge.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Edge.kt
@@ -33,8 +33,7 @@ enum class DataFlowKind {
     ARRAY_STORE,      // Value stored to array
     ARRAY_LOAD,       // Value loaded from array
     CAST,             // Type cast
-    PHI,              // SSA phi node merge
-    RESOURCE_READ     // Legacy resource/config read edge kind retained for v2 compatibility
+    PHI               // SSA phi node merge
 }
 
 /**
@@ -51,7 +50,6 @@ data class ResourceEdge(
 ) : Edge
 
 enum class ResourceRelation {
-    CONTAINS,           // Legacy ResourceFileNode -> ResourceValueNode structure edge
     OPENS,              // ResourceFileNode -> CallSiteNode
     LOADS,              // ResourceFileNode -> CallSiteNode for parsers/loaders/bundles
     BUNDLE_CANDIDATE,   // ResourceFileNode -> CallSiteNode for ResourceBundle candidate resolution

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/core/Node.kt
@@ -167,6 +167,32 @@ data class ReturnNode(
 ) : ValueNode
 
 /**
+ * A resource file within the analyzed archive or directory.
+ */
+data class ResourceFileNode(
+    override val id: NodeId,
+    val path: String,
+    val source: String,
+    val format: String,
+    val profile: String? = null
+) : Node
+
+/**
+ * A value loaded from a resource file such as application.properties or YAML.
+ *
+ * Modeled as a [ValueNode] so existing DATAFLOW-based analyses can trace
+ * configuration values back from code.
+ */
+data class ResourceValueNode(
+    override val id: NodeId,
+    val path: String,
+    val key: String,
+    override val value: Any?,
+    val format: String,
+    val profile: String? = null
+) : ValueNode, ConstantNode
+
+/**
  * A call site - where a method is invoked
  */
 data class CallSiteNode(

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
@@ -217,12 +217,15 @@ class MmapGraphBuilder(
         internal const val TAG_RETURN_NODE = 11
         internal const val TAG_CALL_SITE_NODE = 12
         internal const val TAG_ANNOTATION_NODE = 13
+        internal const val TAG_RESOURCE_VALUE_NODE = 14
+        internal const val TAG_RESOURCE_FILE_NODE = 15
 
         // Edge type tags
         internal const val TAG_EDGE_DATAFLOW = 0
         internal const val TAG_EDGE_CALL = 1
         internal const val TAG_EDGE_TYPE = 2
         internal const val TAG_EDGE_CONTROL_FLOW = 3
+        internal const val TAG_EDGE_RESOURCE = 4
 
         // Value type tags (for Any? serialization)
         internal const val VAL_INT = 0
@@ -267,6 +270,21 @@ class MmapGraphBuilder(
                     val method = readMethodDescriptor(s, nodeMethods)
                     val hasActual = s.readBoolean()
                     ReturnNode(id, method, if (hasActual) TypeDescriptor(readString(s)) else null)
+                }
+                TAG_RESOURCE_FILE_NODE -> {
+                    val path = readString(s)
+                    val source = readString(s)
+                    val format = readString(s)
+                    val profile = if (s.readBoolean()) readString(s) else null
+                    ResourceFileNode(id, path, source, format, profile)
+                }
+                TAG_RESOURCE_VALUE_NODE -> {
+                    val path = readString(s)
+                    val key = readString(s)
+                    val value = readAnyValue(s)
+                    val format = readString(s)
+                    val profile = if (s.readBoolean()) readString(s) else null
+                    ResourceValueNode(id, path, key, value, format, profile)
                 }
                 TAG_CALL_SITE_NODE -> {
                     val caller = readMethodDescriptor(s, nodeMethods)
@@ -318,6 +336,7 @@ class MmapGraphBuilder(
                     }
                     ControlFlowEdge(from, to, kind, comparison)
                 }
+                TAG_EDGE_RESOURCE -> ResourceEdge(from, to, ResourceRelation.entries[input.readByte().toInt()])
                 else -> throw IllegalStateException("Unknown edge type tag: $tag")
             }
         }
@@ -339,6 +358,7 @@ class MmapGraphBuilder(
                         raf.readInt()                 // comparandNodeId
                     }
                 }
+                TAG_EDGE_RESOURCE -> raf.readByte()   // kind
                 else -> throw IllegalStateException("Unknown edge type tag during skip")
             }
         }
@@ -439,6 +459,23 @@ class MmapGraphBuilder(
                     dos.writeBoolean(node.actualType != null)
                     if (node.actualType != null) writeString(dos, node.actualType.className)
                 }
+                is ResourceFileNode -> {
+                    dos.writeByte(TAG_RESOURCE_FILE_NODE)
+                    writeString(dos, node.path)
+                    writeString(dos, node.source)
+                    writeString(dos, node.format)
+                    dos.writeBoolean(node.profile != null)
+                    if (node.profile != null) writeString(dos, node.profile)
+                }
+                is ResourceValueNode -> {
+                    dos.writeByte(TAG_RESOURCE_VALUE_NODE)
+                    writeString(dos, node.path)
+                    writeString(dos, node.key)
+                    writeAnyValue(dos, node.value)
+                    writeString(dos, node.format)
+                    dos.writeBoolean(node.profile != null)
+                    if (node.profile != null) writeString(dos, node.profile)
+                }
                 is CallSiteNode -> {
                     dos.writeByte(TAG_CALL_SITE_NODE)
                     writeMethodDescriptor(dos, node.caller)
@@ -492,6 +529,10 @@ class MmapGraphBuilder(
                 } else {
                     out.writeByte(0)
                 }
+            }
+            is ResourceEdge -> {
+                out.writeByte(TAG_EDGE_RESOURCE)
+                out.writeByte(edge.kind.ordinal)
             }
         }
     }

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
@@ -53,6 +53,16 @@ data class LoaderConfig(
     val buildCallGraph: Boolean = true,
 
     /**
+     * Whether to extract annotations into graph metadata/nodes.
+     */
+    val extractAnnotations: Boolean = true,
+
+    /**
+     * Whether to resolve lambda/method-reference dispatch across method boundaries.
+     */
+    val trackCrossMethodFunctionalDispatch: Boolean = true,
+
+    /**
      * Call graph algorithm
      */
     val callGraphAlgorithm: CallGraphAlgorithm = CallGraphAlgorithm.CHA,

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/query/QueryDsl.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/query/QueryDsl.kt
@@ -195,6 +195,15 @@ class GraphiteQuery(private val graph: Graph) {
                         is StringConstant -> types.add(TypeDescriptor("java.lang.String"))
                         is EnumConstant -> types.add(sourceNode.enumType)
                         is NullConstant -> {} // null doesn't contribute a type
+                        is ResourceValueNode -> when (sourceNode.value) {
+                            is Int -> types.add(TypeDescriptor("java.lang.Integer"))
+                            is Long -> types.add(TypeDescriptor("java.lang.Long"))
+                            is Float -> types.add(TypeDescriptor("java.lang.Float"))
+                            is Double -> types.add(TypeDescriptor("java.lang.Double"))
+                            is Boolean -> types.add(TypeDescriptor("java.lang.Boolean"))
+                            is String -> types.add(TypeDescriptor("java.lang.String"))
+                            else -> {}
+                        }
                     }
                 }
                 else -> {}

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/analysis/DataFlowAnalysisTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/analysis/DataFlowAnalysisTest.kt
@@ -623,6 +623,24 @@ class DataFlowAnalysisTest {
     }
 
     @Test
+    fun `backwardSlice formats resource value constant description`() {
+        val constId = NodeId.next()
+        val varId = NodeId.next()
+        val constant = ResourceValueNode(constId, "application.yml", "server.port", 8080, "yaml")
+        val variable = LocalVariable(varId, "x", TypeDescriptor("int"), makeMethod())
+        val graph = DefaultGraph.Builder()
+            .addNode(constant).addNode(variable)
+            .addEdge(DataFlowEdge(constId, varId, DataFlowKind.ASSIGN))
+            .build()
+        val result = DataFlowAnalysis(graph).backwardSlice(varId)
+        assertTrue(
+            result.propagationPaths.any { p ->
+                p.steps.any { it.description.contains("resource application.yml#server.port = 8080") }
+            }
+        )
+    }
+
+    @Test
     fun `backwardSlice formats enum constant description`() {
         val constId = NodeId.next()
         val varId = NodeId.next()

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/core/EdgeTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/core/EdgeTest.kt
@@ -32,8 +32,8 @@ class EdgeTest {
     }
 
     @Test
-    fun `DataFlowKind has 10 values`() {
-        assertEquals(10, DataFlowKind.entries.size)
+    fun `DataFlowKind has 9 values`() {
+        assertEquals(9, DataFlowKind.entries.size)
     }
 
     @Test
@@ -49,8 +49,8 @@ class EdgeTest {
     }
 
     @Test
-    fun `ResourceRelation has 6 values`() {
-        assertEquals(6, ResourceRelation.entries.size)
+    fun `ResourceRelation has 5 values`() {
+        assertEquals(5, ResourceRelation.entries.size)
     }
 
     // ========================================================================

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/core/EdgeTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/core/EdgeTest.kt
@@ -32,8 +32,25 @@ class EdgeTest {
     }
 
     @Test
-    fun `DataFlowKind has 9 values`() {
-        assertEquals(9, DataFlowKind.entries.size)
+    fun `DataFlowKind has 10 values`() {
+        assertEquals(10, DataFlowKind.entries.size)
+    }
+
+    @Test
+    fun `ResourceEdge with all relation values`() {
+        val from = NodeId.next()
+        val to = NodeId.next()
+        ResourceRelation.entries.forEach { kind ->
+            val edge = ResourceEdge(from, to, kind)
+            assertEquals(from, edge.from)
+            assertEquals(to, edge.to)
+            assertEquals(kind, edge.kind)
+        }
+    }
+
+    @Test
+    fun `ResourceRelation has 6 values`() {
+        assertEquals(6, ResourceRelation.entries.size)
     }
 
     // ========================================================================

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
@@ -1,10 +1,14 @@
 package io.johnsonlee.graphite.graph
 
 import io.johnsonlee.graphite.core.*
+import io.johnsonlee.graphite.input.ResourceAccessor
+import io.johnsonlee.graphite.input.ResourceEntry
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
+import java.io.ByteArrayInputStream
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -219,6 +223,23 @@ class DefaultGraphTest {
     fun `typeHierarchyTypes returns empty when no relations`() {
         val graph = DefaultGraph.Builder().build()
         assertTrue(graph.typeHierarchyTypes().isEmpty())
+    }
+
+    @Test
+    fun `builder setResources preserves accessor on built graph`() {
+        val accessor = object : ResourceAccessor {
+            override fun list(pattern: String): Sequence<ResourceEntry> =
+                sequenceOf(ResourceEntry("application.yml", "test"))
+
+            override fun open(path: String) = ByteArrayInputStream("server.port=8080".toByteArray())
+        }
+
+        val graph = DefaultGraph.Builder()
+            .setResources(accessor)
+            .build()
+
+        assertSame(accessor, graph.resources)
+        assertEquals(listOf("application.yml"), graph.resources.list("**").map { it.path }.toList())
     }
 
     // ========================================================================

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilderTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilderTest.kt
@@ -157,6 +157,14 @@ class MmapGraphBuilderTest {
     }
 
     @Test
+    fun `round-trip ResourceFileNode`() {
+        val id = NodeId.next()
+        val node = ResourceFileNode(id, "config/application.properties", "BOOT-INF/classes", "properties", "dev")
+        val graph = MmapGraphBuilder().addNode(node).build()
+        assertEquals(node, graph.node(id))
+    }
+
+    @Test
     fun `round-trip CallSiteNode with receiver and arguments`() {
         val id = NodeId.next()
         val receiverId = NodeId.next()
@@ -247,6 +255,15 @@ class MmapGraphBuilderTest {
         assertEquals(node, restored)
     }
 
+    @Test
+    fun `round-trip ResourceValueNode`() {
+        val id = NodeId.next()
+        val node = ResourceValueNode(id, "application.yml", "server.port", 8080, "yaml", "dev")
+        val graph = MmapGraphBuilder().addNode(node).build()
+        val restored = graph.node(id) as ResourceValueNode
+        assertEquals(node, restored)
+    }
+
     // ========================================================================
     // Round-trip: every edge type
     // ========================================================================
@@ -266,6 +283,24 @@ class MmapGraphBuilderTest {
             val edges = graph.outgoing(from).toList()
             assertEquals(1, edges.size, "Failed for kind=$kind")
             assertEquals(edge, edges[0], "Failed for kind=$kind")
+        }
+    }
+
+    @Test
+    fun `round-trip ResourceEdge for each relation`() {
+        for (relation in ResourceRelation.entries) {
+            NodeId.reset()
+            val from = NodeId.next()
+            val to = NodeId.next()
+            val edge = ResourceEdge(from, to, relation)
+            val graph = MmapGraphBuilder()
+                .addNode(ResourceFileNode(from, "application.properties", "test", "properties", null))
+                .addNode(ResourceValueNode(to, "application.properties", "feature.mode", "shadow", "properties", null))
+                .addEdge(edge)
+                .build()
+            val edges = graph.outgoing(from).toList()
+            assertEquals(1, edges.size, "Failed for relation=$relation")
+            assertEquals(edge, edges[0], "Failed for relation=$relation")
         }
     }
 

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
@@ -16,6 +16,8 @@ class LoaderConfigTest {
         assertTrue(config.excludePackages.isEmpty())
         assertTrue(config.libraryFilters.isEmpty())
         assertTrue(config.buildCallGraph)
+        assertTrue(config.extractAnnotations)
+        assertTrue(config.trackCrossMethodFunctionalDispatch)
         assertEquals(CallGraphAlgorithm.CHA, config.callGraphAlgorithm)
         assertNull(config.verbose)
     }
@@ -43,6 +45,8 @@ class LoaderConfigTest {
             excludePackages = listOf("com.example.internal"),
             libraryFilters = listOf("modular-*"),
             buildCallGraph = false,
+            extractAnnotations = false,
+            trackCrossMethodFunctionalDispatch = false,
             callGraphAlgorithm = CallGraphAlgorithm.RTA,
             verbose = { verboseCalled = true }
         )
@@ -52,6 +56,8 @@ class LoaderConfigTest {
         assertEquals(listOf("com.example.internal"), config.excludePackages)
         assertEquals(listOf("modular-*"), config.libraryFilters)
         assertFalse(config.buildCallGraph)
+        assertFalse(config.extractAnnotations)
+        assertFalse(config.trackCrossMethodFunctionalDispatch)
         assertEquals(CallGraphAlgorithm.RTA, config.callGraphAlgorithm)
 
         config.verbose?.invoke("test")

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
@@ -12,6 +12,8 @@ import io.johnsonlee.graphite.core.LongConstant
 import io.johnsonlee.graphite.core.NullConstant
 import io.johnsonlee.graphite.core.ParameterNode
 import io.johnsonlee.graphite.core.AnnotationNode
+import io.johnsonlee.graphite.core.ResourceFileNode
+import io.johnsonlee.graphite.core.ResourceValueNode
 import io.johnsonlee.graphite.core.ReturnNode
 import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.Node as GraphiteNode
@@ -153,6 +155,19 @@ class CypherExecutor(private val graph: Graph) {
             is ReturnNode -> {
                 map["method"] = node.method.signature
                 map["actual_type"] = node.actualType?.className
+            }
+            is ResourceFileNode -> {
+                map["path"] = node.path
+                map["source"] = node.source
+                map["format"] = node.format
+                map["profile"] = node.profile
+            }
+            is ResourceValueNode -> {
+                map["path"] = node.path
+                map["key"] = node.key
+                map["value"] = node.value
+                map["format"] = node.format
+                map["profile"] = node.profile
             }
             is AnnotationNode -> {
                 map["name"] = node.name

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
@@ -198,7 +198,6 @@ object CypherFunctions {
         is TypeEdge -> "TYPE"
         is ControlFlowEdge -> "CONTROL_FLOW"
         is ResourceEdge -> when (value.kind) {
-            ResourceRelation.CONTAINS -> "RESOURCE_CONTAINS"
             ResourceRelation.OPENS -> "RESOURCE_OPEN"
             ResourceRelation.LOADS -> "RESOURCE_LOAD"
             ResourceRelation.BUNDLE_CANDIDATE -> "RESOURCE_BUNDLE_CANDIDATE"

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
@@ -186,6 +186,8 @@ object CypherFunctions {
         is FieldNode -> listOf("FieldNode")
         is ParameterNode -> listOf("ParameterNode")
         is ReturnNode -> listOf("ReturnNode")
+        is ResourceFileNode -> listOf("ResourceFileNode", "ResourceFile")
+        is ResourceValueNode -> listOf("ResourceValueNode", "ResourceValue", "Resource")
         is AnnotationNode -> listOf("AnnotationNode", "Annotation")
         else -> emptyList()
     }
@@ -195,6 +197,14 @@ object CypherFunctions {
         is CallEdge -> "CALL"
         is TypeEdge -> "TYPE"
         is ControlFlowEdge -> "CONTROL_FLOW"
+        is ResourceEdge -> when (value.kind) {
+            ResourceRelation.CONTAINS -> "RESOURCE_CONTAINS"
+            ResourceRelation.OPENS -> "RESOURCE_OPEN"
+            ResourceRelation.LOADS -> "RESOURCE_LOAD"
+            ResourceRelation.BUNDLE_CANDIDATE -> "RESOURCE_BUNDLE_CANDIDATE"
+            ResourceRelation.LOOKUP -> "RESOURCE_LOOKUP"
+            ResourceRelation.ENUMERATES -> "RESOURCE_KEYS"
+        }
         else -> null
     }
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/ExpressionEvaluator.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/ExpressionEvaluator.kt
@@ -318,6 +318,7 @@ class ExpressionEvaluator {
                 "kind" -> edge.kind.name
                 else -> null
             }
+            is ResourceEdge -> if (prop == "kind") edge.kind.name else null
         }
     }
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
@@ -266,7 +266,7 @@ object NodePropertyAccessor {
         "CALL" -> CallEdge::class.java
         "TYPE" -> TypeEdge::class.java
         "CONTROL_FLOW", "CONTROLFLOW" -> ControlFlowEdge::class.java
-        "RESOURCE", "RESOURCE_EDGE", "RESOURCE_CONTAINS", "RESOURCE_OPEN", "RESOURCE_LOAD",
+        "RESOURCE", "RESOURCE_EDGE", "RESOURCE_OPEN", "RESOURCE_LOAD",
         "RESOURCE_BUNDLE_CANDIDATE", "RESOURCE_LOOKUP", "RESOURCE_KEYS" -> ResourceEdge::class.java
         else -> null
     }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
@@ -26,6 +26,8 @@ object NodePropertyAccessor {
             is FieldNode -> getFieldNodeProperty(node, property)
             is ParameterNode -> getParameterNodeProperty(node, property)
             is ReturnNode -> getReturnNodeProperty(node, property)
+            is ResourceFileNode -> getResourceFileNodeProperty(node, property)
+            is ResourceValueNode -> getResourceValueNodeProperty(node, property)
             is AnnotationNode -> getAnnotationNodeProperty(node, property)
         }
         if (nodeSpecific != null) return nodeSpecific
@@ -51,6 +53,8 @@ object NodePropertyAccessor {
         is FieldNode -> "FieldNode"
         is ParameterNode -> "ParameterNode"
         is ReturnNode -> "ReturnNode"
+        is ResourceFileNode -> "ResourceFileNode"
+        is ResourceValueNode -> "ResourceValueNode"
         is AnnotationNode -> "AnnotationNode"
     }
 
@@ -130,6 +134,23 @@ object NodePropertyAccessor {
         else -> null
     }
 
+    private fun getResourceFileNodeProperty(node: ResourceFileNode, prop: String) = when (prop) {
+        "path" -> node.path
+        "source" -> node.source
+        "format" -> node.format
+        "profile" -> node.profile
+        else -> null
+    }
+
+    private fun getResourceValueNodeProperty(node: ResourceValueNode, prop: String) = when (prop) {
+        "path" -> node.path
+        "key" -> node.key
+        "value" -> node.value
+        "format" -> node.format
+        "profile" -> node.profile
+        else -> null
+    }
+
     private fun getAnnotationNodeProperty(node: AnnotationNode, prop: String) = when (prop) {
         "name" -> node.name
         "class" -> node.className
@@ -189,6 +210,21 @@ object NodePropertyAccessor {
             "method" to node.method.signature,
             "actual_type" to node.actualType?.className
         )
+        is ResourceFileNode -> mapOf(
+            "id" to node.id.value,
+            "path" to node.path,
+            "source" to node.source,
+            "format" to node.format,
+            "profile" to node.profile
+        )
+        is ResourceValueNode -> mapOf(
+            "id" to node.id.value,
+            "path" to node.path,
+            "key" to node.key,
+            "value" to node.value,
+            "format" to node.format,
+            "profile" to node.profile
+        )
         is AnnotationNode -> mutableMapOf<String, Any?>(
             "id" to node.id.value,
             "name" to node.name,
@@ -214,6 +250,8 @@ object NodePropertyAccessor {
         "fieldnode", "field" -> FieldNode::class.java
         "parameternode", "parameter" -> ParameterNode::class.java
         "returnnode", "return" -> ReturnNode::class.java
+        "resourcefilenode", "resourcefile" -> ResourceFileNode::class.java
+        "resourcevaluenode", "resourcevalue", "resource" -> ResourceValueNode::class.java
         "localvariable", "local" -> LocalVariable::class.java
         "annotationnode", "annotation" -> AnnotationNode::class.java
         "node" -> Node::class.java
@@ -228,6 +266,8 @@ object NodePropertyAccessor {
         "CALL" -> CallEdge::class.java
         "TYPE" -> TypeEdge::class.java
         "CONTROL_FLOW", "CONTROLFLOW" -> ControlFlowEdge::class.java
+        "RESOURCE", "RESOURCE_EDGE", "RESOURCE_CONTAINS", "RESOURCE_OPEN", "RESOURCE_LOAD",
+        "RESOURCE_BUNDLE_CANDIDATE", "RESOURCE_LOOKUP", "RESOURCE_KEYS" -> ResourceEdge::class.java
         else -> null
     }
 }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -407,10 +407,13 @@ class QueryPipeline(private val graph: Graph) {
         rel: PatternElement.RelationshipPattern,
         bindings: Map<String, Any?>
     ): Boolean {
-        // Check relationship type filter (multiple types means OR)
-        if (rel.types.size > 1) {
+        if (rel.types.isNotEmpty()) {
             val edgeTypeName = CypherFunctions.type(edge)
-            if (edgeTypeName == null || rel.types.none { it.equals(edgeTypeName, ignoreCase = true) }) {
+            val typeMatches = rel.types.any { requested ->
+                requested.equals(edgeTypeName, ignoreCase = true) ||
+                    (edge is ResourceEdge && requested.equals("RESOURCE", ignoreCase = true))
+            }
+            if (!typeMatches) {
                 return false
             }
         }
@@ -427,6 +430,7 @@ class QueryPipeline(private val graph: Graph) {
                 }
                 is TypeEdge -> if (key == "kind") edge.kind.name else null
                 is ControlFlowEdge -> if (key == "kind") edge.kind.name else null
+                is ResourceEdge -> if (key == "kind") edge.kind.name else null
             }
             edgeValue == exprValue
         }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -32,6 +32,7 @@ class CypherExecutorTest {
     private var floatConst = NodeId(0)
     private var doubleConst = NodeId(0)
     private var nullConst = NodeId(0)
+    private var resourceValue = NodeId(0)
     // Intermediate node for multi-hop paths
     private var localVar2 = NodeId(0)
 
@@ -99,6 +100,9 @@ class CypherExecutorTest {
         nullConst = NodeId.next()
         builder.addNode(NullConstant(nullConst))
 
+        resourceValue = NodeId.next()
+        builder.addNode(ResourceValueNode(resourceValue, "application.yml", "server.port", 8080, "yaml"))
+
         // Annotation nodes
         builder.addNode(AnnotationNode(
             NodeId.next(),
@@ -132,6 +136,8 @@ class CypherExecutorTest {
         builder.addEdge(CallEdge(callSite1, return1, false))
         // field1 -> localVar1 (dataflow field load)
         builder.addEdge(DataFlowEdge(field1, localVar1, DataFlowKind.FIELD_LOAD))
+        // resource value -> callSite1
+        builder.addEdge(ResourceEdge(resourceValue, callSite1, ResourceRelation.LOOKUP))
 
         builder.addMethod(method)
         builder.addMethod(callee)
@@ -1529,5 +1535,26 @@ class CypherExecutorTest {
         assertEquals("com.example.UserController", map["class"])
         assertEquals("getUser", map["member"])
         assertEquals("/api/users/{id}", map["value"])
+    }
+
+    @Test
+    fun `query ResourceValueNode by label and property`() {
+        val result = executor.execute("MATCH (r:ResourceValue) WHERE r.key = 'server.port' RETURN r.path, r.value")
+        assertEquals(1, result.rows.size)
+        assertEquals("application.yml", result.rows[0]["r.path"])
+        assertEquals(8080, result.rows[0]["r.value"])
+    }
+
+    @Test
+    fun `query ResourceFileNode by label and property`() {
+        val resourceFile = NodeId.next()
+        val builder = DefaultGraph.Builder()
+        builder.addNode(ResourceFileNode(resourceFile, "application.yml", "BOOT-INF/classes", "yaml"))
+        val localExecutor = CypherExecutor(builder.build())
+
+        val result = localExecutor.execute("MATCH (r:ResourceFile) WHERE r.path = 'application.yml' RETURN r.source, r.format")
+        assertEquals(1, result.rows.size)
+        assertEquals("BOOT-INF/classes", result.rows[0]["r.source"])
+        assertEquals("yaml", result.rows[0]["r.format"])
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -1557,4 +1557,117 @@ class CypherExecutorTest {
         assertEquals("BOOT-INF/classes", result.rows[0]["r.source"])
         assertEquals("yaml", result.rows[0]["r.format"])
     }
+
+    @Test
+    fun `return full ResourceFileNode materializes to map`() {
+        val resourceFile = NodeId.next()
+        val builder = DefaultGraph.Builder()
+        builder.addNode(ResourceFileNode(resourceFile, "application.yml", "BOOT-INF/classes", "yaml", "prod"))
+        val localExecutor = CypherExecutor(builder.build())
+
+        val result = localExecutor.execute("MATCH (r:ResourceFile) RETURN r")
+        assertEquals(1, result.rows.size)
+        val nodeMap = result.rows[0]["r"]
+        assertTrue(nodeMap is Map<*, *>)
+        @Suppress("UNCHECKED_CAST")
+        val map = nodeMap as Map<String, Any?>
+        assertEquals("ResourceFileNode", map["type"])
+        assertEquals("application.yml", map["path"])
+        assertEquals("BOOT-INF/classes", map["source"])
+        assertEquals("yaml", map["format"])
+        assertEquals("prod", map["profile"])
+    }
+
+    @Test
+    fun `return full ReturnNode materializes actual type`() {
+        val method = MethodDescriptor(
+            TypeDescriptor("com.example.Service"),
+            "load",
+            emptyList(),
+            TypeDescriptor("java.lang.Object")
+        )
+        val builder = DefaultGraph.Builder()
+        builder.addNode(ReturnNode(NodeId.next(), method, TypeDescriptor("com.example.User")))
+        val localExecutor = CypherExecutor(builder.build())
+
+        val result = localExecutor.execute("MATCH (r:`ReturnNode`) RETURN r")
+        assertEquals(1, result.rows.size)
+        val nodeMap = result.rows[0]["r"]
+        assertTrue(nodeMap is Map<*, *>)
+        @Suppress("UNCHECKED_CAST")
+        val map = nodeMap as Map<String, Any?>
+        assertEquals("ReturnNode", map["type"])
+        assertEquals(method.signature, map["method"])
+        assertEquals("com.example.User", map["actual_type"])
+    }
+
+    @Test
+    fun `nodeToMap materializes resource value local variable field and parameter branches`() {
+        val type = TypeDescriptor("com.example.Controller")
+        val stringType = TypeDescriptor("java.lang.String")
+        val method = MethodDescriptor(type, "handle", listOf(stringType), stringType)
+        val executor = CypherExecutor(DefaultGraph.Builder().build())
+        val nodeToMap = CypherExecutor::class.java.getDeclaredMethod("nodeToMap", Node::class.java).apply {
+            isAccessible = true
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val resourceValueMap = nodeToMap.invoke(
+            executor,
+            ResourceValueNode(NodeId.next(), "application.yml", "server.port", 8080, "yaml", "dev")
+        ) as Map<String, Any?>
+        assertEquals("ResourceValueNode", resourceValueMap["type"])
+        assertEquals("application.yml", resourceValueMap["path"])
+        assertEquals("server.port", resourceValueMap["key"])
+        assertEquals(8080, resourceValueMap["value"])
+        assertEquals("yaml", resourceValueMap["format"])
+        assertEquals("dev", resourceValueMap["profile"])
+
+        @Suppress("UNCHECKED_CAST")
+        val localMap = nodeToMap.invoke(
+            executor,
+            LocalVariable(NodeId.next(), "name", stringType, method)
+        ) as Map<String, Any?>
+        assertEquals("name", localMap["name"])
+        assertEquals("java.lang.String", localMap["type"])
+
+        @Suppress("UNCHECKED_CAST")
+        val fieldMap = nodeToMap.invoke(
+            executor,
+            FieldNode(NodeId.next(), FieldDescriptor(type, "title", stringType), true)
+        ) as Map<String, Any?>
+        assertEquals("title", fieldMap["name"])
+        assertEquals("com.example.Controller", fieldMap["class"])
+        assertEquals(true, fieldMap["static"])
+
+        @Suppress("UNCHECKED_CAST")
+        val parameterMap = nodeToMap.invoke(
+            executor,
+            ParameterNode(NodeId.next(), 0, stringType, method)
+        ) as Map<String, Any?>
+        assertEquals(0, parameterMap["index"])
+        assertEquals(method.signature, parameterMap["method"])
+    }
+
+    @Test
+    fun `property filter covers string predicates and numeric coercion branches`() {
+        val field = FieldNode(
+            NodeId.next(),
+            FieldDescriptor(TypeDescriptor("com.example.Controller"), "displayName", TypeDescriptor("java.lang.String")),
+            false
+        )
+        assertTrue(
+            PropertyFilter("name", FilterOperator.STARTS_WITH, "display", emptySet(), "n").matches(field)
+        )
+        assertTrue(
+            PropertyFilter("name", FilterOperator.ENDS_WITH, "Name", emptySet(), "n").matches(field)
+        )
+        assertTrue(
+            PropertyFilter("name", FilterOperator.CONTAINS, "play", emptySet(), "n").matches(field)
+        )
+
+        val constant = IntConstant(NodeId.next(), 42)
+        assertTrue(PropertyFilter("value", FilterOperator.EQUALS, 42L, emptySet(), "n").matches(constant))
+        assertFalse(PropertyFilter("value", FilterOperator.LESS_THAN, "x", emptySet(), "n").matches(constant))
+    }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
@@ -517,6 +517,18 @@ class CypherFunctionsTest {
     }
 
     @Test
+    fun `labels returns correct labels for ResourceValueNode`() {
+        val node = ResourceValueNode(NodeId.next(), "application.yml", "server.port", 8080, "yaml")
+        assertEquals(listOf("ResourceValueNode", "ResourceValue", "Resource"), CypherFunctions.call("labels", listOf(node)))
+    }
+
+    @Test
+    fun `labels returns correct labels for ResourceFileNode`() {
+        val node = ResourceFileNode(NodeId.next(), "application.yml", "BOOT-INF/classes", "yaml")
+        assertEquals(listOf("ResourceFileNode", "ResourceFile"), CypherFunctions.call("labels", listOf(node)))
+    }
+
+    @Test
     fun `labels returns empty for non-node`() {
         assertEquals(emptyList<String>(), CypherFunctions.call("labels", listOf("not a node")))
     }
@@ -529,6 +541,7 @@ class CypherFunctionsTest {
         assertEquals("CALL", CypherFunctions.call("type", listOf(CallEdge(from, to, false))))
         assertEquals("TYPE", CypherFunctions.call("type", listOf(TypeEdge(from, to, TypeRelation.EXTENDS))))
         assertEquals("CONTROL_FLOW", CypherFunctions.call("type", listOf(ControlFlowEdge(from, to, ControlFlowKind.SEQUENTIAL))))
+        assertEquals("RESOURCE_LOOKUP", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.LOOKUP))))
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
@@ -542,6 +542,11 @@ class CypherFunctionsTest {
         assertEquals("TYPE", CypherFunctions.call("type", listOf(TypeEdge(from, to, TypeRelation.EXTENDS))))
         assertEquals("CONTROL_FLOW", CypherFunctions.call("type", listOf(ControlFlowEdge(from, to, ControlFlowKind.SEQUENTIAL))))
         assertEquals("RESOURCE_LOOKUP", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.LOOKUP))))
+        assertEquals("RESOURCE_CONTAINS", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.CONTAINS))))
+        assertEquals("RESOURCE_OPEN", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.OPENS))))
+        assertEquals("RESOURCE_LOAD", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.LOADS))))
+        assertEquals("RESOURCE_BUNDLE_CANDIDATE", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.BUNDLE_CANDIDATE))))
+        assertEquals("RESOURCE_KEYS", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.ENUMERATES))))
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherFunctionsTest.kt
@@ -542,7 +542,6 @@ class CypherFunctionsTest {
         assertEquals("TYPE", CypherFunctions.call("type", listOf(TypeEdge(from, to, TypeRelation.EXTENDS))))
         assertEquals("CONTROL_FLOW", CypherFunctions.call("type", listOf(ControlFlowEdge(from, to, ControlFlowKind.SEQUENTIAL))))
         assertEquals("RESOURCE_LOOKUP", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.LOOKUP))))
-        assertEquals("RESOURCE_CONTAINS", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.CONTAINS))))
         assertEquals("RESOURCE_OPEN", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.OPENS))))
         assertEquals("RESOURCE_LOAD", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.LOADS))))
         assertEquals("RESOURCE_BUNDLE_CANDIDATE", CypherFunctions.call("type", listOf(ResourceEdge(from, to, ResourceRelation.BUNDLE_CANDIDATE))))

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
@@ -251,6 +251,48 @@ class NodePropertyAccessorTest {
     }
 
     @Test
+    fun `ResourceValueNode properties`() {
+        val node = ResourceValueNode(NodeId(400), "application.yml", "server.port", 8080, "yaml")
+        assertEquals("application.yml", NodePropertyAccessor.getProperty(node, "path"))
+        assertEquals("server.port", NodePropertyAccessor.getProperty(node, "key"))
+        assertEquals(8080, NodePropertyAccessor.getProperty(node, "value"))
+        assertEquals("yaml", NodePropertyAccessor.getProperty(node, "format"))
+        assertNull(NodePropertyAccessor.getProperty(node, "profile"))
+    }
+
+    @Test
+    fun `ResourceFileNode properties`() {
+        val node = ResourceFileNode(NodeId(399), "application.yml", "BOOT-INF/classes", "yaml", "prod")
+        assertEquals("application.yml", NodePropertyAccessor.getProperty(node, "path"))
+        assertEquals("BOOT-INF/classes", NodePropertyAccessor.getProperty(node, "source"))
+        assertEquals("yaml", NodePropertyAccessor.getProperty(node, "format"))
+        assertEquals("prod", NodePropertyAccessor.getProperty(node, "profile"))
+    }
+
+    @Test
+    fun `getAllProperties for ResourceValueNode`() {
+        val node = ResourceValueNode(NodeId(401), "config/application.properties", "feature.x.enabled", true, "properties", "dev")
+        val props = NodePropertyAccessor.getAllProperties(node)
+        assertEquals(401, props["id"])
+        assertEquals("config/application.properties", props["path"])
+        assertEquals("feature.x.enabled", props["key"])
+        assertEquals(true, props["value"])
+        assertEquals("properties", props["format"])
+        assertEquals("dev", props["profile"])
+    }
+
+    @Test
+    fun `getAllProperties for ResourceFileNode`() {
+        val node = ResourceFileNode(NodeId(398), "config/application.properties", "nested.jar", "properties", "dev")
+        val props = NodePropertyAccessor.getAllProperties(node)
+        assertEquals(398, props["id"])
+        assertEquals("config/application.properties", props["path"])
+        assertEquals("nested.jar", props["source"])
+        assertEquals("properties", props["format"])
+        assertEquals("dev", props["profile"])
+    }
+
+    @Test
     fun `resolveNodeLabel maps standard names`() {
         assertEquals(CallSiteNode::class.java, NodePropertyAccessor.resolveNodeLabel("CallSiteNode"))
         assertEquals(CallSiteNode::class.java, NodePropertyAccessor.resolveNodeLabel("callsite"))
@@ -270,6 +312,9 @@ class NodePropertyAccessorTest {
         assertEquals(ParameterNode::class.java, NodePropertyAccessor.resolveNodeLabel("parameter"))
         assertEquals(ReturnNode::class.java, NodePropertyAccessor.resolveNodeLabel("ReturnNode"))
         assertEquals(ReturnNode::class.java, NodePropertyAccessor.resolveNodeLabel("return"))
+        assertEquals(ResourceFileNode::class.java, NodePropertyAccessor.resolveNodeLabel("ResourceFile"))
+        assertEquals(ResourceValueNode::class.java, NodePropertyAccessor.resolveNodeLabel("ResourceValueNode"))
+        assertEquals(ResourceValueNode::class.java, NodePropertyAccessor.resolveNodeLabel("resource"))
         assertEquals(LocalVariable::class.java, NodePropertyAccessor.resolveNodeLabel("LocalVariable"))
         assertEquals(LocalVariable::class.java, NodePropertyAccessor.resolveNodeLabel("local"))
         assertEquals(Node::class.java, NodePropertyAccessor.resolveNodeLabel("node"))
@@ -296,6 +341,9 @@ class NodePropertyAccessorTest {
         assertEquals(TypeEdge::class.java, NodePropertyAccessor.resolveEdgeType("TYPE"))
         assertEquals(ControlFlowEdge::class.java, NodePropertyAccessor.resolveEdgeType("CONTROL_FLOW"))
         assertEquals(ControlFlowEdge::class.java, NodePropertyAccessor.resolveEdgeType("CONTROLFLOW"))
+        assertEquals(ResourceEdge::class.java, NodePropertyAccessor.resolveEdgeType("RESOURCE"))
+        assertEquals(ResourceEdge::class.java, NodePropertyAccessor.resolveEdgeType("RESOURCE_LOOKUP"))
+        assertEquals(ResourceEdge::class.java, NodePropertyAccessor.resolveEdgeType("RESOURCE_CONTAINS"))
     }
 
     @Test
@@ -312,6 +360,8 @@ class NodePropertyAccessorTest {
         assertEquals("FieldNode", NodePropertyAccessor.nodeTypeName(FieldNode(NodeId.next(), FieldDescriptor(type, "f", intType), false)))
         assertEquals("ParameterNode", NodePropertyAccessor.nodeTypeName(ParameterNode(NodeId.next(), 0, intType, method)))
         assertEquals("ReturnNode", NodePropertyAccessor.nodeTypeName(ReturnNode(NodeId.next(), method)))
+        assertEquals("ResourceFileNode", NodePropertyAccessor.nodeTypeName(ResourceFileNode(NodeId.next(), "application.yml", "BOOT-INF/classes", "yaml")))
+        assertEquals("ResourceValueNode", NodePropertyAccessor.nodeTypeName(ResourceValueNode(NodeId.next(), "application.yml", "k", "v", "yaml")))
         assertEquals("LocalVariable", NodePropertyAccessor.nodeTypeName(LocalVariable(NodeId.next(), "x", intType, method)))
     }
 

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
@@ -343,7 +343,6 @@ class NodePropertyAccessorTest {
         assertEquals(ControlFlowEdge::class.java, NodePropertyAccessor.resolveEdgeType("CONTROLFLOW"))
         assertEquals(ResourceEdge::class.java, NodePropertyAccessor.resolveEdgeType("RESOURCE"))
         assertEquals(ResourceEdge::class.java, NodePropertyAccessor.resolveEdgeType("RESOURCE_LOOKUP"))
-        assertEquals(ResourceEdge::class.java, NodePropertyAccessor.resolveEdgeType("RESOURCE_CONTAINS"))
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -1475,4 +1475,61 @@ class QueryPipelineTest {
         assertEquals(2L, result.rows[0]["cnt"])
         assertEquals(99, result.rows[0]["fixed"])
     }
+
+    @Test
+    fun `match resource relationship by generic RESOURCE type and kind property`() {
+        val builder = DefaultGraph.Builder()
+        val resourceFile = ResourceFileNode(NodeId.next(), "messages.properties", "classpath", "properties")
+        val lookupMethod = MethodDescriptor(type, "lookup", emptyList(), stringType)
+        val bundleMethod = MethodDescriptor(
+            TypeDescriptor("java.util.ResourceBundle"),
+            "getString",
+            listOf(stringType),
+            stringType
+        )
+        val callSite = CallSiteNode(NodeId.next(), lookupMethod, bundleMethod, 12, null, emptyList())
+        builder.addNode(resourceFile)
+        builder.addNode(callSite)
+        builder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.LOOKUP))
+        val localPipeline = QueryPipeline(builder.build())
+
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(
+                nodePattern("r", "ResourceFile", mapOf("path" to lit("messages.properties"))),
+                relPattern(type = "RESOURCE", properties = mapOf("kind" to lit("LOOKUP"))),
+                nodePattern("c", "CallSiteNode")
+            ))),
+            CypherClause.Return(listOf(returnItem(prop(variable("c"), "callee_name"), "name")))
+        )
+
+        val result = localPipeline.execute(clauses)
+        assertEquals(1, result.rows.size)
+        assertEquals("getString", result.rows[0]["name"])
+    }
+
+    @Test
+    fun `path variable without explicit edge variable materializes alternating node edge path`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(
+                CypherPattern(
+                    listOf(
+                        nodePattern("a", "IntConstant"),
+                        relPattern(type = "DATAFLOW"),
+                        nodePattern("b", "ParameterNode")
+                    ),
+                    pathVariable = "p"
+                )
+            )),
+            CypherClause.Return(listOf(returnItem(variable("p"), "path")))
+        )
+
+        val result = pipeline.execute(clauses)
+        assertEquals(1, result.rows.size)
+        val path = result.rows[0]["path"]
+        assertTrue(path is List<*>)
+        assertEquals(3, path.size)
+        assertTrue(path[0] is IntConstant)
+        assertTrue(path[1] is DataFlowEdge)
+        assertTrue(path[2] is ParameterNode)
+    }
 }

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
@@ -130,8 +130,12 @@ class ExploreCommand : Callable<Int> {
             )
         }
 
-        app.get("/api/resources/content") { ctx ->
-            val path = ctx.queryParam("path") ?: run { ctx.status(400).result("Missing 'path' parameter"); return@get }
+        app.get("/api/resources/{path}*") { ctx ->
+            val path = ctx.path().removePrefix("/api/resources/").trimStart('/')
+            if (path.isBlank()) {
+                ctx.status(404).result("Resource not found")
+                return@get
+            }
             try {
                 val entry = resolveResourceEntry(graph, path)
                 val bytes = graph.resources.open(path).use { it.readBytes() }
@@ -164,6 +168,14 @@ class ExploreCommand : Callable<Int> {
                     "endpoints" to endpoints
                 )
             )
+        }
+
+        app.get("/openapi.json") { ctx ->
+            ctx.json(buildOpenApiSpec())
+        }
+
+        app.get("/swagger.json") { ctx ->
+            ctx.json(buildOpenApiSpec())
         }
 
         app.get("/api/overview") { ctx ->
@@ -329,6 +341,237 @@ class ExploreCommand : Callable<Int> {
 
     private fun resolveResourceEntry(graph: Graph, path: String): ResourceEntry? =
         graph.resources.list("**").firstOrNull { it.path == path }
+
+    internal fun buildOpenApiSpec(): Map<String, Any?> = mapOf(
+        "openapi" to "3.0.3",
+        "info" to mapOf(
+            "title" to "Graphite Explore API",
+            "version" to "1.0.0",
+            "description" to "Machine-readable API surface for Graphite Explore."
+        ),
+        "paths" to mapOf(
+            "/api/info" to mapOf(
+                "get" to operation(
+                    "Get graph summary statistics",
+                    parameters = emptyList(),
+                    responses = mapOf("200" to response("Graph statistics"))
+                )
+            ),
+            "/api/nodes" to mapOf(
+                "get" to operation(
+                    "List graph nodes",
+                    parameters = listOf(
+                        queryParameter("type", "string", false, "Optional node label/type filter"),
+                        queryParameter("limit", "integer", false, "Maximum number of nodes to return")
+                    ),
+                    responses = mapOf("200" to response("Node list"))
+                )
+            ),
+            "/api/node/{id}" to mapOf(
+                "get" to operation(
+                    "Fetch a single node by id",
+                    parameters = listOf(
+                        pathParameter("id", "integer", "Node identifier")
+                    ),
+                    responses = mapOf(
+                        "200" to response("Node payload"),
+                        "400" to response("Invalid node id"),
+                        "404" to response("Node not found")
+                    )
+                )
+            ),
+            "/api/node/{id}/outgoing" to mapOf(
+                "get" to operation(
+                    "List outgoing edges for a node",
+                    parameters = listOf(pathParameter("id", "integer", "Node identifier")),
+                    responses = mapOf(
+                        "200" to response("Outgoing edges"),
+                        "400" to response("Invalid node id")
+                    )
+                )
+            ),
+            "/api/node/{id}/incoming" to mapOf(
+                "get" to operation(
+                    "List incoming edges for a node",
+                    parameters = listOf(pathParameter("id", "integer", "Node identifier")),
+                    responses = mapOf(
+                        "200" to response("Incoming edges"),
+                        "400" to response("Invalid node id")
+                    )
+                )
+            ),
+            "/api/call-sites" to mapOf(
+                "get" to operation(
+                    "List call sites",
+                    parameters = listOf(
+                        queryParameter("class", "string", false, "Optional caller/callee class filter"),
+                        queryParameter("method", "string", false, "Optional method name filter"),
+                        queryParameter("limit", "integer", false, "Maximum number of results")
+                    ),
+                    responses = mapOf("200" to response("Call site list"))
+                )
+            ),
+            "/api/methods" to mapOf(
+                "get" to operation(
+                    "List methods",
+                    parameters = listOf(
+                        queryParameter("class", "string", false, "Optional declaring class filter"),
+                        queryParameter("name", "string", false, "Optional method name filter"),
+                        queryParameter("limit", "integer", false, "Maximum number of results")
+                    ),
+                    responses = mapOf("200" to response("Method list"))
+                )
+            ),
+            "/api/annotations" to mapOf(
+                "get" to operation(
+                    "Fetch member annotations",
+                    parameters = listOf(
+                        queryParameter("class", "string", true, "Declaring class name"),
+                        queryParameter("member", "string", true, "Member name")
+                    ),
+                    responses = mapOf(
+                        "200" to response("Annotation map"),
+                        "400" to response("Missing required parameters")
+                    )
+                )
+            ),
+            "/api/resources" to mapOf(
+                "get" to operation(
+                    "List persisted resources",
+                    parameters = listOf(
+                        queryParameter("pattern", "string", false, "Glob pattern, defaults to **"),
+                        queryParameter("limit", "integer", false, "Maximum number of results")
+                    ),
+                    responses = mapOf("200" to response("Resource listing"))
+                )
+            ),
+            "/api/resources/{path}" to mapOf(
+                "get" to operation(
+                    "Read persisted raw resource content",
+                    parameters = listOf(
+                        pathParameter("path", "string", "Resource path inside the graph payload; may include nested segments")
+                    ),
+                    responses = mapOf(
+                        "200" to response("Raw resource content"),
+                        "404" to response("Resource not found")
+                    )
+                )
+            ),
+            "/api/api-spec" to mapOf(
+                "get" to operation(
+                    "Extract framework API endpoints from the graph",
+                    parameters = listOf(
+                        queryParameter("limit", "integer", false, "Maximum number of endpoints"),
+                        queryParameter("class", "string", false, "Optional controller class filter")
+                    ),
+                    responses = mapOf("200" to response("Extracted framework API specification"))
+                )
+            ),
+            "/api/overview" to mapOf(
+                "get" to operation(
+                    "Build a class-level overview graph",
+                    parameters = listOf(
+                        queryParameter("limit", "integer", false, "Maximum number of classes")
+                    ),
+                    responses = mapOf("200" to response("Overview graph"))
+                )
+            ),
+            "/api/subgraph" to mapOf(
+                "get" to operation(
+                    "Build a local subgraph around a node",
+                    parameters = listOf(
+                        queryParameter("center", "integer", true, "Center node id"),
+                        queryParameter("depth", "integer", false, "Traversal depth")
+                    ),
+                    responses = mapOf(
+                        "200" to response("Subgraph"),
+                        "400" to response("Missing or invalid parameters")
+                    )
+                )
+            ),
+            "/api/cypher" to mapOf(
+                "get" to operation(
+                    "Execute a Cypher query via query string",
+                    parameters = listOf(
+                        queryParameter("query", "string", true, "Cypher query text")
+                    ),
+                    responses = mapOf(
+                        "200" to response("Cypher result"),
+                        "400" to response("Missing or invalid query")
+                    )
+                ),
+                "post" to operation(
+                    "Execute a Cypher query via JSON body",
+                    parameters = emptyList(),
+                    requestBody = mapOf(
+                        "required" to true,
+                        "content" to mapOf(
+                            "application/json" to mapOf(
+                                "schema" to mapOf(
+                                    "type" to "object",
+                                    "properties" to mapOf(
+                                        "query" to mapOf(
+                                            "type" to "string",
+                                            "description" to "Cypher query text"
+                                        )
+                                    ),
+                                    "required" to listOf("query")
+                                )
+                            )
+                        )
+                    ),
+                    responses = mapOf(
+                        "200" to response("Cypher result"),
+                        "400" to response("Missing or invalid query")
+                    )
+                )
+            ),
+            "/openapi.json" to mapOf(
+                "get" to operation(
+                    "Fetch this OpenAPI document",
+                    parameters = emptyList(),
+                    responses = mapOf("200" to response("OpenAPI specification"))
+                )
+            ),
+            "/swagger.json" to mapOf(
+                "get" to operation(
+                    "Fetch this API document via Swagger-compatible alias",
+                    parameters = emptyList(),
+                    responses = mapOf("200" to response("OpenAPI specification"))
+                )
+            )
+        )
+    )
+
+    private fun operation(
+        summary: String,
+        parameters: List<Map<String, Any?>>,
+        responses: Map<String, Any?>,
+        requestBody: Map<String, Any?>? = null
+    ): Map<String, Any?> = buildMap {
+        put("summary", summary)
+        put("responses", responses)
+        if (parameters.isNotEmpty()) put("parameters", parameters)
+        if (requestBody != null) put("requestBody", requestBody)
+    }
+
+    private fun queryParameter(name: String, type: String, required: Boolean, description: String): Map<String, Any?> =
+        parameter("query", name, type, required, description)
+
+    private fun pathParameter(name: String, type: String, description: String): Map<String, Any?> =
+        parameter("path", name, type, true, description)
+
+    private fun parameter(location: String, name: String, type: String, required: Boolean, description: String): Map<String, Any?> =
+        mapOf(
+            "in" to location,
+            "name" to name,
+            "required" to required,
+            "description" to description,
+            "schema" to mapOf("type" to type)
+        )
+
+    private fun response(description: String): Map<String, Any?> =
+        mapOf("description" to description)
 
     private fun listResources(graph: Graph, pattern: String, limit: Int): List<Map<String, Any?>> {
         return graph.resources.list(pattern)

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
@@ -5,10 +5,13 @@ import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.cypher.CypherExecutor
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.input.ResourceEntry
 import io.johnsonlee.graphite.webgraph.GraphStore
 import io.javalin.Javalin
 import io.javalin.json.JavalinGson
 import picocli.CommandLine.*
+import java.io.IOException
+import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.util.concurrent.Callable
 
@@ -111,6 +114,56 @@ class ExploreCommand : Callable<Int> {
             val className = ctx.queryParam("class") ?: run { ctx.status(400).result("Missing 'class' parameter"); return@get }
             val memberName = ctx.queryParam("member") ?: run { ctx.status(400).result("Missing 'member' parameter"); return@get }
             ctx.json(graph.memberAnnotations(className, memberName))
+        }
+
+        app.get("/api/resources") { ctx ->
+            val pattern = ctx.queryParam("pattern") ?: "**"
+            val limit = ctx.queryParam("limit")?.toIntOrNull() ?: 100
+            val resources = listResources(graph, pattern, limit)
+            ctx.json(
+                mapOf(
+                    "pattern" to pattern,
+                    "limit" to limit,
+                    "count" to resources.size,
+                    "resources" to resources
+                )
+            )
+        }
+
+        app.get("/api/resources/content") { ctx ->
+            val path = ctx.queryParam("path") ?: run { ctx.status(400).result("Missing 'path' parameter"); return@get }
+            try {
+                val entry = resolveResourceEntry(graph, path)
+                val bytes = graph.resources.open(path).use { it.readBytes() }
+                ctx.json(
+                    mapOf(
+                        "path" to path,
+                        "source" to entry?.source,
+                        "derived" to false,
+                        "size" to bytes.size,
+                        "content" to bytes.toString(Charsets.UTF_8)
+                    )
+                )
+            } catch (_: IOException) {
+                ctx.status(404).result("Resource not found: $path")
+            }
+        }
+
+        app.get("/api/api-spec") { ctx ->
+            val limit = ctx.queryParam("limit")?.toIntOrNull() ?: 200
+            val classPattern = ctx.queryParam("class")
+            val endpoints = extractApiSpec(graph)
+                .asSequence()
+                .filter { classPattern == null || it["class"] == classPattern }
+                .take(limit)
+                .toList()
+            ctx.json(
+                mapOf(
+                    "framework" to "spring-web",
+                    "count" to endpoints.size,
+                    "endpoints" to endpoints
+                )
+            )
         }
 
         app.get("/api/overview") { ctx ->
@@ -223,4 +276,111 @@ class ExploreCommand : Callable<Int> {
         visit(center, depth)
         return mapOf("nodes" to nodes, "edges" to edges)
     }
+
+    internal fun extractApiSpec(graph: Graph): List<Map<String, Any?>> {
+        val mappingAnnotations = setOf(
+            "org.springframework.web.bind.annotation.RequestMapping",
+            "org.springframework.web.bind.annotation.GetMapping",
+            "org.springframework.web.bind.annotation.PostMapping",
+            "org.springframework.web.bind.annotation.PutMapping",
+            "org.springframework.web.bind.annotation.DeleteMapping",
+            "org.springframework.web.bind.annotation.PatchMapping"
+        )
+
+        return graph.methods(MethodPattern())
+            .flatMap { method ->
+                val className = method.declaringClass.className
+                val classAnnotations = graph.memberAnnotations(className, "<class>")
+                val memberAnnotations = graph.memberAnnotations(className, method.name)
+                val classBasePaths = extractPaths(classAnnotations["org.springframework.web.bind.annotation.RequestMapping"])
+                val mappingEntries = memberAnnotations
+                    .filterKeys { it in mappingAnnotations }
+                    .entries
+
+                mappingEntries.asSequence().flatMap { (annotationName, values) ->
+                    val methodPaths = extractPaths(values)
+                    val httpMethods = extractHttpMethods(annotationName, values)
+                    combinePaths(classBasePaths, methodPaths).asSequence().flatMap { path ->
+                        httpMethods.asSequence().map { httpMethod ->
+                            mapOf(
+                                "class" to className,
+                                "member" to method.name,
+                                "signature" to method.signature,
+                                "httpMethod" to httpMethod,
+                                "path" to path,
+                                "annotation" to annotationName,
+                                "returns" to method.returnType.className,
+                                "parameters" to method.parameterTypes.map { it.className },
+                                "annotations" to memberAnnotations.keys.sorted()
+                            )
+                        }
+                    }
+                }
+            }
+            .sortedWith(
+                compareBy<Map<String, Any?>>(
+                    { it["path"] as String },
+                    { it["httpMethod"] as String },
+                    { it["signature"] as String }
+                )
+            )
+            .toList()
+    }
+
+    private fun resolveResourceEntry(graph: Graph, path: String): ResourceEntry? =
+        graph.resources.list("**").firstOrNull { it.path == path }
+
+    private fun listResources(graph: Graph, pattern: String, limit: Int): List<Map<String, Any?>> {
+        return graph.resources.list(pattern)
+            .map { entry ->
+                mapOf("path" to entry.path, "source" to entry.source, "derived" to false)
+            }
+            .take(limit)
+            .toList()
+    }
+
+    private fun extractPaths(annotationValues: Map<String, Any?>?): List<String> {
+        val paths = extractStringValues(annotationValues?.get("path")) + extractStringValues(annotationValues?.get("value"))
+        return if (paths.isEmpty()) listOf("/") else paths
+    }
+
+    private fun extractHttpMethods(annotationName: String, annotationValues: Map<String, Any?>): List<String> {
+        return when (annotationName) {
+            "org.springframework.web.bind.annotation.GetMapping" -> listOf("GET")
+            "org.springframework.web.bind.annotation.PostMapping" -> listOf("POST")
+            "org.springframework.web.bind.annotation.PutMapping" -> listOf("PUT")
+            "org.springframework.web.bind.annotation.DeleteMapping" -> listOf("DELETE")
+            "org.springframework.web.bind.annotation.PatchMapping" -> listOf("PATCH")
+            else -> extractStringValues(annotationValues["method"]).ifEmpty { listOf("REQUEST") }
+        }
+    }
+
+    private fun extractStringValues(value: Any?): List<String> = when (value) {
+        null -> emptyList()
+        is String -> listOf(value)
+        is Iterable<*> -> value.filterIsInstance<String>()
+        is Array<*> -> value.filterIsInstance<String>()
+        else -> emptyList()
+    }
+
+    private fun combinePaths(basePaths: List<String>, methodPaths: List<String>): List<String> {
+        val bases = if (basePaths.isEmpty()) listOf("/") else basePaths
+        val methods = if (methodPaths.isEmpty()) listOf("/") else methodPaths
+        return bases.asSequence()
+            .flatMap { base -> methods.asSequence().map { method -> normalizePath(base, method) } }
+            .distinct()
+            .toList()
+    }
+
+    private fun normalizePath(base: String, method: String): String {
+        val basePart = base.trim().trim('/')
+        val methodPart = method.trim().trim('/')
+        return when {
+            basePart.isEmpty() && methodPart.isEmpty() -> "/"
+            basePart.isEmpty() -> "/$methodPart"
+            methodPart.isEmpty() -> "/$basePart"
+            else -> "/$basePart/$methodPart"
+        }
+    }
+
 }

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/Helpers.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/Helpers.kt
@@ -5,6 +5,8 @@ import io.johnsonlee.graphite.core.*
 internal fun resolveNodeType(type: String?): Class<out Node> = when (type?.lowercase()) {
     "callsite", "callsitenode" -> CallSiteNode::class.java
     "constant", "constantnode" -> ConstantNode::class.java
+    "resourcefile", "resourcefilenode" -> ResourceFileNode::class.java
+    "resource", "resourcevalue", "resourcevaluenode" -> ResourceValueNode::class.java
     "field", "fieldnode" -> FieldNode::class.java
     "parameter", "parameternode" -> ParameterNode::class.java
     "return", "returnnode" -> ReturnNode::class.java
@@ -22,6 +24,8 @@ internal fun formatNode(node: Node): String = when (node) {
     is DoubleConstant -> "DoubleConstant[${node.id}] = ${node.value}"
     is BooleanConstant -> "BooleanConstant[${node.id}] = ${node.value}"
     is NullConstant -> "NullConstant[${node.id}]"
+    is ResourceFileNode -> "ResourceFile[${node.id}] ${node.path} (${node.source})"
+    is ResourceValueNode -> "ResourceValue[${node.id}] ${node.path}#${node.key} = ${node.value}"
     is FieldNode -> "Field[${node.id}] ${node.descriptor.declaringClass.simpleName}.${node.descriptor.name}: ${node.descriptor.type.simpleName}"
     is ParameterNode -> "Parameter[${node.id}] ${node.method.name}#${node.index}: ${node.type.simpleName}"
     is ReturnNode -> "Return[${node.id}] ${node.method.name}"
@@ -39,6 +43,25 @@ internal fun nodeToMap(node: Node): Map<String, Any?> = when (node) {
     is DoubleConstant -> mapOf("type" to "DoubleConstant", "id" to node.id.value, "value" to node.value, "label" to "${node.value}d")
     is BooleanConstant -> mapOf("type" to "BooleanConstant", "id" to node.id.value, "value" to node.value, "label" to "${node.value}")
     is NullConstant -> mapOf("type" to "NullConstant", "id" to node.id.value, "label" to "null")
+    is ResourceFileNode -> mapOf(
+        "type" to "ResourceFileNode",
+        "id" to node.id.value,
+        "path" to node.path,
+        "source" to node.source,
+        "format" to node.format,
+        "profile" to node.profile,
+        "label" to node.path
+    )
+    is ResourceValueNode -> mapOf(
+        "type" to "ResourceValueNode",
+        "id" to node.id.value,
+        "path" to node.path,
+        "key" to node.key,
+        "value" to node.value,
+        "format" to node.format,
+        "profile" to node.profile,
+        "label" to "${node.key}=${node.value}"
+    )
     is FieldNode -> mapOf("type" to "FieldNode", "id" to node.id.value, "class" to node.descriptor.declaringClass.className, "name" to node.descriptor.name, "fieldType" to node.descriptor.type.className, "label" to "${node.descriptor.declaringClass.simpleName}.${node.descriptor.name}")
     is ParameterNode -> mapOf("type" to "ParameterNode", "id" to node.id.value, "index" to node.index, "paramType" to node.type.className, "method" to node.method.signature, "label" to "param#${node.index}")
     is ReturnNode -> mapOf("type" to "ReturnNode", "id" to node.id.value, "method" to node.method.signature, "label" to "return")
@@ -51,4 +74,5 @@ internal fun edgeToMap(edge: Edge): Map<String, Any?> = when (edge) {
     is CallEdge -> mapOf("from" to edge.from.value, "to" to edge.to.value, "type" to "Call", "virtual" to edge.isVirtual, "dynamic" to edge.isDynamic)
     is TypeEdge -> mapOf("from" to edge.from.value, "to" to edge.to.value, "type" to "Type", "kind" to edge.kind.name)
     is ControlFlowEdge -> mapOf("from" to edge.from.value, "to" to edge.to.value, "type" to "ControlFlow", "kind" to edge.kind.name)
+    is ResourceEdge -> mapOf("from" to edge.from.value, "to" to edge.to.value, "type" to "Resource", "kind" to edge.kind.name)
 }

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -7,9 +7,12 @@ import io.javalin.Javalin
 import io.javalin.json.JavalinGson
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.input.ResourceAccessor
+import io.johnsonlee.graphite.input.ResourceEntry
 import io.johnsonlee.graphite.webgraph.GraphStore
 import org.junit.AfterClass
 import org.junit.BeforeClass
+import java.io.ByteArrayInputStream
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URI
@@ -41,11 +44,33 @@ class ExploreCommandTest {
         private lateinit var callSiteNode: CallSiteNode
         private lateinit var enumConstNode: EnumConstant
         private lateinit var fieldNode: FieldNode
+        private lateinit var resourceFileNode: ResourceFileNode
+        private lateinit var propertyFileNode: ResourceFileNode
+        private val resources = mapOf(
+            "application.yml" to "server:\n  port: 8080\nfeature:\n  enabled: true\n",
+            "config/application.properties" to "feature.mode=shadow\n"
+        )
+
+        private class TestResourceAccessor(
+            private val resources: Map<String, String>
+        ) : ResourceAccessor {
+            override fun list(pattern: String): Sequence<ResourceEntry> {
+                val matcher = java.nio.file.FileSystems.getDefault().getPathMatcher("glob:$pattern")
+                return resources.keys.asSequence()
+                    .filter { matcher.matches(Path.of(it)) }
+                    .map { ResourceEntry(it, "test-fixture") }
+            }
+
+            override fun open(path: String) =
+                resources[path]?.let { ByteArrayInputStream(it.toByteArray()) }
+                    ?: throw java.io.IOException("Resource not found: $path")
+        }
 
         @BeforeClass
         @JvmStatic
         fun setUp() {
             val builder = DefaultGraph.Builder()
+                .setResources(TestResourceAccessor(resources))
 
             paramNode = ParameterNode(NodeId.next(), 0, TypeDescriptor("int"), barMethod)
             localNode = LocalVariable(NodeId.next(), "x", TypeDescriptor("int"), barMethod)
@@ -55,6 +80,18 @@ class ExploreCommandTest {
             callSiteNode = CallSiteNode(NodeId.next(), barMethod, bazMethod, 10, null, listOf(paramNode.id))
             enumConstNode = EnumConstant(NodeId.next(), TypeDescriptor("com.example.Status"), "ACTIVE", listOf(1, "active"))
             fieldNode = FieldNode(NodeId.next(), FieldDescriptor(fooType, "name", TypeDescriptor("java.lang.String")), false)
+            resourceFileNode = ResourceFileNode(
+                NodeId.next(),
+                "application.yml",
+                "test-fixture",
+                "yaml"
+            )
+            propertyFileNode = ResourceFileNode(
+                NodeId.next(),
+                "config/application.properties",
+                "test-fixture",
+                "properties"
+            )
 
             builder.addNode(paramNode)
             builder.addNode(localNode)
@@ -64,10 +101,13 @@ class ExploreCommandTest {
             builder.addNode(callSiteNode)
             builder.addNode(enumConstNode)
             builder.addNode(fieldNode)
+            builder.addNode(resourceFileNode)
+            builder.addNode(propertyFileNode)
 
             builder.addEdge(DataFlowEdge(paramNode.id, localNode.id, DataFlowKind.ASSIGN))
             builder.addEdge(DataFlowEdge(intConstNode.id, localNode.id, DataFlowKind.ASSIGN))
             builder.addEdge(DataFlowEdge(localNode.id, returnNode.id, DataFlowKind.RETURN_VALUE))
+            builder.addEdge(ResourceEdge(propertyFileNode.id, callSiteNode.id, ResourceRelation.LOOKUP))
             builder.addEdge(CallEdge(callSiteNode.id, callSiteNode.id, isVirtual = false))
 
             builder.addMethod(barMethod)
@@ -80,6 +120,10 @@ class ExploreCommandTest {
 
             builder.addMemberAnnotation("com.example.Foo", "bar", "javax.annotation.Nullable", emptyMap())
             builder.addMemberAnnotation(
+                "com.example.Foo", "<class>", "org.springframework.web.bind.annotation.RequestMapping",
+                mapOf("value" to "/v1")
+            )
+            builder.addMemberAnnotation(
                 "com.example.Foo", "bar", "org.springframework.web.bind.annotation.GetMapping",
                 mapOf("value" to "/api/bar")
             )
@@ -87,7 +131,6 @@ class ExploreCommandTest {
             val graph = builder.build()
             graphDir = Files.createTempDirectory("explore-test")
             GraphStore.save(graph, graphDir)
-
             val loadedGraph = GraphStore.load(graphDir)
             app = Javalin.create { config ->
                 config.jsonMapper(JavalinGson(GsonBuilder().setPrettyPrinting().create()))
@@ -154,8 +197,8 @@ class ExploreCommandTest {
         val (code, body) = get("/api/info")
         assertEquals(200, code, "Expected 200 but got $code, body: $body")
         val info: Map<String, Double> = parseJson(body)
-        assertEquals(8.0, info["nodes"])
-        assertEquals(4.0, info["edges"])
+        assertEquals(10.0, info["nodes"])
+        assertEquals(5.0, info["edges"])
         assertEquals(3.0, info["methods"])
         assertEquals(1.0, info["callSites"])
     }
@@ -169,7 +212,7 @@ class ExploreCommandTest {
         val (code, body) = get("/api/nodes?limit=100")
         assertEquals(200, code)
         val nodes: List<Map<String, Any?>> = parseJson(body)
-        assertEquals(8, nodes.size)
+        assertEquals(10, nodes.size)
     }
 
     @Test
@@ -393,6 +436,96 @@ class ExploreCommandTest {
         assertEquals(200, code, "Expected 200, body: $body")
         val annotations: Map<String, Map<String, Any?>> = parseJson(body)
         assertEquals(0, annotations.size)
+    }
+
+    // ========================================================================
+    // /api/resources
+    // ========================================================================
+
+    @Test
+    fun `GET api resources returns matching resources`() {
+        val (code, body) = get("/api/resources?pattern=**&limit=10")
+        assertEquals(200, code, "Expected 200, body: $body")
+        val result: Map<String, Any?> = parseJson(body)
+        assertEquals(2.0, result["count"])
+        @Suppress("UNCHECKED_CAST")
+        val resourceEntries = result["resources"] as List<Map<String, Any?>>
+        assertEquals(2, resourceEntries.size)
+        assertTrue(resourceEntries.any { it["path"] == "application.yml" })
+        assertTrue(resourceEntries.all { it["source"] == "test-fixture" })
+        assertTrue(resourceEntries.all { it["derived"] == false })
+    }
+
+    @Test
+    fun `GET api resources respects glob pattern`() {
+        val (code, body) = get("/api/resources?pattern=**/*.properties")
+        assertEquals(200, code, "Expected 200, body: $body")
+        val result: Map<String, Any?> = parseJson(body)
+        @Suppress("UNCHECKED_CAST")
+        val resourceEntries = result["resources"] as List<Map<String, Any?>>
+        assertEquals(1, resourceEntries.size)
+        assertEquals("config/application.properties", resourceEntries.single()["path"])
+    }
+
+    @Test
+    fun `GET api resource content returns text payload`() {
+        val (code, body) = get("/api/resources/content?path=application.yml")
+        assertEquals(200, code, "Expected 200, body: $body")
+        val result: Map<String, Any?> = parseJson(body)
+        assertEquals("application.yml", result["path"])
+        assertEquals("test-fixture", result["source"])
+        assertEquals(false, result["derived"])
+        assertTrue((result["content"] as String).contains("server:"))
+    }
+
+    @Test
+    fun `GET api resource content returns 404 for missing path`() {
+        val (code, body) = get("/api/resources/content?path=missing.yml")
+        assertEquals(404, code, "Expected 404, body: $body")
+    }
+
+    @Test
+    fun `GET api resource content returns 400 when path missing`() {
+        val (code, body) = get("/api/resources/content")
+        assertEquals(400, code, "Expected 400, body: $body")
+    }
+
+    // ========================================================================
+    // /api/api-spec
+    // ========================================================================
+
+    @Test
+    fun `GET api api-spec returns Spring endpoints`() {
+        val (code, body) = get("/api/api-spec")
+        assertEquals(200, code, "Expected 200, body: $body")
+        val result: Map<String, Any?> = parseJson(body)
+        assertEquals("spring-web", result["framework"])
+        @Suppress("UNCHECKED_CAST")
+        val endpoints = result["endpoints"] as List<Map<String, Any?>>
+        assertEquals(1, endpoints.size)
+        val endpoint = endpoints.single()
+        assertEquals("com.example.Foo", endpoint["class"])
+        assertEquals("bar", endpoint["member"])
+        assertEquals("GET", endpoint["httpMethod"])
+        assertEquals("/v1/api/bar", endpoint["path"])
+        assertEquals(barMethod.signature, endpoint["signature"])
+    }
+
+    @Test
+    fun `GET api api-spec supports class filter`() {
+        val (code, body) = get("/api/api-spec?class=com.example.Foo")
+        assertEquals(200, code, "Expected 200, body: $body")
+        val result: Map<String, Any?> = parseJson(body)
+        @Suppress("UNCHECKED_CAST")
+        val endpoints = result["endpoints"] as List<Map<String, Any?>>
+        assertEquals(1, endpoints.size)
+
+        val (missingCode, missingBody) = get("/api/api-spec?class=com.example.Baz")
+        assertEquals(200, missingCode, "Expected 200, body: $missingBody")
+        val missingResult: Map<String, Any?> = parseJson(missingBody)
+        @Suppress("UNCHECKED_CAST")
+        val missingEndpoints = missingResult["endpoints"] as List<Map<String, Any?>>
+        assertTrue(missingEndpoints.isEmpty())
     }
 
     // ========================================================================

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -528,6 +528,111 @@ class ExploreCommandTest {
         assertTrue(missingEndpoints.isEmpty())
     }
 
+    @Test
+    fun `extractApiSpec handles RequestMapping arrays iterables and default request method`() {
+        val method = MethodDescriptor(
+            TypeDescriptor("com.example.RequestController"),
+            "handle",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val fallbackMethod = MethodDescriptor(
+            TypeDescriptor("com.example.RequestController"),
+            "fallback",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val graph = DefaultGraph.Builder()
+            .addMethod(method)
+            .addMethod(fallbackMethod)
+            .addMemberAnnotation(
+                "com.example.RequestController",
+                "<class>",
+                "org.springframework.web.bind.annotation.RequestMapping",
+                mapOf("value" to arrayOf("/v2", "/v1"))
+            )
+            .addMemberAnnotation(
+                "com.example.RequestController",
+                "handle",
+                "org.springframework.web.bind.annotation.RequestMapping",
+                mapOf(
+                    "path" to listOf("/beta", "/alpha"),
+                    "method" to arrayOf("POST", "PATCH")
+                )
+            )
+            .addMemberAnnotation(
+                "com.example.RequestController",
+                "fallback",
+                "org.springframework.web.bind.annotation.RequestMapping",
+                emptyMap()
+            )
+            .build()
+
+        val endpoints = ExploreCommand().extractApiSpec(graph)
+
+        assertEquals(10, endpoints.size)
+        val fallbackEndpoints = endpoints.filter { it["member"] == "fallback" }
+        assertEquals(2, fallbackEndpoints.size)
+        assertTrue(fallbackEndpoints.all { it["httpMethod"] == "REQUEST" })
+        assertEquals(setOf("/v1", "/v2"), fallbackEndpoints.map { it["path"] }.toSet())
+
+        val handlePaths = endpoints.filter { it["member"] == "handle" }.map { it["path"] as String }
+        assertEquals(
+            listOf("/v1/alpha", "/v1/alpha", "/v1/beta", "/v1/beta", "/v2/alpha", "/v2/alpha", "/v2/beta", "/v2/beta"),
+            handlePaths
+        )
+        val handleMethods = endpoints.filter { it["member"] == "handle" }.map { it["httpMethod"] as String }.toSet()
+        assertEquals(setOf("PATCH", "POST"), handleMethods)
+        assertEquals("/v1", endpoints.first()["path"])
+    }
+
+    @Test
+    fun `private API spec helpers cover all HTTP mapping branches`() {
+        val explore = ExploreCommand()
+        val extractHttpMethods = ExploreCommand::class.java.getDeclaredMethod(
+            "extractHttpMethods",
+            String::class.java,
+            Map::class.java
+        ).apply { isAccessible = true }
+        val extractStringValues = ExploreCommand::class.java.getDeclaredMethod(
+            "extractStringValues",
+            Any::class.java
+        ).apply { isAccessible = true }
+        val combinePaths = ExploreCommand::class.java.getDeclaredMethod(
+            "combinePaths",
+            List::class.java,
+            List::class.java
+        ).apply { isAccessible = true }
+
+        assertEquals(listOf("GET"), extractHttpMethods.invoke(explore, "org.springframework.web.bind.annotation.GetMapping", emptyMap<String, Any?>()))
+        assertEquals(listOf("POST"), extractHttpMethods.invoke(explore, "org.springframework.web.bind.annotation.PostMapping", emptyMap<String, Any?>()))
+        assertEquals(listOf("PUT"), extractHttpMethods.invoke(explore, "org.springframework.web.bind.annotation.PutMapping", emptyMap<String, Any?>()))
+        assertEquals(listOf("DELETE"), extractHttpMethods.invoke(explore, "org.springframework.web.bind.annotation.DeleteMapping", emptyMap<String, Any?>()))
+        assertEquals(listOf("PATCH"), extractHttpMethods.invoke(explore, "org.springframework.web.bind.annotation.PatchMapping", emptyMap<String, Any?>()))
+        assertEquals(
+            listOf("HEAD"),
+            extractHttpMethods.invoke(
+                explore,
+                "org.springframework.web.bind.annotation.RequestMapping",
+                mapOf("method" to "HEAD")
+            )
+        )
+        assertEquals(
+            listOf("REQUEST"),
+            extractHttpMethods.invoke(explore, "org.springframework.web.bind.annotation.RequestMapping", mapOf("method" to 123))
+        )
+
+        assertEquals(emptyList<String>(), extractStringValues.invoke(explore, null))
+        assertEquals(listOf("one"), extractStringValues.invoke(explore, "one"))
+        assertEquals(listOf("two"), extractStringValues.invoke(explore, listOf("two", 2)))
+        assertEquals(listOf("three"), extractStringValues.invoke(explore, arrayOf("three", 3)))
+        assertEquals(emptyList<String>(), extractStringValues.invoke(explore, 42))
+
+        assertEquals(listOf("/"), combinePaths.invoke(explore, emptyList<String>(), emptyList<String>()))
+        assertEquals(listOf("/users"), combinePaths.invoke(explore, listOf("/"), listOf("/users")))
+        assertEquals(listOf("/api"), combinePaths.invoke(explore, listOf("/api"), emptyList<String>()))
+    }
+
     // ========================================================================
     // /api/overview
     // ========================================================================

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -469,7 +469,7 @@ class ExploreCommandTest {
 
     @Test
     fun `GET api resource content returns text payload`() {
-        val (code, body) = get("/api/resources/content?path=application.yml")
+        val (code, body) = get("/api/resources/application.yml")
         assertEquals(200, code, "Expected 200, body: $body")
         val result: Map<String, Any?> = parseJson(body)
         assertEquals("application.yml", result["path"])
@@ -480,14 +480,37 @@ class ExploreCommandTest {
 
     @Test
     fun `GET api resource content returns 404 for missing path`() {
-        val (code, body) = get("/api/resources/content?path=missing.yml")
+        val (code, body) = get("/api/resources/missing.yml")
         assertEquals(404, code, "Expected 404, body: $body")
     }
 
     @Test
-    fun `GET api resource content returns 400 when path missing`() {
-        val (code, body) = get("/api/resources/content")
-        assertEquals(400, code, "Expected 400, body: $body")
+    fun `GET openapi json exposes discoverable explore API`() {
+        val (code, body) = get("/openapi.json")
+        assertEquals(200, code, "Expected 200, body: $body")
+        val result: Map<String, Any?> = parseJson(body)
+        assertEquals("3.0.3", result["openapi"])
+        @Suppress("UNCHECKED_CAST")
+        val paths = result["paths"] as Map<String, Map<String, Any?>>
+        assertTrue(paths.containsKey("/api/cypher"))
+        assertTrue(paths.containsKey("/api/api-spec"))
+        assertTrue(paths.containsKey("/api/resources/{path}"))
+        @Suppress("UNCHECKED_CAST")
+        val cypher = paths["/api/cypher"] as Map<String, Map<String, Any?>>
+        assertTrue(cypher.containsKey("get"))
+        assertTrue(cypher.containsKey("post"))
+        @Suppress("UNCHECKED_CAST")
+        val post = cypher["post"] as Map<String, Any?>
+        assertTrue(post.containsKey("requestBody"))
+    }
+
+    @Test
+    fun `GET swagger json aliases the OpenAPI document`() {
+        val (openapiCode, openapiBody) = get("/openapi.json")
+        val (swaggerCode, swaggerBody) = get("/swagger.json")
+        assertEquals(200, openapiCode)
+        assertEquals(200, swaggerCode)
+        assertEquals(parseJson<Map<String, Any?>>(openapiBody), parseJson<Map<String, Any?>>(swaggerBody))
     }
 
     // ========================================================================
@@ -631,6 +654,23 @@ class ExploreCommandTest {
         assertEquals(listOf("/"), combinePaths.invoke(explore, emptyList<String>(), emptyList<String>()))
         assertEquals(listOf("/users"), combinePaths.invoke(explore, listOf("/"), listOf("/users")))
         assertEquals(listOf("/api"), combinePaths.invoke(explore, listOf("/api"), emptyList<String>()))
+    }
+
+    @Test
+    fun `buildOpenApiSpec describes cypher and resource endpoints`() {
+        val spec = ExploreCommand().buildOpenApiSpec()
+        assertEquals("3.0.3", spec["openapi"])
+        @Suppress("UNCHECKED_CAST")
+        val paths = spec["paths"] as Map<String, Map<String, Any?>>
+        assertTrue(paths.containsKey("/openapi.json"))
+        assertTrue(paths.containsKey("/swagger.json"))
+        @Suppress("UNCHECKED_CAST")
+        val resources = paths["/api/resources/{path}"] as Map<String, Map<String, Any?>>
+        @Suppress("UNCHECKED_CAST")
+        val get = resources["get"] as Map<String, Any?>
+        @Suppress("UNCHECKED_CAST")
+        val parameters = get["parameters"] as List<Map<String, Any?>>
+        assertEquals("path", parameters.single()["name"])
     }
 
     // ========================================================================

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/HelpersTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/HelpersTest.kt
@@ -456,11 +456,11 @@ class HelpersTest {
 
     @Test
     fun `edgeToMap for ResourceEdge includes correct fields`() {
-        val edge = ResourceEdge(resourceFileNode.id, resourceValueNode.id, ResourceRelation.CONTAINS)
+        val edge = ResourceEdge(resourceFileNode.id, resourceValueNode.id, ResourceRelation.LOOKUP)
         val map = edgeToMap(edge)
         assertEquals(resourceFileNode.id.value, map["from"])
         assertEquals(resourceValueNode.id.value, map["to"])
         assertEquals("Resource", map["type"])
-        assertEquals("CONTAINS", map["kind"])
+        assertEquals("LOOKUP", map["kind"])
     }
 }

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/HelpersTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/HelpersTest.kt
@@ -19,6 +19,8 @@ class HelpersTest {
         private val callSiteNode = CallSiteNode(NodeId.next(), barMethod, bazMethod, 10, null, listOf(paramNode.id))
         private val enumConstNode = EnumConstant(NodeId.next(), TypeDescriptor("com.example.Status"), "ACTIVE", listOf(1, "active"))
         private val fieldNode = FieldNode(NodeId.next(), FieldDescriptor(fooType, "name", TypeDescriptor("java.lang.String")), false)
+        private val resourceFileNode = ResourceFileNode(NodeId.next(), "application.yml", "test-fixture", "yaml", "dev")
+        private val resourceValueNode = ResourceValueNode(NodeId.next(), "application.yml", "server.port", 8080, "yaml", "dev")
     }
 
     // ========================================================================
@@ -59,6 +61,18 @@ class HelpersTest {
     fun `resolveNodeType maps LocalVariable`() {
         assertEquals(LocalVariable::class.java, resolveNodeType("local"))
         assertEquals(LocalVariable::class.java, resolveNodeType("LocalVariable"))
+    }
+
+    @Test
+    fun `resolveNodeType maps ResourceValueNode`() {
+        assertEquals(ResourceValueNode::class.java, resolveNodeType("resource"))
+        assertEquals(ResourceValueNode::class.java, resolveNodeType("ResourceValueNode"))
+    }
+
+    @Test
+    fun `resolveNodeType maps ResourceFileNode`() {
+        assertEquals(ResourceFileNode::class.java, resolveNodeType("resourcefile"))
+        assertEquals(ResourceFileNode::class.java, resolveNodeType("ResourceFileNode"))
     }
 
     @Test
@@ -174,6 +188,22 @@ class HelpersTest {
         assertTrue(result.startsWith("NullConstant["), "Should start with 'NullConstant[', got: $result")
     }
 
+    @Test
+    fun `formatNode formats ResourceValueNode`() {
+        val result = formatNode(resourceValueNode)
+        assertTrue(result.startsWith("ResourceValue["), "Should start with 'ResourceValue[', got: $result")
+        assertTrue(result.contains("server.port"), "Should contain resource key, got: $result")
+        assertTrue(result.contains("8080"), "Should contain resource value, got: $result")
+    }
+
+    @Test
+    fun `formatNode formats ResourceFileNode`() {
+        val result = formatNode(resourceFileNode)
+        assertTrue(result.startsWith("ResourceFile["), "Should start with 'ResourceFile[', got: $result")
+        assertTrue(result.contains("application.yml"), "Should contain resource path, got: $result")
+        assertTrue(result.contains("test-fixture"), "Should contain resource source, got: $result")
+    }
+
     // ========================================================================
     // nodeToMap
     // ========================================================================
@@ -212,6 +242,27 @@ class HelpersTest {
         assertEquals("EnumConstant", map["type"])
         assertEquals("com.example.Status", map["enumType"])
         assertEquals("ACTIVE", map["enumName"])
+    }
+
+    @Test
+    fun `nodeToMap for ResourceValueNode includes correct fields`() {
+        val map = nodeToMap(resourceValueNode)
+        assertEquals("ResourceValueNode", map["type"])
+        assertEquals("application.yml", map["path"])
+        assertEquals("server.port", map["key"])
+        assertEquals(8080, map["value"])
+        assertEquals("yaml", map["format"])
+        assertEquals("dev", map["profile"])
+    }
+
+    @Test
+    fun `nodeToMap for ResourceFileNode includes correct fields`() {
+        val map = nodeToMap(resourceFileNode)
+        assertEquals("ResourceFileNode", map["type"])
+        assertEquals("application.yml", map["path"])
+        assertEquals("test-fixture", map["source"])
+        assertEquals("yaml", map["format"])
+        assertEquals("dev", map["profile"])
     }
 
     @Test
@@ -401,5 +452,15 @@ class HelpersTest {
         assertEquals(n2Id.value, map["to"])
         assertEquals("ControlFlow", map["type"])
         assertEquals("BRANCH_TRUE", map["kind"])
+    }
+
+    @Test
+    fun `edgeToMap for ResourceEdge includes correct fields`() {
+        val edge = ResourceEdge(resourceFileNode.id, resourceValueNode.id, ResourceRelation.CONTAINS)
+        val map = edgeToMap(edge)
+        assertEquals(resourceFileNode.id.value, map["from"])
+        assertEquals(resourceValueNode.id.value, map["to"])
+        assertEquals("Resource", map["type"])
+        assertEquals("CONTAINS", map["kind"])
     }
 }

--- a/graphite-mcp/src/index.ts
+++ b/graphite-mcp/src/index.ts
@@ -35,6 +35,14 @@ async function graphitePost(path: string, body: unknown): Promise<unknown> {
   return res.json();
 }
 
+function encodeResourcePath(path: string): string {
+  return path
+    .split("/")
+    .filter((part) => part.length > 0)
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+}
+
 const server = new McpServer({
   name: "graphite",
   version: "1.0.0",
@@ -45,6 +53,17 @@ server.tool("info", "Get graph statistics (node count, edge count, methods, call
   const data = await graphiteGet("/api/info");
   return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
 });
+
+// Explore API discovery
+server.tool(
+  "openapi",
+  "Fetch the machine-readable OpenAPI document for the explore server",
+  {},
+  async () => {
+    const data = await graphiteGet("/openapi.json");
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+);
 
 // Cypher query
 server.tool(
@@ -155,6 +174,54 @@ server.tool(
   },
   async ({ class_name, member_name }) => {
     const data = await graphiteGet("/api/annotations", { class: class_name, member: member_name });
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+);
+
+// Extract framework API endpoints
+server.tool(
+  "api_spec",
+  "Extract framework API endpoints from the graph",
+  {
+    class_name: z.string().optional().describe("Optional controller class filter"),
+    limit: z.number().optional().default(200).describe("Max endpoints to return"),
+  },
+  async ({ class_name, limit }) => {
+    const params: Record<string, string> = {};
+    if (class_name) params.class = class_name;
+    if (limit) params.limit = String(limit);
+    const data = await graphiteGet("/api/api-spec", params);
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+);
+
+// List resources
+server.tool(
+  "resources",
+  "List persisted resources available in the graph",
+  {
+    pattern: z.string().optional().describe("Glob pattern filter, defaults to **"),
+    limit: z.number().optional().default(100).describe("Max results"),
+  },
+  async ({ pattern, limit }) => {
+    const params: Record<string, string> = {};
+    if (pattern) params.pattern = pattern;
+    if (limit) params.limit = String(limit);
+    const data = await graphiteGet("/api/resources", params);
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+);
+
+// Read raw resource content
+server.tool(
+  "resource",
+  "Read persisted raw resource content by path",
+  {
+    path: z.string().describe("Resource path inside the saved graph"),
+  },
+  async ({ path }) => {
+    const encodedPath = encodeResourcePath(path);
+    const data = await graphiteGet(`/api/resources/${encodedPath}`);
     return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
   }
 );

--- a/graphite-sootup/build.gradle.kts
+++ b/graphite-sootup/build.gradle.kts
@@ -26,11 +26,13 @@ dependencies {
     implementation(libs.sootup.java.bytecode.frontend)
     implementation(libs.sootup.callgraph)
     implementation(libs.asm)  // For parsing generic signatures from bytecode
+    implementation(libs.gson)
 
     // Test dependencies - real libraries for integration testing
     testImplementation(libs.ff4j.core)
     testImplementation(libs.spring.web)
     testImplementation(libs.jackson.annotations)
+    testImplementation(libs.gson)
     testImplementation(libs.guava)
 
     // Lombok for testing Lombok-generated code analysis

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -1,9 +1,5 @@
 package io.johnsonlee.graphite.sootup
 
-import com.google.gson.JsonArray
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.FullGraphBuilder
@@ -12,20 +8,15 @@ import io.johnsonlee.graphite.input.CallGraphAlgorithm
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.LoaderConfig
 import io.johnsonlee.graphite.input.ResourceAccessor
-import java.io.ByteArrayInputStream
 import java.util.Locale
-import java.util.Properties
 import java.util.ResourceBundle
 import java.util.ServiceLoader
-import javax.xml.XMLConstants
-import javax.xml.parsers.DocumentBuilderFactory
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type as AsmType
 import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldInsnNode
-import org.objectweb.asm.tree.FieldNode as AsmFieldNode
 import org.objectweb.asm.tree.InsnNode
 import org.objectweb.asm.tree.IntInsnNode
 import org.objectweb.asm.tree.LdcInsnNode
@@ -33,8 +24,6 @@ import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
 import org.objectweb.asm.tree.TypeInsnNode
 import org.objectweb.asm.tree.VarInsnNode
-import org.w3c.dom.Element
-import org.w3c.dom.Node as DomNode
 import sootup.core.frontend.BodySource
 import sootup.core.graph.StmtGraph
 import sootup.core.jimple.basic.NoPositionInformation
@@ -107,11 +96,6 @@ class SootUpAdapter(
 
     private data class LocalKey(val method: MethodDescriptor, val name: String)
     private data class ParameterBinding(val method: MethodDescriptor, val index: Int)
-    private data class PlaceholderBinding(
-        val key: String?,
-        val defaultValue: Any?,
-        val hasDefaultValue: Boolean
-    )
     private data class BundleControlSpec(
         val noFallback: Boolean = false,
         val formats: Set<String> = setOf("java.properties", "java.class"),
@@ -455,18 +439,6 @@ class SootUpAdapter(
      */
     private fun visitFieldsForClass(sootClass: SootClass) {
         val className = sootClass.type.fullyQualifiedName
-        val configurationPropertiesPrefix = extractConfigurationPropertiesPrefix(sootClass)
-        val valueAnnotationsByField = if (sootClass is JavaSootClass) {
-            val fromSoot = sootClass.fields.associate { it.signature.toString() to extractValueAnnotationBinding(it.annotations) }
-            val fromAsm = getAsmFieldNodes(sootClass)
-                ?.associate { asmField -> asmField.name to extractValueAnnotationBinding(asmField) }
-                ?: emptyMap()
-            sootClass.fields.associate { field ->
-                field.signature.toString() to (fromSoot[field.signature.toString()] ?: fromAsm[field.name])
-            }
-        } else {
-            emptyMap()
-        }
         sootClass.fields.forEach { field ->
             val fieldName = field.name
 
@@ -478,8 +450,6 @@ class SootUpAdapter(
             // Use field signature as key (same format as getOrCreateField)
             val fieldSig = field.signature.toString()
             if (fieldNodes.containsKey(fieldSig)) {
-                linkValueAnnotatedField(valueAnnotationsByField[fieldSig], fieldNodes[fieldSig]!!)
-                linkConfigurationPropertiesField(configurationPropertiesPrefix, field.name, fieldNodes[fieldSig]!!)
                 return@forEach
             }
 
@@ -500,8 +470,6 @@ class SootUpAdapter(
             )
             fieldNodes[fieldSig] = node
             graphBuilder.addNode(node)
-            linkValueAnnotatedField(valueAnnotationsByField[fieldSig], node)
-            linkConfigurationPropertiesField(configurationPropertiesPrefix, field.name, node)
         }
     }
 
@@ -1123,7 +1091,6 @@ class SootUpAdapter(
     }
 
     companion object {
-        private val NULL_CONSTANT_KEY = Any()
         private val WRAPPER_CLASSES = setOf(
             "java.lang.Integer",
             "java.lang.Long",
@@ -1500,16 +1467,16 @@ class SootUpAdapter(
     private fun streamMethodsOrNull(sootClass: SootClass): Sequence<SootMethod>? {
         if (sootClass !is JavaSootClass) return null
         val methodNodes = getAsmMethodNodes(sootClass) ?: return null
-        return methodNodes.asSequence().mapNotNull { methodNode ->
-            try {
-                createStreamingMethod(sootClass, methodNode)
-            } catch (oom: OutOfMemoryError) {
-                log("Skipping method ${sootClass.type}.${methodNode.name}${methodNode.desc}: OOM during streaming resolution")
-                System.gc()
-                null
-            } catch (e: Exception) {
-                log("Skipping method ${sootClass.type}.${methodNode.name}${methodNode.desc}: ${e.message}")
-                null
+        return sequence {
+            for (methodNode in methodNodes) {
+                try {
+                    createStreamingMethod(sootClass, methodNode)?.let { yield(it) }
+                } catch (oom: OutOfMemoryError) {
+                    log("Skipping method ${sootClass.type}.${methodNode.name}${methodNode.desc}: OOM during streaming resolution")
+                    System.gc()
+                } catch (e: Exception) {
+                    log("Skipping method ${sootClass.type}.${methodNode.name}${methodNode.desc}: ${e.message}")
+                }
             }
         }
     }
@@ -1518,22 +1485,6 @@ class SootUpAdapter(
         val classNode = getAsmClassNode(sootClass) ?: return null
         @Suppress("UNCHECKED_CAST")
         return classNode.methods as? List<MethodNode>
-    }
-
-    private fun getAsmFieldNodes(sootClass: JavaSootClass): List<AsmFieldNode>? {
-        return try {
-            val resourcePath = sootClass.type.fullyQualifiedName.replace('.', '/') + ".class"
-            resourceAccessor.open(resourcePath).use { input ->
-                val classNode = ClassNode()
-                ClassReader(input).accept(classNode, ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES)
-                @Suppress("UNCHECKED_CAST")
-                classNode.fields as? List<AsmFieldNode>
-            }
-        } catch (_: Exception) {
-            val classNode = getAsmClassNode(sootClass) ?: return null
-            @Suppress("UNCHECKED_CAST")
-            classNode.fields as? List<AsmFieldNode>
-        }
     }
 
     private fun loadMethodNodesFromResource(sootClass: JavaSootClass): List<MethodNode>? {
@@ -1588,17 +1539,18 @@ class SootUpAdapter(
         )
     }
 
-    private fun resolveMethodsOrEmpty(sootClass: SootClass): Set<out SootMethod> {
-        return try {
-            sootClass.methods
-        } catch (oom: OutOfMemoryError) {
-            log("Skipping methods for ${sootClass.type}: OOM during method resolution")
-            System.gc()
-            emptySet()
-        } catch (e: IllegalStateException) {
-            log("Skipping methods for ${sootClass.type}: ${e.message}")
-            emptySet()
+    private fun resolveMethodsOrEmpty(sootClass: SootClass): Set<SootMethod> = try {
+        sootClass.methods
+    } catch (failure: Throwable) {
+        when (failure) {
+            is OutOfMemoryError -> {
+                log("Skipping methods for ${sootClass.type}: OOM during method resolution")
+                System.gc()
+            }
+            is IllegalStateException -> log("Skipping methods for ${sootClass.type}: ${failure.message}")
+            else -> throw failure
         }
+        emptySet()
     }
 
     private fun getOrCreateValueNode(value: Value, method: MethodDescriptor): ValueNode? {
@@ -1684,43 +1636,6 @@ class SootUpAdapter(
                         value = 0
                     )
                 }
-            }
-            graphBuilder.addNode(node)
-            node
-        }
-    }
-
-    private fun getOrCreateConstantValue(value: Any?): ConstantNode {
-        val cacheKey = value ?: NULL_CONSTANT_KEY
-        return constantNodes.getOrPut(cacheKey) {
-            val node = when (value) {
-                null -> NullConstant(
-                    id = nextNodeId("const")
-                )
-                is Int -> IntConstant(
-                    id = nextNodeId("const"),
-                    value = value
-                )
-                is Long -> LongConstant(
-                    id = nextNodeId("const"),
-                    value = value
-                )
-                is Float -> FloatConstant(
-                    id = nextNodeId("const"),
-                    value = value
-                )
-                is Double -> DoubleConstant(
-                    id = nextNodeId("const"),
-                    value = value
-                )
-                is Boolean -> BooleanConstant(
-                    id = nextNodeId("const"),
-                    value = value
-                )
-                else -> StringConstant(
-                    id = nextNodeId("const"),
-                    value = value.toString()
-                )
             }
             graphBuilder.addNode(node)
             node
@@ -1821,64 +1736,6 @@ class SootUpAdapter(
         return classesByName[className]
     }
 
-    private fun extractListResourceBundleEntries(sootClass: SootClass): Map<String, Any?> {
-        val javaSootClass = sootClass as? JavaSootClass ?: return emptyMap()
-        val methodNode = (getAsmMethodNodes(javaSootClass) ?: loadMethodNodesFromResource(javaSootClass))
-            ?.firstOrNull { it.name == "getContents" }
-            ?: return emptyMap()
-        val returned = evaluateArrayLiteral(methodNode) as? List<*> ?: return emptyMap()
-        return buildMap {
-            returned.forEach { entry ->
-                val tuple = entry as? List<*> ?: return@forEach
-                val key = tuple.getOrNull(0) as? String ?: return@forEach
-                put(key, normalizeRuntimeBundleValue(tuple.getOrNull(1)))
-            }
-        }
-    }
-
-    private fun evaluateArrayLiteral(methodNode: MethodNode): Any? {
-        val stack = ArrayDeque<Any?>()
-        val locals = mutableMapOf<Int, Any?>()
-        for (insn in methodNode.instructions) {
-            when (insn) {
-                is InsnNode -> when (insn.opcode) {
-                    Opcodes.ACONST_NULL -> stack.addLast(null)
-                    Opcodes.ICONST_M1 -> stack.addLast(-1)
-                    Opcodes.ICONST_0 -> stack.addLast(0)
-                    Opcodes.ICONST_1 -> stack.addLast(1)
-                    Opcodes.ICONST_2 -> stack.addLast(2)
-                    Opcodes.ICONST_3 -> stack.addLast(3)
-                    Opcodes.ICONST_4 -> stack.addLast(4)
-                    Opcodes.ICONST_5 -> stack.addLast(5)
-                    Opcodes.DUP -> stack.lastOrNull()?.let(stack::addLast)
-                    Opcodes.AASTORE -> {
-                        val value = stack.removeLastOrNull()
-                        val index = (stack.removeLastOrNull() as? Number)?.toInt() ?: continue
-                        val array = stack.removeLastOrNull() as? MutableList<Any?> ?: continue
-                        if (index in array.indices) array[index] = value
-                    }
-                    Opcodes.ARETURN -> return stack.removeLastOrNull()
-                    Opcodes.ALOAD, Opcodes.ILOAD -> Unit
-                    else -> Unit
-                }
-                is IntInsnNode -> when (insn.opcode) {
-                    Opcodes.BIPUSH, Opcodes.SIPUSH -> stack.addLast(insn.operand)
-                }
-                is LdcInsnNode -> stack.addLast(insn.cst)
-                is TypeInsnNode -> if (insn.opcode == Opcodes.ANEWARRAY) {
-                    val size = (stack.removeLastOrNull() as? Number)?.toInt() ?: continue
-                    stack.addLast(MutableList<Any?>(size) { null })
-                }
-                is VarInsnNode -> when (insn.opcode) {
-                    Opcodes.ASTORE, Opcodes.ISTORE -> locals[insn.`var`] = stack.removeLastOrNull()
-                    Opcodes.ALOAD, Opcodes.ILOAD -> stack.addLast(locals[insn.`var`])
-                }
-                else -> Unit
-            }
-        }
-        return null
-    }
-
     private fun extractControlFormatsFromMethod(methodNode: MethodNode): Set<String>? =
         when (val value = evaluateLiteralMethod(methodNode)) {
             is List<*> -> value.mapNotNull {
@@ -1920,25 +1777,19 @@ class SootUpAdapter(
         }
         for (insn in methodNode.instructions) {
             when (insn) {
-                is InsnNode -> when (insn.opcode) {
-                    Opcodes.ACONST_NULL -> stack.addLast(null)
-                    Opcodes.ICONST_M1 -> stack.addLast(-1)
-                    Opcodes.ICONST_0 -> stack.addLast(0)
-                    Opcodes.ICONST_1 -> stack.addLast(1)
-                    Opcodes.ICONST_2 -> stack.addLast(2)
-                    Opcodes.ICONST_3 -> stack.addLast(3)
-                    Opcodes.ICONST_4 -> stack.addLast(4)
-                    Opcodes.ICONST_5 -> stack.addLast(5)
-                    Opcodes.DUP -> stack.lastOrNull()?.let(stack::addLast)
-                    Opcodes.ARETURN -> return stack.removeLastOrNull()
+                is InsnNode -> when {
+                    insn.opcode == Opcodes.ACONST_NULL -> stack.addLast(null)
+                    insn.opcode in Opcodes.ICONST_M1..Opcodes.ICONST_5 -> stack.addLast(insn.opcode - Opcodes.ICONST_0)
+                    insn.opcode == Opcodes.DUP -> stack.lastOrNull()?.let(stack::addLast)
+                    insn.opcode == Opcodes.ARETURN -> return stack.removeLastOrNull()
                 }
-                is IntInsnNode -> when (insn.opcode) {
-                    Opcodes.BIPUSH, Opcodes.SIPUSH -> stack.addLast(insn.operand)
+                is IntInsnNode -> if (insn.opcode == Opcodes.BIPUSH || insn.opcode == Opcodes.SIPUSH) {
+                    stack.addLast(insn.operand)
                 }
                 is LdcInsnNode -> stack.addLast(insn.cst)
-                is VarInsnNode -> when (insn.opcode) {
-                    Opcodes.ASTORE, Opcodes.ISTORE -> locals[insn.`var`] = stack.removeLastOrNull()
-                    Opcodes.ALOAD, Opcodes.ILOAD -> stack.addLast(locals[insn.`var`])
+                is VarInsnNode -> when {
+                    insn.opcode == Opcodes.ASTORE || insn.opcode == Opcodes.ISTORE -> locals[insn.`var`] = stack.removeLastOrNull()
+                    insn.opcode == Opcodes.ALOAD || insn.opcode == Opcodes.ILOAD -> stack.addLast(locals[insn.`var`])
                 }
                 is FieldInsnNode -> if (insn.opcode == Opcodes.GETSTATIC) {
                     stack.addLast(resolveStaticLiteral(insn.owner.replace('/', '.'), insn.name))
@@ -1952,20 +1803,12 @@ class SootUpAdapter(
                     val owner = insn.owner.replace('/', '.')
                     val result = when {
                         insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.List" && insn.name == "of" -> args
-                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Arrays" && insn.name == "asList" -> {
-                            val first = args.singleOrNull()
-                            when (first) {
-                                is List<*> -> first
-                                else -> args
-                            }
-                        }
+                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Arrays" && insn.name == "asList" ->
+                            (args.singleOrNull() as? List<*>) ?: args
                         insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Collections" && insn.name == "singletonList" -> args
-                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Locale" && insn.name == "forLanguageTag" -> {
+                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Locale" && insn.name == "forLanguageTag" ->
                             (args.firstOrNull() as? String)?.let(::normalizeLocaleSpec)
-                        }
-                        insn.opcode == Opcodes.INVOKESPECIAL && owner == "java.util.Locale" && insn.name == "<init>" -> {
-                            null
-                        }
+                        insn.opcode == Opcodes.INVOKESPECIAL && owner == "java.util.Locale" && insn.name == "<init>" -> null
                         else -> null
                     }
                     if (AsmType.getReturnType(insn.desc).sort != AsmType.VOID) {
@@ -1979,16 +1822,10 @@ class SootUpAdapter(
     }
 
     private fun resolveStaticLiteral(owner: String, fieldName: String): Any? = when {
+        owner == "java.util.Locale" -> extractLocaleSpec(fieldName)
         fieldName == "FORMAT_CLASS" -> listOf("java.class")
         fieldName == "FORMAT_PROPERTIES" -> listOf("java.properties")
         fieldName == "FORMAT_DEFAULT" -> listOf("java.class", "java.properties")
-        owner == "java.util.ResourceBundle.Control" || owner == "java.util.ResourceBundle\$Control" -> when (fieldName) {
-            "FORMAT_CLASS" -> listOf("java.class")
-            "FORMAT_PROPERTIES" -> listOf("java.properties")
-            "FORMAT_DEFAULT" -> listOf("java.class", "java.properties")
-            else -> null
-        }
-        owner == "java.util.Locale" -> extractLocaleSpec(fieldName)
         else -> null
     }
 
@@ -2040,9 +1877,7 @@ class SootUpAdapter(
         val supported = declaringClass == "java.util.Properties" ||
             declaringClass == "java.util.PropertyResourceBundle" ||
             declaringClass == "java.util.ResourceBundle" ||
-            declaringClass == "java.lang.System" ||
-            declaringClass == "org.springframework.core.env.Environment" ||
-            declaringClass == "org.springframework.core.env.PropertyResolver"
+            declaringClass == "java.lang.System"
         if (!supported || invokeExpr.args.isEmpty()) return null
         val firstArg = invokeExpr.args[0]
         return if (firstArg is SootStringConstant) firstArg.value else null
@@ -2261,17 +2096,10 @@ class SootUpAdapter(
     private fun isStructuredResourceLoadCall(calleeSignature: MethodSignature): Boolean {
         val declaringClass = calleeSignature.declClassType.fullyQualifiedName
         val methodName = calleeSignature.name
-        if (isPropertiesLoadCall(calleeSignature) || isPropertyResourceBundleConstructor(calleeSignature)) return true
-        return when (declaringClass) {
-            "com.fasterxml.jackson.databind.ObjectMapper" -> methodName in setOf("readTree", "readValue", "readValues")
-            "com.fasterxml.jackson.dataformat.xml.XmlMapper" -> methodName in setOf("readTree", "readValue", "readValues")
-            "com.google.gson.Gson" -> methodName == "fromJson"
-            "org.yaml.snakeyaml.Yaml" -> methodName in setOf("load", "loadAll", "loadAs")
-            "javax.xml.parsers.DocumentBuilder" -> methodName == "parse"
-            "org.dom4j.io.SAXReader" -> methodName == "read"
-            "org.jdom2.input.SAXBuilder" -> methodName == "build"
-            else -> false
-        }
+        return isPropertiesLoadCall(calleeSignature) ||
+            isPropertyResourceBundleConstructor(calleeSignature) ||
+            (declaringClass == "com.google.gson.Gson" && methodName == "fromJson") ||
+            (declaringClass == "javax.xml.parsers.DocumentBuilder" && methodName == "parse")
     }
 
     private fun collectMatchingResourceBundlePaths(
@@ -2529,13 +2357,6 @@ class SootUpAdapter(
         bundleParent(bundle)?.let(::indexRuntimeBundle)
     }
 
-    private fun normalizeRuntimeBundleValue(value: Any?): Any? = when (value) {
-        is String, is Number, is Boolean -> value
-        is Array<*> -> value.map(::normalizeRuntimeBundleValue)
-        is Iterable<*> -> value.map(::normalizeRuntimeBundleValue)
-        else -> value?.toString()
-    }
-
     private fun toControl(controlSpec: BundleControlSpec): ResourceBundle.Control =
         if (controlSpec.noFallback) {
             ResourceBundle.Control.getNoFallbackControl(controlFormatsList(controlSpec))
@@ -2643,127 +2464,11 @@ class SootUpAdapter(
 
     private fun normalizeResourcePath(caller: MethodDescriptor, declaringClass: String, rawPath: String): String {
         val trimmed = rawPath.trim()
-        if (trimmed.isEmpty()) return trimmed
-        if (declaringClass == "java.lang.ClassLoader") {
+        if (trimmed.isEmpty() || declaringClass == "java.lang.ClassLoader" || trimmed.startsWith("/")) {
             return trimmed.removePrefix("/")
         }
-        if (trimmed.startsWith("/")) {
-            return trimmed.removePrefix("/")
-        }
-        val packagePath = caller.declaringClass.className.substringBeforeLast('.', "")
-            .replace('.', '/')
+        val packagePath = caller.declaringClass.className.substringBeforeLast('.', "").replace('.', '/')
         return if (packagePath.isEmpty()) trimmed else "$packagePath/$trimmed"
-    }
-
-    private fun linkValueAnnotatedField(binding: PlaceholderBinding?, fieldNode: FieldNode) {
-        if (binding == null) return
-        binding.key?.let { configKey ->
-            lookupResourceFiles(null).forEach { resourceFile ->
-                graphBuilder.addEdge(ResourceEdge(resourceFile.id, fieldNode.id, ResourceRelation.LOOKUP))
-            }
-        }
-        if (binding.hasDefaultValue) {
-            val defaultNode = getOrCreateConstantValue(binding.defaultValue)
-            graphBuilder.addEdge(
-                DataFlowEdge(
-                    from = defaultNode.id,
-                    to = fieldNode.id,
-                    kind = DataFlowKind.ASSIGN
-                )
-            )
-        }
-    }
-
-    private fun extractValueAnnotationBinding(annotations: Iterable<*>): PlaceholderBinding? {
-        val valueAnnotation = annotations.firstOrNull {
-            getAnnotationFullName(it) == "org.springframework.beans.factory.annotation.Value"
-        } ?: return null
-        val expression = normalizeAnnotationValue(getAnnotationValues(valueAnnotation)["value"]) as? String ?: return null
-        return extractPlaceholderBinding(expression)
-    }
-
-    private fun extractValueAnnotationBinding(fieldNode: AsmFieldNode): PlaceholderBinding? {
-        val annotations = (fieldNode.visibleAnnotations ?: emptyList()) + (fieldNode.invisibleAnnotations ?: emptyList())
-        val valueAnnotation = annotations.firstOrNull { it.desc == "Lorg/springframework/beans/factory/annotation/Value;" }
-            ?: return null
-        val rawValues = valueAnnotation.values ?: return null
-        var expression: String? = null
-        var index = 0
-        while (index + 1 < rawValues.size) {
-            val key = rawValues[index] as? String
-            val value = rawValues[index + 1]
-            if (key == "value") {
-                expression = value?.toString()
-                break
-            }
-            index += 2
-        }
-        return expression?.let { extractPlaceholderBinding(it) }
-    }
-
-    private fun extractPlaceholderBinding(expression: String): PlaceholderBinding {
-        val trimmed = expression.trim()
-        val match = Regex("""\$\{([^:}]+)(?::([^}]*))?}""").find(trimmed)
-        if (match != null) {
-            return PlaceholderBinding(
-                key = match.groupValues.getOrNull(1)?.takeIf { it.isNotBlank() },
-                defaultValue = match.groupValues.getOrNull(2)?.let(::parseScalar),
-                hasDefaultValue = match.groups[2] != null
-            )
-        }
-        return PlaceholderBinding(
-            key = null,
-            defaultValue = parseScalar(trimmed),
-            hasDefaultValue = true
-        )
-    }
-
-    private fun extractConfigurationPropertiesPrefix(sootClass: SootClass): String? {
-        if (sootClass is JavaSootClass) {
-            val fromSoot = extractConfigurationPropertiesPrefix(sootClass.annotations)
-            if (fromSoot != null) return fromSoot
-            val fromAsm = getAsmClassNode(sootClass)?.let { classNode ->
-                val annotations = buildList {
-                    classNode.visibleAnnotations?.let { addAll(AsmUtil.createAnnotationUsage(it).toList()) }
-                    classNode.invisibleAnnotations?.let { addAll(AsmUtil.createAnnotationUsage(it).toList()) }
-                }
-                extractConfigurationPropertiesPrefix(annotations)
-            }
-            if (fromAsm != null) return fromAsm
-        }
-        return null
-    }
-
-    private fun extractConfigurationPropertiesPrefix(annotations: Iterable<*>): String? {
-        val configAnnotation = annotations.firstOrNull {
-            getAnnotationFullName(it) == "org.springframework.boot.context.properties.ConfigurationProperties"
-        } ?: return null
-        val values = getAnnotationValues(configAnnotation)
-        return normalizeAnnotationValue(values["prefix"]) as? String
-            ?: normalizeAnnotationValue(values["value"]) as? String
-    }
-
-    private fun linkConfigurationPropertiesField(prefix: String?, fieldName: String, fieldNode: FieldNode) {
-        if (prefix.isNullOrBlank()) return
-        configurationPropertyKeys(prefix, fieldName).forEach { key ->
-            lookupResourceFiles(null).forEach { resourceFile ->
-                graphBuilder.addEdge(ResourceEdge(resourceFile.id, fieldNode.id, ResourceRelation.LOOKUP))
-            }
-        }
-    }
-
-    private fun configurationPropertyKeys(prefix: String, fieldName: String): Set<String> {
-        val kebab = fieldName
-            .replace(Regex("([a-z0-9])([A-Z])"), "$1-$2")
-            .lowercase()
-        val snake = fieldName
-            .replace(Regex("([a-z0-9])([A-Z])"), "$1_$2")
-            .lowercase()
-        return linkedSetOf(
-            "$prefix.$fieldName",
-            "$prefix.$kebab",
-            "$prefix.$snake"
-        )
     }
 
     private fun isResourceConfig(path: String): Boolean =
@@ -2785,215 +2490,6 @@ class SootUpAdapter(
         val fileName = path.substringAfterLast('/')
         val match = Regex("""application-([^.]+)\.(properties|json|xml|ya?ml)""").matchEntire(fileName)
         return match?.groupValues?.getOrNull(1)
-    }
-
-    private fun loadProperties(content: String): Map<String, Any?> {
-        val properties = Properties()
-        properties.load(content.reader())
-        return properties.stringPropertyNames().associateWith { parseScalar(properties.getProperty(it)) }
-    }
-
-    private fun loadYaml(content: String): Map<String, Any?> {
-        val result = linkedMapOf<String, Any?>()
-        val pathStack = mutableListOf<String>()
-        var previousIndent = 0
-
-        content.lineSequence().forEach { rawLine ->
-            val line = rawLine.substringBefore('#').trimEnd()
-            if (line.isBlank() || ':' !in line) return@forEach
-            val indent = rawLine.indexOfFirst { !it.isWhitespace() }.coerceAtLeast(0)
-            val level = indent / 2
-            while (pathStack.size > level) {
-                pathStack.removeAt(pathStack.lastIndex)
-            }
-            if (level < previousIndent / 2 && pathStack.size > level) {
-                while (pathStack.size > level) {
-                    pathStack.removeAt(pathStack.lastIndex)
-                }
-            }
-            previousIndent = indent
-
-            val key = line.substringBefore(':').trim()
-            val valuePart = line.substringAfter(':').trim()
-            if (valuePart.isEmpty()) {
-                if (pathStack.size == level) {
-                    pathStack.add(key)
-                } else {
-                    pathStack[level] = key
-                }
-            } else {
-                val fullKey = (pathStack + key).joinToString(".")
-                result[fullKey] = parseScalar(valuePart)
-            }
-        }
-
-        return result
-    }
-
-    private fun loadJson(content: String): Map<String, Any?> {
-        val element = JsonParser.parseString(content)
-        val result = linkedMapOf<String, Any?>()
-        flattenJson(element, emptyList(), result)
-        return result
-    }
-
-    private fun flattenJson(element: JsonElement?, path: List<String>, dest: MutableMap<String, Any?>) {
-        when {
-            element == null || element.isJsonNull -> {
-                if (path.isNotEmpty()) dest[path.joinToString(".")] = null
-            }
-            element.isJsonObject -> flattenJsonObject(element.asJsonObject, path, dest)
-            element.isJsonArray -> flattenJsonArray(element.asJsonArray, path, dest)
-            element.isJsonPrimitive -> {
-                if (path.isNotEmpty()) dest[path.joinToString(".")] = parseJsonPrimitive(element)
-            }
-        }
-    }
-
-    private fun flattenJsonObject(obj: JsonObject, path: List<String>, dest: MutableMap<String, Any?>) {
-        obj.entrySet().forEach { (key, value) ->
-            flattenJson(value, path + key, dest)
-        }
-    }
-
-    private fun flattenJsonArray(array: JsonArray, path: List<String>, dest: MutableMap<String, Any?>) {
-        array.forEachIndexed { index, element ->
-            val base = path.toMutableList()
-            if (base.isNotEmpty()) {
-                base[base.lastIndex] = "${base.last()}[$index]"
-            } else {
-                base += "[$index]"
-            }
-            flattenJson(element, base, dest)
-        }
-    }
-
-    private fun parseJsonPrimitive(element: JsonElement): Any? {
-        val primitive = element.asJsonPrimitive
-        return when {
-            primitive.isBoolean -> primitive.asBoolean
-            primitive.isNumber -> parseScalar(primitive.asString)
-            primitive.isString -> primitive.asString
-            else -> primitive.toString()
-        }
-    }
-
-    private fun loadXml(content: ByteArray): Map<String, Any?> {
-        val text = content.toString(Charsets.UTF_8)
-        val looksLikePropertiesXml = Regex("""<\s*properties(?:\s|>)""").containsMatchIn(text)
-        return if (looksLikePropertiesXml) {
-            runCatching { loadXmlProperties(content) }
-                .getOrElse { loadGenericXml(content) }
-        } else {
-            loadGenericXml(content)
-        }
-    }
-
-    private fun loadXmlProperties(content: ByteArray): Map<String, Any?> {
-        val properties = Properties()
-        ByteArrayInputStream(content).use(properties::loadFromXML)
-        return properties.stringPropertyNames().associateWith { parseScalar(properties.getProperty(it)) }
-    }
-
-    private fun loadGenericXml(content: ByteArray): Map<String, Any?> {
-        val factory = DocumentBuilderFactory.newInstance().apply {
-            isNamespaceAware = false
-            runCatching { setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true) }
-            runCatching { setFeature("http://apache.org/xml/features/disallow-doctype-decl", true) }
-            runCatching { setFeature("http://xml.org/sax/features/external-general-entities", false) }
-            runCatching { setFeature("http://xml.org/sax/features/external-parameter-entities", false) }
-        }
-        val document = ByteArrayInputStream(content).use { input ->
-            factory.newDocumentBuilder().parse(input).apply { documentElement.normalize() }
-        }
-        val result = linkedMapOf<String, Any?>()
-        val elements = document.getElementsByTagName("*")
-        for (index in 0 until elements.length) {
-            val element = elements.item(index) as? Element ?: continue
-            val elementKey = xmlElementPath(element) ?: continue
-            if (element.hasAttributes()) {
-                val attributes = element.attributes
-                for (attributeIndex in 0 until attributes.length) {
-                    val attribute = attributes.item(attributeIndex)
-                    if (attribute != null && attribute.nodeName.isNotBlank()) {
-                        result["$elementKey.@${attribute.nodeName}"] = parseScalar(attribute.nodeValue ?: "")
-                    }
-                }
-            }
-
-            val childElements = xmlChildElements(element)
-            val directTextContent = element.childNodes.toTextValue()
-            if (childElements.isEmpty()) {
-                element.textContent
-                    ?.trim()
-                    ?.takeIf { it.isNotEmpty() }
-                    ?.let { result[elementKey] = parseScalar(it) }
-            } else if (directTextContent != null) {
-                result["$elementKey.#text"] = parseScalar(directTextContent)
-            }
-        }
-        return result
-    }
-
-    private fun xmlChildElements(element: Element): List<Element> {
-        val children = mutableListOf<Element>()
-        for (index in 0 until element.childNodes.length) {
-            val node = element.childNodes.item(index)
-            if (node is Element) {
-                children += node
-            }
-        }
-        return children
-    }
-
-    private fun xmlElementPath(element: Element): String? {
-        val parts = mutableListOf<String>()
-        var current: Element? = element
-        while (current != null) {
-            val parent = current.parentNode as? Element
-            if (parent == null) {
-                if (parts.isEmpty() && xmlChildElements(current).isEmpty()) {
-                    parts += current.tagName
-                }
-                break
-            }
-            val sameNamedSiblings = xmlChildElements(parent).filter { it.tagName == current.tagName }
-            val name = if (sameNamedSiblings.size > 1) {
-                "${current.tagName}[${sameNamedSiblings.indexOf(current)}]"
-            } else {
-                current.tagName
-            }
-            parts += name
-            current = parent
-        }
-        return parts.asReversed().joinToString(".").takeIf { it.isNotBlank() }
-    }
-
-    private fun org.w3c.dom.NodeList.toTextValue(): String? {
-        val text = buildString {
-            for (index in 0 until length) {
-            val node = item(index)
-            if (node.nodeType == DomNode.TEXT_NODE || node.nodeType == DomNode.CDATA_SECTION_NODE) {
-                append(node.nodeValue)
-            }
-        }
-        }.trim()
-        return text.takeIf { it.isNotEmpty() }
-    }
-
-    private fun parseScalar(value: String): Any? {
-        val trimmed = value.trim()
-        return when {
-            trimmed.equals("true", ignoreCase = true) -> true
-            trimmed.equals("false", ignoreCase = true) -> false
-            trimmed.equals("null", ignoreCase = true) -> null
-            trimmed.toIntOrNull() != null -> trimmed.toInt()
-            trimmed.toLongOrNull() != null -> trimmed.toLong()
-            trimmed.toDoubleOrNull() != null -> trimmed.toDouble()
-            trimmed.startsWith("\"") && trimmed.endsWith("\"") -> trimmed.removeSurrounding("\"")
-            trimmed.startsWith("'") && trimmed.endsWith("'") -> trimmed.removeSurrounding("'")
-            else -> trimmed
-        }
     }
 
     /**

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -102,8 +102,8 @@ class SootUpAdapter(
     private val resourceAccessor: ResourceAccessor = EmptyResourceAccessor,
     private val graphBuilder: FullGraphBuilder = DefaultGraph.Builder()
 ) {
-    private val trackCrossMethodFunctionalDispatch = config.buildCallGraph
-    private val extractAnnotationsEnabled = config.buildCallGraph
+    private val trackCrossMethodFunctionalDispatch = config.trackCrossMethodFunctionalDispatch
+    private val extractAnnotationsEnabled = config.extractAnnotations
 
     private data class LocalKey(val method: MethodDescriptor, val name: String)
     private data class ParameterBinding(val method: MethodDescriptor, val index: Int)

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -175,6 +175,13 @@ class SootUpAdapter(
     private val configurationResourcePaths = linkedSetOf<String>()
     private val runtimeIndexedBundles = mutableSetOf<String>()
     private val bundleControlSpecsByClass = mutableMapOf<String, BundleControlSpec?>()
+    private val classesByName: Map<String, SootClass> by lazy {
+        buildMap {
+            view.classes.forEach { sootClass ->
+                put(sootClass.type.fullyQualifiedName, sootClass)
+            }
+        }
+    }
 
     // Per-method: tracks which NodeIds were created from each statement
     // Reset per method in processMethod()
@@ -1760,6 +1767,7 @@ class SootUpAdapter(
     private fun indexResourceValues() {
         resourceAccessor.list("**")
             .forEach { entry ->
+                if (entry.path.endsWith(".class", ignoreCase = true)) return@forEach
                 val format = resourceFormat(entry.path)
                 val profile = resourceProfile(entry.path)
                 val fileNode = ResourceFileNode(
@@ -1810,12 +1818,7 @@ class SootUpAdapter(
     }
 
     private fun resolveClassByName(className: String): SootClass? {
-        for (candidate in view.classes) {
-            if (candidate.type.fullyQualifiedName == className) {
-                return candidate
-            }
-        }
-        return null
+        return classesByName[className]
     }
 
     private fun extractListResourceBundleEntries(sootClass: SootClass): Map<String, Any?> {

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapter.kt
@@ -1,5 +1,9 @@
 package io.johnsonlee.graphite.sootup
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.FullGraphBuilder
@@ -8,9 +12,29 @@ import io.johnsonlee.graphite.input.CallGraphAlgorithm
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.LoaderConfig
 import io.johnsonlee.graphite.input.ResourceAccessor
+import java.io.ByteArrayInputStream
+import java.util.Locale
+import java.util.Properties
+import java.util.ResourceBundle
 import java.util.ServiceLoader
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type as AsmType
+import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FieldInsnNode
+import org.objectweb.asm.tree.FieldNode as AsmFieldNode
+import org.objectweb.asm.tree.InsnNode
+import org.objectweb.asm.tree.IntInsnNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.TypeInsnNode
+import org.objectweb.asm.tree.VarInsnNode
+import org.w3c.dom.Element
+import org.w3c.dom.Node as DomNode
 import sootup.core.frontend.BodySource
 import sootup.core.graph.StmtGraph
 import sootup.core.jimple.basic.NoPositionInformation
@@ -83,6 +107,28 @@ class SootUpAdapter(
 
     private data class LocalKey(val method: MethodDescriptor, val name: String)
     private data class ParameterBinding(val method: MethodDescriptor, val index: Int)
+    private data class PlaceholderBinding(
+        val key: String?,
+        val defaultValue: Any?,
+        val hasDefaultValue: Boolean
+    )
+    private data class BundleControlSpec(
+        val noFallback: Boolean = false,
+        val formats: Set<String> = setOf("java.properties", "java.class"),
+        val candidateLocales: List<String>? = null
+    )
+    private data class LocaleBuilderSpec(
+        val language: String? = null,
+        val country: String? = null,
+        val variant: String? = null,
+        val languageTag: String? = null
+    ) {
+        fun toLocaleSpec(): String? {
+            languageTag?.takeIf { it.isNotBlank() }?.let { return it }
+            val raw = listOfNotNull(language, country, variant).joinToString("_")
+            return raw.takeIf { it.isNotBlank() }
+        }
+    }
 
     // Maps to track created nodes for cross-referencing
     private val localNodes = mutableMapOf<LocalKey, LocalVariable>()
@@ -112,11 +158,23 @@ class SootUpAdapter(
     private val fieldDynamicTargets = mutableMapOf<String, MutableList<MethodDescriptor>>()
 
     private val arrayDynamicTargets = mutableMapOf<LocalKey, MutableList<MethodDescriptor>>()
+    private val localeSpecsByLocal = mutableMapOf<LocalKey, String>()
+    private val localeBuilderSpecsByLocal = mutableMapOf<LocalKey, LocaleBuilderSpec>()
+    private val stringValuesByLocal = mutableMapOf<LocalKey, String>()
+    private val bundleControlFormatsByLocal = mutableMapOf<LocalKey, String?>()
+    private val resourceHandlePathsByLocal = mutableMapOf<LocalKey, LinkedHashSet<String>>()
+    private val propertiesPathsByLocal = mutableMapOf<LocalKey, LinkedHashSet<String>>()
+    private val resourceBundlePaths = mutableMapOf<LocalKey, LinkedHashSet<String>>()
+    private val bundleControlSpecsByLocal = mutableMapOf<LocalKey, BundleControlSpec>()
 
     private val fieldLoadLocals = mutableMapOf<String, MutableList<LocalKey>>()
 
     private val resolvedMethodCache = mutableMapOf<MethodSignature, MethodSignature>()
     private val methodDescriptorCache = mutableMapOf<MethodSignature, MethodDescriptor>()
+    private val resourceFilesByPath = mutableMapOf<String, MutableList<ResourceFileNode>>()
+    private val configurationResourcePaths = linkedSetOf<String>()
+    private val runtimeIndexedBundles = mutableSetOf<String>()
+    private val bundleControlSpecsByClass = mutableMapOf<String, BundleControlSpec?>()
 
     // Per-method: tracks which NodeIds were created from each statement
     // Reset per method in processMethod()
@@ -129,6 +187,8 @@ class SootUpAdapter(
      * Build the complete graph from the SootUp view
      */
     fun buildGraph(): Graph {
+        indexResourceValues()
+        indexClassBundles()
         log("Starting buildGraph pass 1")
         var pass1Count = 0
         // Pass 1: All classes — type hierarchy + enum values
@@ -388,6 +448,18 @@ class SootUpAdapter(
      */
     private fun visitFieldsForClass(sootClass: SootClass) {
         val className = sootClass.type.fullyQualifiedName
+        val configurationPropertiesPrefix = extractConfigurationPropertiesPrefix(sootClass)
+        val valueAnnotationsByField = if (sootClass is JavaSootClass) {
+            val fromSoot = sootClass.fields.associate { it.signature.toString() to extractValueAnnotationBinding(it.annotations) }
+            val fromAsm = getAsmFieldNodes(sootClass)
+                ?.associate { asmField -> asmField.name to extractValueAnnotationBinding(asmField) }
+                ?: emptyMap()
+            sootClass.fields.associate { field ->
+                field.signature.toString() to (fromSoot[field.signature.toString()] ?: fromAsm[field.name])
+            }
+        } else {
+            emptyMap()
+        }
         sootClass.fields.forEach { field ->
             val fieldName = field.name
 
@@ -399,6 +471,8 @@ class SootUpAdapter(
             // Use field signature as key (same format as getOrCreateField)
             val fieldSig = field.signature.toString()
             if (fieldNodes.containsKey(fieldSig)) {
+                linkValueAnnotatedField(valueAnnotationsByField[fieldSig], fieldNodes[fieldSig]!!)
+                linkConfigurationPropertiesField(configurationPropertiesPrefix, field.name, fieldNodes[fieldSig]!!)
                 return@forEach
             }
 
@@ -419,6 +493,8 @@ class SootUpAdapter(
             )
             fieldNodes[fieldSig] = node
             graphBuilder.addNode(node)
+            linkValueAnnotatedField(valueAnnotationsByField[fieldSig], node)
+            linkConfigurationPropertiesField(configurationPropertiesPrefix, field.name, node)
         }
     }
 
@@ -515,6 +591,9 @@ class SootUpAdapter(
             val allocType = toTypeDescriptor(rightOp.type)
             val allocNode = getOrCreateLocalWithType(leftOp, method, allocType)
             allocationNodes[localKey(method, leftOp.name)] = allocNode
+            if (isLocaleBuilderClassName(allocType.className)) {
+                localeBuilderSpecsByLocal[localKey(method, leftOp.name)] = LocaleBuilderSpec()
+            }
             recordStmtNode(stmt, allocNode.id)
             return
         }
@@ -596,6 +675,29 @@ class SootUpAdapter(
             } else if (trackCrossMethodFunctionalDispatch) {
                 // Record for deferred resolution
                 fieldLoadLocals.getOrPut(fieldKey) { mutableListOf() }.add(localKey)
+            }
+        }
+
+        if (leftOp is Local) {
+            val targetKey = localKey(method, leftOp.name)
+            when (rightOp) {
+                is SootStringConstant -> stringValuesByLocal[targetKey] = rightOp.value
+                is Local -> stringValuesByLocal[localKey(method, rightOp.name)]?.let { stringValuesByLocal[targetKey] = it }
+            }
+            when (rightOp) {
+                is Local -> {
+                    localeSpecsByLocal[localKey(method, rightOp.name)]?.let { localeSpecsByLocal[targetKey] = it }
+                    localeBuilderSpecsByLocal[localKey(method, rightOp.name)]?.let { localeBuilderSpecsByLocal[targetKey] = it }
+                    bundleControlFormatsByLocal[localKey(method, rightOp.name)]?.let { bundleControlFormatsByLocal[targetKey] = it }
+                    resourceHandlePathsByLocal[localKey(method, rightOp.name)]?.let { resourceHandlePathsByLocal[targetKey] = LinkedHashSet(it) }
+                    propertiesPathsByLocal[localKey(method, rightOp.name)]?.let { propertiesPathsByLocal[targetKey] = LinkedHashSet(it) }
+                    resourceBundlePaths[localKey(method, rightOp.name)]?.let { resourceBundlePaths[targetKey] = LinkedHashSet(it) }
+                    bundleControlSpecsByLocal[localKey(method, rightOp.name)]?.let { bundleControlSpecsByLocal[targetKey] = it }
+                }
+                is JStaticFieldRef -> {
+                    extractLocaleSpec(method, rightOp)?.let { localeSpecsByLocal[targetKey] = it }
+                    extractControlFormat(method, rightOp)?.let { bundleControlFormatsByLocal[targetKey] = it }
+                }
             }
         }
 
@@ -690,6 +792,15 @@ class SootUpAdapter(
             return
         }
 
+        if (calleeSignature.declClassType.fullyQualifiedName == "java.util.Locale" && calleeSignature.name == "<init>") {
+            val receiverLocal = (invokeExpr as? AbstractInstanceInvokeExpr)?.base as? Local
+            val localeSpec = extractConstructedLocaleSpec(invokeExpr)
+            if (receiverLocal != null && localeSpec != null) {
+                localeSpecsByLocal[localKey(caller, receiverLocal.name)] = localeSpec
+            }
+        }
+        updateLocaleBuilderState(caller, calleeSignature, invokeExpr, resultNode)
+
         // Extract receiver for instance method calls
         val receiverNode = if (invokeExpr is AbstractInstanceInvokeExpr) {
             getOrCreateValueNode(invokeExpr.base, caller)
@@ -710,6 +821,11 @@ class SootUpAdapter(
         if (stmt != null) {
             recordStmtNode(stmt, callSite.id)
         }
+        linkResourceReads(callSite, calleeSignature, invokeExpr)
+        linkResourceFileReads(callSite, calleeSignature, invokeExpr, caller)
+        linkResourceBundleReads(callSite, calleeSignature, invokeExpr, caller)
+        linkStructuredResourceLoads(callSite, calleeSignature, invokeExpr, caller)
+        trackResourceAssociations(callSite, calleeSignature, invokeExpr, caller, resultNode)
 
         // Resolve functional interface dispatch:
         // If the receiver was assigned from an invokedynamic, connect this
@@ -830,6 +946,10 @@ class SootUpAdapter(
         // Track call result locals for return value propagation
         if (resultNode is LocalVariable) {
             val resultKey = localKey(caller, resultNode.name)
+            extractResourceLookupPath(caller, calleeSignature, invokeExpr)?.let { resourceHandlePathsByLocal[resultKey] = linkedSetOf(it) }
+            extractResourceBundlePaths(caller, calleeSignature, invokeExpr)?.let { resourceBundlePaths[resultKey] = LinkedHashSet(it) }
+            extractLocaleFactorySpec(calleeSignature, invokeExpr)?.let { localeSpecsByLocal[resultKey] = it }
+            extractBundleControlSpec(caller, calleeSignature, invokeExpr)?.let { bundleControlSpecsByLocal[resultKey] = it }
             if (trackCrossMethodFunctionalDispatch) {
                 callResultLocals
                     .getOrPut(callee) { mutableListOf() }
@@ -996,6 +1116,7 @@ class SootUpAdapter(
     }
 
     companion object {
+        private val NULL_CONSTANT_KEY = Any()
         private val WRAPPER_CLASSES = setOf(
             "java.lang.Integer",
             "java.lang.Long",
@@ -1006,8 +1127,18 @@ class SootUpAdapter(
             "java.lang.Boolean",
             "java.lang.Character"
         )
+        private const val LOCALE_BUILDER_CLASS = "java.util.Locale\$Builder"
+        private const val LOCALE_BUILDER_CLASS_ALT = "java.util.Locale.Builder"
+        private const val RESOURCE_BUNDLE_CONTROL_CLASS = "java.util.ResourceBundle\$Control"
+        private const val RESOURCE_BUNDLE_CONTROL_CLASS_ALT = "java.util.ResourceBundle.Control"
         private const val MAX_CONTROL_FLOW_STATEMENTS = 2_000
     }
+
+    private fun isLocaleBuilderClassName(name: String): Boolean =
+        name == LOCALE_BUILDER_CLASS || name == LOCALE_BUILDER_CLASS_ALT
+
+    private fun isResourceBundleControlTypeName(name: String): Boolean =
+        name == RESOURCE_BUNDLE_CONTROL_CLASS || name == RESOURCE_BUNDLE_CONTROL_CLASS_ALT
 
     private fun processReturn(stmt: JReturnStmt, method: MethodDescriptor) {
         val returnValue = stmt.op
@@ -1377,6 +1508,42 @@ class SootUpAdapter(
     }
 
     private fun getAsmMethodNodes(sootClass: JavaSootClass): List<MethodNode>? {
+        val classNode = getAsmClassNode(sootClass) ?: return null
+        @Suppress("UNCHECKED_CAST")
+        return classNode.methods as? List<MethodNode>
+    }
+
+    private fun getAsmFieldNodes(sootClass: JavaSootClass): List<AsmFieldNode>? {
+        return try {
+            val resourcePath = sootClass.type.fullyQualifiedName.replace('.', '/') + ".class"
+            resourceAccessor.open(resourcePath).use { input ->
+                val classNode = ClassNode()
+                ClassReader(input).accept(classNode, ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES)
+                @Suppress("UNCHECKED_CAST")
+                classNode.fields as? List<AsmFieldNode>
+            }
+        } catch (_: Exception) {
+            val classNode = getAsmClassNode(sootClass) ?: return null
+            @Suppress("UNCHECKED_CAST")
+            classNode.fields as? List<AsmFieldNode>
+        }
+    }
+
+    private fun loadMethodNodesFromResource(sootClass: JavaSootClass): List<MethodNode>? {
+        return try {
+            val resourcePath = sootClass.type.fullyQualifiedName.replace('.', '/') + ".class"
+            resourceAccessor.open(resourcePath).use { input ->
+                val classNode = ClassNode()
+                ClassReader(input).accept(classNode, ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES)
+                @Suppress("UNCHECKED_CAST")
+                classNode.methods as? List<MethodNode>
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun getAsmClassNode(sootClass: JavaSootClass): ClassNode? {
         val classSource = sootClass.classSource
         if (classSource.javaClass.name != "sootup.java.bytecode.frontend.conversion.AsmClassSource") {
             return null
@@ -1385,9 +1552,7 @@ class SootUpAdapter(
         return try {
             val classNodeField = classSource.javaClass.getDeclaredField("classNode")
             classNodeField.isAccessible = true
-            val classNode = classNodeField.get(classSource) as? ClassNode ?: return null
-            @Suppress("UNCHECKED_CAST")
-            classNode.methods as? List<MethodNode>
+            classNodeField.get(classSource) as? ClassNode
         } catch (_: ReflectiveOperationException) {
             null
         }
@@ -1518,6 +1683,43 @@ class SootUpAdapter(
         }
     }
 
+    private fun getOrCreateConstantValue(value: Any?): ConstantNode {
+        val cacheKey = value ?: NULL_CONSTANT_KEY
+        return constantNodes.getOrPut(cacheKey) {
+            val node = when (value) {
+                null -> NullConstant(
+                    id = nextNodeId("const")
+                )
+                is Int -> IntConstant(
+                    id = nextNodeId("const"),
+                    value = value
+                )
+                is Long -> LongConstant(
+                    id = nextNodeId("const"),
+                    value = value
+                )
+                is Float -> FloatConstant(
+                    id = nextNodeId("const"),
+                    value = value
+                )
+                is Double -> DoubleConstant(
+                    id = nextNodeId("const"),
+                    value = value
+                )
+                is Boolean -> BooleanConstant(
+                    id = nextNodeId("const"),
+                    value = value
+                )
+                else -> StringConstant(
+                    id = nextNodeId("const"),
+                    value = value.toString()
+                )
+            }
+            graphBuilder.addNode(node)
+            node
+        }
+    }
+
     private fun getOrCreateField(fieldRef: JFieldRef): FieldNode {
         val fieldSig = fieldRef.fieldSignature
         val key = fieldSig.toString()
@@ -1552,6 +1754,1242 @@ class SootUpAdapter(
             is SootStringConstant -> constant.value
             is SootNullConstant -> null
             else -> null
+        }
+    }
+
+    private fun indexResourceValues() {
+        resourceAccessor.list("**")
+            .forEach { entry ->
+                val format = resourceFormat(entry.path)
+                val profile = resourceProfile(entry.path)
+                val fileNode = ResourceFileNode(
+                    id = nextNodeId("resource"),
+                    path = entry.path,
+                    source = entry.source,
+                    format = format,
+                    profile = profile
+                )
+                graphBuilder.addNode(fileNode)
+                resourceFilesByPath.getOrPut(entry.path) { mutableListOf() }.add(fileNode)
+                if (isResourceConfig(entry.path)) {
+                    configurationResourcePaths += entry.path
+                }
+            }
+    }
+
+    private fun indexClassBundles() {
+        view.classes.forEach { sootClass ->
+            if (!isListResourceBundleClass(sootClass)) return@forEach
+            indexListResourceBundle(sootClass)
+        }
+    }
+
+    private fun indexListResourceBundle(sootClass: SootClass) {
+        val path = sootClass.type.fullyQualifiedName
+        if (resourceFilesByPath.containsKey(path)) return
+        val fileNode = ResourceFileNode(
+            id = nextNodeId("resource"),
+            path = path,
+            source = "class-bundle",
+            format = "listbundle",
+            profile = null
+        )
+        graphBuilder.addNode(fileNode)
+        resourceFilesByPath.getOrPut(path) { mutableListOf() }.add(fileNode)
+    }
+
+    private fun isListResourceBundleClass(sootClass: SootClass): Boolean {
+        var current: SootClass? = sootClass
+        while (current != null) {
+            val superType = current.superclass.orElse(null) ?: return false
+            val superName = superType.fullyQualifiedName
+            if (superName == "java.util.ListResourceBundle") return true
+            current = resolveClassByName(superName)
+        }
+        return false
+    }
+
+    private fun resolveClassByName(className: String): SootClass? {
+        for (candidate in view.classes) {
+            if (candidate.type.fullyQualifiedName == className) {
+                return candidate
+            }
+        }
+        return null
+    }
+
+    private fun extractListResourceBundleEntries(sootClass: SootClass): Map<String, Any?> {
+        val javaSootClass = sootClass as? JavaSootClass ?: return emptyMap()
+        val methodNode = (getAsmMethodNodes(javaSootClass) ?: loadMethodNodesFromResource(javaSootClass))
+            ?.firstOrNull { it.name == "getContents" }
+            ?: return emptyMap()
+        val returned = evaluateArrayLiteral(methodNode) as? List<*> ?: return emptyMap()
+        return buildMap {
+            returned.forEach { entry ->
+                val tuple = entry as? List<*> ?: return@forEach
+                val key = tuple.getOrNull(0) as? String ?: return@forEach
+                put(key, normalizeRuntimeBundleValue(tuple.getOrNull(1)))
+            }
+        }
+    }
+
+    private fun evaluateArrayLiteral(methodNode: MethodNode): Any? {
+        val stack = ArrayDeque<Any?>()
+        val locals = mutableMapOf<Int, Any?>()
+        for (insn in methodNode.instructions) {
+            when (insn) {
+                is InsnNode -> when (insn.opcode) {
+                    Opcodes.ACONST_NULL -> stack.addLast(null)
+                    Opcodes.ICONST_M1 -> stack.addLast(-1)
+                    Opcodes.ICONST_0 -> stack.addLast(0)
+                    Opcodes.ICONST_1 -> stack.addLast(1)
+                    Opcodes.ICONST_2 -> stack.addLast(2)
+                    Opcodes.ICONST_3 -> stack.addLast(3)
+                    Opcodes.ICONST_4 -> stack.addLast(4)
+                    Opcodes.ICONST_5 -> stack.addLast(5)
+                    Opcodes.DUP -> stack.lastOrNull()?.let(stack::addLast)
+                    Opcodes.AASTORE -> {
+                        val value = stack.removeLastOrNull()
+                        val index = (stack.removeLastOrNull() as? Number)?.toInt() ?: continue
+                        val array = stack.removeLastOrNull() as? MutableList<Any?> ?: continue
+                        if (index in array.indices) array[index] = value
+                    }
+                    Opcodes.ARETURN -> return stack.removeLastOrNull()
+                    Opcodes.ALOAD, Opcodes.ILOAD -> Unit
+                    else -> Unit
+                }
+                is IntInsnNode -> when (insn.opcode) {
+                    Opcodes.BIPUSH, Opcodes.SIPUSH -> stack.addLast(insn.operand)
+                }
+                is LdcInsnNode -> stack.addLast(insn.cst)
+                is TypeInsnNode -> if (insn.opcode == Opcodes.ANEWARRAY) {
+                    val size = (stack.removeLastOrNull() as? Number)?.toInt() ?: continue
+                    stack.addLast(MutableList<Any?>(size) { null })
+                }
+                is VarInsnNode -> when (insn.opcode) {
+                    Opcodes.ASTORE, Opcodes.ISTORE -> locals[insn.`var`] = stack.removeLastOrNull()
+                    Opcodes.ALOAD, Opcodes.ILOAD -> stack.addLast(locals[insn.`var`])
+                }
+                else -> Unit
+            }
+        }
+        return null
+    }
+
+    private fun extractControlFormatsFromMethod(methodNode: MethodNode): Set<String>? =
+        when (val value = evaluateLiteralMethod(methodNode)) {
+            is List<*> -> value.mapNotNull {
+                when (it) {
+                    "java.class", "java.properties" -> it as String
+                    else -> null
+                }
+            }.toSet().takeIf { it.isNotEmpty() }
+            "java.class" -> setOf("java.class")
+            "java.properties" -> setOf("java.properties")
+            else -> null
+        }
+
+    private fun extractCandidateLocalesFromMethod(methodNode: MethodNode): List<String>? =
+        (evaluateLiteralMethod(methodNode) as? List<*>)
+            ?.mapNotNull { value ->
+                when (value) {
+                    is String -> normalizeLocaleSpec(value)
+                    else -> null
+                }
+            }
+            ?.takeIf { it.isNotEmpty() }
+
+    private fun returnsNullLiteral(methodNode: MethodNode): Boolean =
+        evaluateLiteralMethod(methodNode) == null
+
+    private fun evaluateLiteralMethod(methodNode: MethodNode): Any? {
+        val stack = ArrayDeque<Any?>()
+        val locals = mutableMapOf<Int, Any?>()
+        val argTypes = AsmType.getArgumentTypes(methodNode.desc)
+        var localIndex = if ((methodNode.access and Opcodes.ACC_STATIC) != 0) 0 else 1
+        argTypes.forEach { argType ->
+            locals[localIndex] = when (argType.className) {
+                "java.util.Locale" -> "arg-locale"
+                "java.lang.String" -> "arg-string"
+                else -> null
+            }
+            localIndex += argType.size
+        }
+        for (insn in methodNode.instructions) {
+            when (insn) {
+                is InsnNode -> when (insn.opcode) {
+                    Opcodes.ACONST_NULL -> stack.addLast(null)
+                    Opcodes.ICONST_M1 -> stack.addLast(-1)
+                    Opcodes.ICONST_0 -> stack.addLast(0)
+                    Opcodes.ICONST_1 -> stack.addLast(1)
+                    Opcodes.ICONST_2 -> stack.addLast(2)
+                    Opcodes.ICONST_3 -> stack.addLast(3)
+                    Opcodes.ICONST_4 -> stack.addLast(4)
+                    Opcodes.ICONST_5 -> stack.addLast(5)
+                    Opcodes.DUP -> stack.lastOrNull()?.let(stack::addLast)
+                    Opcodes.ARETURN -> return stack.removeLastOrNull()
+                }
+                is IntInsnNode -> when (insn.opcode) {
+                    Opcodes.BIPUSH, Opcodes.SIPUSH -> stack.addLast(insn.operand)
+                }
+                is LdcInsnNode -> stack.addLast(insn.cst)
+                is VarInsnNode -> when (insn.opcode) {
+                    Opcodes.ASTORE, Opcodes.ISTORE -> locals[insn.`var`] = stack.removeLastOrNull()
+                    Opcodes.ALOAD, Opcodes.ILOAD -> stack.addLast(locals[insn.`var`])
+                }
+                is FieldInsnNode -> if (insn.opcode == Opcodes.GETSTATIC) {
+                    stack.addLast(resolveStaticLiteral(insn.owner.replace('/', '.'), insn.name))
+                }
+                is MethodInsnNode -> {
+                    val args = buildList {
+                        repeat(AsmType.getArgumentTypes(insn.desc).size) {
+                            add(0, stack.removeLastOrNull())
+                        }
+                    }
+                    val owner = insn.owner.replace('/', '.')
+                    val result = when {
+                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.List" && insn.name == "of" -> args
+                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Arrays" && insn.name == "asList" -> {
+                            val first = args.singleOrNull()
+                            when (first) {
+                                is List<*> -> first
+                                else -> args
+                            }
+                        }
+                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Collections" && insn.name == "singletonList" -> args
+                        insn.opcode == Opcodes.INVOKESTATIC && owner == "java.util.Locale" && insn.name == "forLanguageTag" -> {
+                            (args.firstOrNull() as? String)?.let(::normalizeLocaleSpec)
+                        }
+                        insn.opcode == Opcodes.INVOKESPECIAL && owner == "java.util.Locale" && insn.name == "<init>" -> {
+                            null
+                        }
+                        else -> null
+                    }
+                    if (AsmType.getReturnType(insn.desc).sort != AsmType.VOID) {
+                        stack.addLast(result)
+                    }
+                }
+                else -> Unit
+            }
+        }
+        return null
+    }
+
+    private fun resolveStaticLiteral(owner: String, fieldName: String): Any? = when {
+        fieldName == "FORMAT_CLASS" -> listOf("java.class")
+        fieldName == "FORMAT_PROPERTIES" -> listOf("java.properties")
+        fieldName == "FORMAT_DEFAULT" -> listOf("java.class", "java.properties")
+        owner == "java.util.ResourceBundle.Control" || owner == "java.util.ResourceBundle\$Control" -> when (fieldName) {
+            "FORMAT_CLASS" -> listOf("java.class")
+            "FORMAT_PROPERTIES" -> listOf("java.properties")
+            "FORMAT_DEFAULT" -> listOf("java.class", "java.properties")
+            else -> null
+        }
+        owner == "java.util.Locale" -> extractLocaleSpec(fieldName)
+        else -> null
+    }
+
+    private fun linkResourceReads(callSite: CallSiteNode, calleeSignature: MethodSignature, invokeExpr: AbstractInvokeExpr) {
+        val configKey = extractResourceLookupKey(calleeSignature, invokeExpr)
+        val resourcePaths = extractBoundResourcePaths(callSite.caller, calleeSignature, invokeExpr)
+        if (configKey != null) {
+            lookupResourceFiles(resourcePaths).forEach { resourceFile ->
+                graphBuilder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.LOOKUP))
+            }
+            return
+        }
+
+        if (isResourceEnumerationCall(calleeSignature)) {
+            resourcePaths?.forEach { path ->
+                resourceFilesByPath[path]?.forEach { resourceFile ->
+                    graphBuilder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.ENUMERATES))
+                }
+            }
+        }
+    }
+
+    private fun linkResourceFileReads(
+        callSite: CallSiteNode,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr,
+        caller: MethodDescriptor
+    ) {
+        val resourcePaths = extractResourceBundlePaths(caller, calleeSignature, invokeExpr)
+            ?: extractResourceLookupPath(caller, calleeSignature, invokeExpr)?.let(::listOf)
+            ?: return
+        resourcePaths.forEach { resourcePath ->
+            resourceFilesByPath[resourcePath]?.forEach { resourceFile ->
+                graphBuilder.addEdge(
+                    ResourceEdge(
+                        from = resourceFile.id,
+                        to = callSite.id,
+                        kind = if (isResourceBundleCall(calleeSignature)) ResourceRelation.BUNDLE_CANDIDATE else ResourceRelation.OPENS
+                    )
+                )
+            }
+        }
+    }
+
+    private fun extractResourceLookupKey(calleeSignature: MethodSignature, invokeExpr: AbstractInvokeExpr): String? {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        val methodName = calleeSignature.name
+        if (methodName !in setOf("getProperty", "getString", "getObject")) return null
+        val supported = declaringClass == "java.util.Properties" ||
+            declaringClass == "java.util.PropertyResourceBundle" ||
+            declaringClass == "java.util.ResourceBundle" ||
+            declaringClass == "java.lang.System" ||
+            declaringClass == "org.springframework.core.env.Environment" ||
+            declaringClass == "org.springframework.core.env.PropertyResolver"
+        if (!supported || invokeExpr.args.isEmpty()) return null
+        val firstArg = invokeExpr.args[0]
+        return if (firstArg is SootStringConstant) firstArg.value else null
+    }
+
+    private fun extractResourceLookupPath(
+        caller: MethodDescriptor,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr
+    ): String? {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        val methodName = calleeSignature.name
+        val supported = (declaringClass == "java.lang.ClassLoader" && methodName in setOf("getResource", "getResourceAsStream")) ||
+            (declaringClass == "java.lang.Class" && methodName in setOf("getResource", "getResourceAsStream"))
+        if (!supported || invokeExpr.args.isEmpty()) return null
+        val firstArg = invokeExpr.args[0] as? SootStringConstant ?: return null
+        return normalizeResourcePath(caller, declaringClass, firstArg.value)
+    }
+
+    private fun extractResourceBundlePaths(
+        caller: MethodDescriptor,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr
+    ): LinkedHashSet<String>? {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        val methodName = calleeSignature.name
+        if (declaringClass != "java.util.ResourceBundle" || methodName != "getBundle" || invokeExpr.args.isEmpty()) {
+            return null
+        }
+        val firstArg = invokeExpr.args[0] as? SootStringConstant ?: return null
+        val baseName = firstArg.value
+        val basePath = baseName.replace('.', '/')
+        val localeArg = calleeSignature.parameterTypes
+            .indexOfFirst { it.toString() == "java.util.Locale" }
+            .takeIf { it >= 0 }
+            ?.let(invokeExpr.args::getOrNull)
+        val controlArg = calleeSignature.parameterTypes
+            .indexOfFirst { isResourceBundleControlTypeName(it.toString()) }
+            .takeIf { it >= 0 }
+            ?.let(invokeExpr.args::getOrNull)
+        val localeSpec = localeArg?.let { extractLocaleSpec(caller, it) }
+        val controlSpec = controlArg?.let { extractBundleControlSpec(caller, it, baseName, localeSpec) }
+        ensureRuntimeBundleIndexed(baseName, localeSpec, controlSpec)
+        return if (localeArg == null) {
+            collectBundleCandidates(baseName, basePath, controlSpec)
+        } else if (localeSpec != null) {
+            buildResourceBundleCandidatePaths(baseName, basePath, localeSpec, controlSpec)
+        } else {
+            collectMatchingResourceBundlePaths(baseName, basePath, controlSpec)
+        }
+    }
+
+    private fun linkResourceBundleReads(
+        callSite: CallSiteNode,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr,
+        caller: MethodDescriptor
+    ) {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        val methodName = calleeSignature.name
+        if (declaringClass != "java.util.ResourceBundle" || methodName !in setOf("getString", "getObject", "getKeys")) return
+        val receiverLocal = (invokeExpr as? AbstractInstanceInvokeExpr)?.base as? Local ?: return
+        val bundlePaths = resourceBundlePaths[localKey(caller, receiverLocal.name)] ?: return
+        if (methodName == "getKeys") {
+            bundlePaths.forEach { bundlePath ->
+                resourceFilesByPath[bundlePath]?.forEach { resourceFile ->
+                    graphBuilder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.ENUMERATES))
+                }
+            }
+            return
+        }
+        bundlePaths.forEach { bundlePath ->
+            resourceFilesByPath[bundlePath]
+                ?.forEach { resourceFile ->
+                    graphBuilder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.LOOKUP))
+                }
+        }
+    }
+
+    private fun linkStructuredResourceLoads(
+        callSite: CallSiteNode,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr,
+        caller: MethodDescriptor
+    ) {
+        if (!isStructuredResourceLoadCall(calleeSignature)) return
+        extractBoundResourcePaths(caller, calleeSignature, invokeExpr)?.forEach { resourcePath ->
+            resourceFilesByPath[resourcePath]?.forEach { resourceFile ->
+                graphBuilder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.LOADS))
+            }
+        }
+    }
+
+    private fun trackResourceAssociations(
+        callSite: CallSiteNode,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr,
+        caller: MethodDescriptor,
+        resultNode: ValueNode?
+    ) {
+        val receiverLocal = (invokeExpr as? AbstractInstanceInvokeExpr)?.base as? Local
+        if (calleeSignature.declClassType.fullyQualifiedName == "java.util.Locale" && calleeSignature.name == "<init>") {
+            val localeSpec = extractConstructedLocaleSpec(invokeExpr)
+            if (receiverLocal != null && localeSpec != null) {
+                localeSpecsByLocal[localKey(caller, receiverLocal.name)] = localeSpec
+            }
+        }
+
+        val boundPaths = extractBoundResourcePaths(caller, calleeSignature, invokeExpr)
+        if (boundPaths != null) {
+            when {
+                isPropertiesLoadCall(calleeSignature) && receiverLocal != null -> {
+                    propertiesPathsByLocal[localKey(caller, receiverLocal.name)] = LinkedHashSet(boundPaths)
+                    boundPaths.forEach { path ->
+                        resourceFilesByPath[path]?.forEach { resourceFile ->
+                            graphBuilder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.LOADS))
+                        }
+                    }
+                }
+                isPropertyResourceBundleConstructor(calleeSignature) && receiverLocal != null -> {
+                    val receiverKey = localKey(caller, receiverLocal.name)
+                    resourceBundlePaths[receiverKey] = LinkedHashSet(boundPaths)
+                    boundPaths.forEach { path ->
+                        resourceFilesByPath[path]?.forEach { resourceFile ->
+                            graphBuilder.addEdge(ResourceEdge(resourceFile.id, callSite.id, ResourceRelation.LOADS))
+                        }
+                    }
+                }
+                isReaderBridgeConstructor(calleeSignature) && receiverLocal != null -> {
+                    resourceHandlePathsByLocal[localKey(caller, receiverLocal.name)] = LinkedHashSet(boundPaths)
+                }
+            }
+        }
+
+        if (resultNode is LocalVariable) {
+            val resultKey = localKey(caller, resultNode.name)
+            extractResourceLookupPath(caller, calleeSignature, invokeExpr)?.let {
+                resourceHandlePathsByLocal[resultKey] = linkedSetOf(it)
+            }
+            if (isReaderFactoryCall(calleeSignature)) {
+                boundPaths?.let { resourceHandlePathsByLocal[resultKey] = LinkedHashSet(it) }
+            }
+        }
+    }
+
+    private fun extractBoundResourcePaths(
+        caller: MethodDescriptor,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr
+    ): LinkedHashSet<String>? {
+        val directPath = extractResourceLookupPath(caller, calleeSignature, invokeExpr)
+        if (directPath != null) return linkedSetOf(directPath)
+
+        val boundPaths = LinkedHashSet<String>()
+        (invokeExpr as? AbstractInstanceInvokeExpr)?.base
+            ?.let { extractBoundResourcePaths(caller, it) }
+            ?.let(boundPaths::addAll)
+        invokeExpr.args.forEach { arg ->
+            extractBoundResourcePaths(caller, arg)?.let(boundPaths::addAll)
+        }
+        return boundPaths.takeIf { it.isNotEmpty() }
+    }
+
+    private fun extractBoundResourcePaths(caller: MethodDescriptor, value: Value): LinkedHashSet<String>? = when (value) {
+        is Local -> {
+            val key = localKey(caller, value.name)
+            resourceHandlePathsByLocal[key]
+                ?: propertiesPathsByLocal[key]
+                ?: resourceBundlePaths[key]
+        }
+        else -> null
+    }?.let(::LinkedHashSet)
+
+    private fun lookupResourceFiles(resourcePaths: Collection<String>?): Sequence<ResourceFileNode> {
+        val scopedPaths = resourcePaths?.takeIf { it.isNotEmpty() } ?: configurationResourcePaths
+        return scopedPaths.asSequence()
+            .flatMap { path -> resourceFilesByPath[path].orEmpty().asSequence() }
+            .distinctBy { it.id }
+    }
+
+    private fun isResourceBundleCall(calleeSignature: MethodSignature): Boolean =
+        calleeSignature.declClassType.fullyQualifiedName == "java.util.ResourceBundle" &&
+            calleeSignature.name == "getBundle"
+
+    private fun isResourceEnumerationCall(calleeSignature: MethodSignature): Boolean {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        return (declaringClass == "java.util.ResourceBundle" || declaringClass == "java.util.PropertyResourceBundle") &&
+            calleeSignature.name == "getKeys"
+    }
+
+    private fun isPropertiesLoadCall(calleeSignature: MethodSignature): Boolean =
+        calleeSignature.declClassType.fullyQualifiedName == "java.util.Properties" &&
+            calleeSignature.name in setOf("load", "loadFromXML")
+
+    private fun isPropertyResourceBundleConstructor(calleeSignature: MethodSignature): Boolean =
+        calleeSignature.declClassType.fullyQualifiedName == "java.util.PropertyResourceBundle" &&
+            calleeSignature.name == "<init>"
+
+    private fun isReaderBridgeConstructor(calleeSignature: MethodSignature): Boolean {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        return calleeSignature.name == "<init>" && declaringClass in setOf(
+            "java.io.InputStreamReader",
+            "java.io.BufferedReader",
+            "java.io.StringReader",
+            "java.io.LineNumberReader"
+        )
+    }
+
+    private fun isReaderFactoryCall(calleeSignature: MethodSignature): Boolean {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        val methodName = calleeSignature.name
+        return (declaringClass == "java.net.URL" && methodName == "openStream") ||
+            (declaringClass == "java.nio.channels.Channels" && methodName == "newReader")
+    }
+
+    private fun isStructuredResourceLoadCall(calleeSignature: MethodSignature): Boolean {
+        val declaringClass = calleeSignature.declClassType.fullyQualifiedName
+        val methodName = calleeSignature.name
+        if (isPropertiesLoadCall(calleeSignature) || isPropertyResourceBundleConstructor(calleeSignature)) return true
+        return when (declaringClass) {
+            "com.fasterxml.jackson.databind.ObjectMapper" -> methodName in setOf("readTree", "readValue", "readValues")
+            "com.fasterxml.jackson.dataformat.xml.XmlMapper" -> methodName in setOf("readTree", "readValue", "readValues")
+            "com.google.gson.Gson" -> methodName == "fromJson"
+            "org.yaml.snakeyaml.Yaml" -> methodName in setOf("load", "loadAll", "loadAs")
+            "javax.xml.parsers.DocumentBuilder" -> methodName == "parse"
+            "org.dom4j.io.SAXReader" -> methodName == "read"
+            "org.jdom2.input.SAXBuilder" -> methodName == "build"
+            else -> false
+        }
+    }
+
+    private fun collectMatchingResourceBundlePaths(
+        baseName: String,
+        basePath: String,
+        controlSpec: BundleControlSpec?
+    ): LinkedHashSet<String> {
+        val candidates = resourceFilesByPath.keys
+            .filter { it == "$basePath.properties" || (it.startsWith("${basePath}_") && it.endsWith(".properties")) || matchesBundleClassPath(it, baseName) }
+            .sortedWith(compareByDescending<String> { it.count { ch -> ch == '_' } }.thenBy { it })
+        return LinkedHashSet(
+            candidates
+                .asSequence()
+                .filter { controlAllowsPath(it, controlSpec) }
+                .toList()
+                .ifEmpty { collectBundleCandidates(baseName, basePath, controlSpec) }
+        )
+    }
+
+    private fun buildResourceBundleCandidatePaths(
+        baseName: String,
+        basePath: String,
+        localeSpec: String,
+        controlSpec: BundleControlSpec?
+    ): LinkedHashSet<String> {
+        val candidates = LinkedHashSet<String>()
+        val localeCandidates = controlSpec?.candidateLocales ?: defaultBundleCandidateLocales(localeSpec)
+        for (candidateLocale in localeCandidates) {
+            if (candidateLocale.isBlank()) {
+                candidates.add("$basePath.properties")
+                candidates.add(baseName)
+            } else {
+                candidates.add("${basePath}_${candidateLocale}.properties")
+                candidates.add("${baseName}_${candidateLocale}")
+            }
+        }
+        return LinkedHashSet(
+            candidates.filter { (it in resourceFilesByPath || it == "$basePath.properties" || it == baseName) && controlAllowsPath(it, controlSpec) }
+        )
+    }
+
+    private fun defaultBundleCandidateLocales(localeSpec: String): List<String> {
+        val parts = localeSpec.split('_').filter { it.isNotBlank() }
+        return buildList {
+            for (size in parts.size downTo 1) {
+                add(parts.take(size).joinToString("_"))
+            }
+            add("")
+        }
+    }
+
+    private fun collectBundleCandidates(baseName: String, basePath: String, controlSpec: BundleControlSpec?): LinkedHashSet<String> =
+        LinkedHashSet(
+            listOf("$basePath.properties", baseName)
+                .filter { controlAllowsPath(it, controlSpec) }
+        )
+
+    private fun updateLocaleBuilderState(
+        caller: MethodDescriptor,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr,
+        resultNode: ValueNode?
+    ) {
+        if (!isLocaleBuilderClassName(calleeSignature.declClassType.fullyQualifiedName)) return
+        val receiverLocal = (invokeExpr as? AbstractInstanceInvokeExpr)?.base as? Local ?: return
+        val receiverKey = localKey(caller, receiverLocal.name)
+        val current = localeBuilderSpecsByLocal[receiverKey] ?: LocaleBuilderSpec()
+        val updated = when (calleeSignature.name) {
+            "<init>" -> LocaleBuilderSpec()
+            "setLanguage" -> current.copy(language = extractStringValue(caller, invokeExpr.args.getOrNull(0)))
+            "setRegion" -> current.copy(country = extractStringValue(caller, invokeExpr.args.getOrNull(0)))
+            "setVariant" -> current.copy(variant = extractStringValue(caller, invokeExpr.args.getOrNull(0)))
+            "setLanguageTag" -> current.copy(languageTag = extractStringValue(caller, invokeExpr.args.getOrNull(0))?.let(::normalizeLocaleSpec))
+            "setLocale" -> extractLocaleSpec(caller, invokeExpr.args.getOrNull(0) ?: return)
+                ?.split('_')
+                ?.let { parts ->
+                    LocaleBuilderSpec(
+                        language = parts.getOrNull(0),
+                        country = parts.getOrNull(1),
+                        variant = parts.drop(2).takeIf { it.isNotEmpty() }?.joinToString("_"),
+                        languageTag = null
+                    )
+                } ?: current
+            "clear", "clearExtensions" -> LocaleBuilderSpec()
+            else -> current
+        }
+        localeBuilderSpecsByLocal[receiverKey] = updated
+
+        if (resultNode is LocalVariable) {
+            val resultKey = localKey(caller, resultNode.name)
+            if (isLocaleBuilderClassName(toTypeDescriptor(calleeSignature.type).className)) {
+                localeBuilderSpecsByLocal[resultKey] = updated
+            }
+            if (calleeSignature.name == "build") {
+                updated.toLocaleSpec()?.let { localeSpecsByLocal[resultKey] = normalizeLocaleSpec(it) }
+            }
+        }
+    }
+
+    private fun extractBundleControlSpec(
+        caller: MethodDescriptor,
+        value: Value,
+        baseName: String,
+        localeSpec: String?
+    ): BundleControlSpec? {
+        val className = when (value) {
+            is Local -> {
+                val key = localKey(caller, value.name)
+                bundleControlSpecsByLocal[key]?.let { return it }
+                allocationNodes[key]?.type?.className ?: localNodes[key]?.type?.className
+            }
+            is JNewExpr -> toTypeDescriptor(value.type).className
+            else -> null
+        }
+        className ?: return null
+        return resolveBundleControlSpec(className)
+            ?: reflectBundleControlSpec(className, baseName, localeSpec)
+    }
+
+    private fun extractBundleControlSpec(
+        caller: MethodDescriptor,
+        calleeSignature: MethodSignature,
+        invokeExpr: AbstractInvokeExpr
+    ): BundleControlSpec? {
+        if (!isResourceBundleControlTypeName(calleeSignature.declClassType.fullyQualifiedName)) return null
+        val formatArg = extractControlFormat(caller, invokeExpr.args.firstOrNull())
+        return when (calleeSignature.name) {
+            "getControl" -> BundleControlSpec(formats = controlFormats(formatArg))
+            "getNoFallbackControl" -> BundleControlSpec(noFallback = true, formats = controlFormats(formatArg))
+            else -> null
+        }
+    }
+
+    private fun extractControlFormat(caller: MethodDescriptor?, value: Value?): String? {
+        return when (value) {
+            is SootStringConstant -> value.value
+            is Local -> caller?.let { bundleControlFormatsByLocal[localKey(it, value.name)] }
+            is JStaticFieldRef -> {
+                if (!isResourceBundleControlTypeName(value.fieldSignature.declClassType.fullyQualifiedName)) {
+                    null
+                } else {
+                    when (value.fieldSignature.name) {
+                        "FORMAT_PROPERTIES" -> "java.properties"
+                        "FORMAT_CLASS" -> "java.class"
+                        "FORMAT_DEFAULT" -> null
+                        else -> null
+                    }
+                }
+            }
+            else -> null
+        }
+    }
+
+    private fun controlFormats(raw: String?): Set<String> = when (raw) {
+        "java.class" -> setOf("java.class")
+        "java.properties" -> setOf("java.properties")
+        else -> setOf("java.properties", "java.class")
+    }
+
+    private fun resolveBundleControlSpec(className: String): BundleControlSpec? =
+        bundleControlSpecsByClass.getOrPut(className) {
+            val sootClass = resolveClassByName(className) ?: return@getOrPut null
+            if (!isResourceBundleControlClass(sootClass)) return@getOrPut null
+            val javaSootClass = sootClass as? JavaSootClass ?: return@getOrPut null
+            val methods = getAsmMethodNodes(javaSootClass) ?: loadMethodNodesFromResource(javaSootClass) ?: return@getOrPut null
+            val formats = methods.firstOrNull { it.name == "getFormats" }
+                ?.let(::extractControlFormatsFromMethod)
+                ?: setOf("java.properties", "java.class")
+            val candidateLocales = methods.firstOrNull { it.name == "getCandidateLocales" }
+                ?.let(::extractCandidateLocalesFromMethod)
+            val noFallback = methods.firstOrNull { it.name == "getFallbackLocale" }
+                ?.let(::returnsNullLiteral)
+                ?: false
+            BundleControlSpec(
+                noFallback = noFallback,
+                formats = formats,
+                candidateLocales = candidateLocales
+            )
+        }
+
+    private fun reflectBundleControlSpec(
+        className: String,
+        baseName: String,
+        localeSpec: String?
+    ): BundleControlSpec? = runCatching {
+        val controlClass = Class.forName(className)
+        if (!ResourceBundle.Control::class.java.isAssignableFrom(controlClass)) return null
+        val instance = controlClass.getDeclaredConstructor().newInstance() as ResourceBundle.Control
+        val locale = localeSpec?.toLocale() ?: Locale.ROOT
+        BundleControlSpec(
+            noFallback = instance.getFallbackLocale(baseName, locale) == null,
+            formats = instance.getFormats(baseName).toSet(),
+            candidateLocales = instance.getCandidateLocales(baseName, locale)
+                .map(::localeSpecOf)
+                .distinct()
+        )
+    }.getOrNull()
+
+    private fun isResourceBundleControlClass(sootClass: SootClass): Boolean {
+        var current: SootClass? = sootClass
+        while (current != null) {
+            val superType = current.superclass.orElse(null) ?: return false
+            val superName = superType.fullyQualifiedName
+            if (isResourceBundleControlTypeName(superName)) return true
+            current = resolveClassByName(superName)
+        }
+        return false
+    }
+
+    private fun controlAllowsPath(path: String, controlSpec: BundleControlSpec?): Boolean {
+        if (controlSpec == null) return true
+        val isProperties = path.endsWith(".properties")
+        val isClassBundle = !isProperties
+        return (isProperties && "java.properties" in controlSpec.formats) ||
+            (isClassBundle && "java.class" in controlSpec.formats)
+    }
+
+    private fun matchesBundleClassPath(path: String, baseName: String): Boolean =
+        path == baseName || path.startsWith("${baseName}_")
+
+    private fun ensureRuntimeBundleIndexed(baseName: String, localeSpec: String?, controlSpec: BundleControlSpec?) {
+        val bundleKey = listOf(baseName, localeSpec.orEmpty(), controlSpec?.formats?.sorted()?.joinToString(","), controlSpec?.noFallback)
+            .joinToString("|")
+        if (!runtimeIndexedBundles.add(bundleKey)) return
+        runCatching {
+            val locale = localeSpec?.toLocale() ?: Locale.ROOT
+            val classLoader = javaClass.classLoader
+            val bundle = when (controlSpec) {
+                null -> ResourceBundle.getBundle(baseName, locale, classLoader)
+                else -> ResourceBundle.getBundle(baseName, locale, classLoader, toControl(controlSpec))
+            }
+            indexRuntimeBundle(bundle)
+        }.onFailure {
+            log("Skipping runtime bundle resolution for $baseName: ${it.message}")
+        }
+    }
+
+    private fun indexRuntimeBundle(bundle: ResourceBundle) {
+        val path = bundle.javaClass.name
+        if (resourceFilesByPath.containsKey(path)) return
+        val format = when (bundle) {
+            is java.util.ListResourceBundle -> "listbundle"
+            is java.util.PropertyResourceBundle -> "propertybundle"
+            else -> "bundle"
+        }
+        val fileNode = ResourceFileNode(
+            id = nextNodeId("resource"),
+            path = path,
+            source = "runtime-bundle",
+            format = format,
+            profile = null
+        )
+        graphBuilder.addNode(fileNode)
+        resourceFilesByPath.getOrPut(path) { mutableListOf() }.add(fileNode)
+        bundleParent(bundle)?.let(::indexRuntimeBundle)
+    }
+
+    private fun normalizeRuntimeBundleValue(value: Any?): Any? = when (value) {
+        is String, is Number, is Boolean -> value
+        is Array<*> -> value.map(::normalizeRuntimeBundleValue)
+        is Iterable<*> -> value.map(::normalizeRuntimeBundleValue)
+        else -> value?.toString()
+    }
+
+    private fun toControl(controlSpec: BundleControlSpec): ResourceBundle.Control =
+        if (controlSpec.noFallback) {
+            ResourceBundle.Control.getNoFallbackControl(controlFormatsList(controlSpec))
+        } else {
+            ResourceBundle.Control.getControl(controlFormatsList(controlSpec))
+        }
+
+    private fun controlFormatsList(controlSpec: BundleControlSpec): List<String> = buildList {
+        if ("java.class" in controlSpec.formats) add("java.class")
+        if ("java.properties" in controlSpec.formats) add("java.properties")
+    }
+
+    private fun String.toLocale(): Locale {
+        if (isBlank()) return Locale.ROOT
+        val parts = split('_').filter { it.isNotBlank() }
+        return when (parts.size) {
+            1 -> Locale(parts[0])
+            2 -> Locale(parts[0], parts[1])
+            else -> Locale(parts[0], parts[1], parts.drop(2).joinToString("_"))
+        }
+    }
+
+    private fun localeSpecOf(locale: Locale): String =
+        normalizeLocaleSpec(
+            listOfNotNull(
+                locale.language.takeIf { it.isNotBlank() },
+                locale.country.takeIf { it.isNotBlank() },
+                locale.variant.takeIf { it.isNotBlank() }
+            ).joinToString("_")
+        )
+
+    private fun bundleParent(bundle: ResourceBundle): ResourceBundle? = runCatching {
+        val field = ResourceBundle::class.java.getDeclaredField("parent")
+        field.isAccessible = true
+        field.get(bundle) as? ResourceBundle
+    }.getOrNull()
+
+    private fun extractLocaleSpec(caller: MethodDescriptor, value: Value): String? = when (value) {
+        is Local -> localeSpecsByLocal[localKey(caller, value.name)]
+        is JStaticFieldRef -> extractLocaleSpec(value)
+        else -> null
+    }
+
+    private fun extractStringValue(caller: MethodDescriptor, value: Value?): String? = when (value) {
+        is SootStringConstant -> value.value
+        is Local -> stringValuesByLocal[localKey(caller, value.name)]
+        else -> null
+    }
+
+    private fun extractLocaleSpec(fieldRef: JStaticFieldRef): String? {
+        if (fieldRef.fieldSignature.declClassType.fullyQualifiedName != "java.util.Locale") return null
+        return extractLocaleSpec(fieldRef.fieldSignature.name)
+    }
+
+    private fun extractLocaleSpec(fieldName: String): String? {
+        return when (fieldName) {
+            "ROOT" -> ""
+            "ENGLISH" -> "en"
+            "US" -> "en_US"
+            "UK" -> "en_GB"
+            "CANADA" -> "en_CA"
+            "CANADA_FRENCH" -> "fr_CA"
+            "FRENCH" -> "fr"
+            "FRANCE" -> "fr_FR"
+            "GERMAN" -> "de"
+            "GERMANY" -> "de_DE"
+            "ITALIAN" -> "it"
+            "ITALY" -> "it_IT"
+            "JAPANESE" -> "ja"
+            "JAPAN" -> "ja_JP"
+            "KOREAN" -> "ko"
+            "KOREA" -> "ko_KR"
+            "CHINESE" -> "zh"
+            "CHINA", "SIMPLIFIED_CHINESE" -> "zh_CN"
+            "TAIWAN", "TRADITIONAL_CHINESE" -> "zh_TW"
+            else -> null
+        }?.let(::normalizeLocaleSpec)
+    }
+
+    private fun extractLocaleFactorySpec(calleeSignature: MethodSignature, invokeExpr: AbstractInvokeExpr): String? {
+        if (calleeSignature.declClassType.fullyQualifiedName != "java.util.Locale") return null
+        return when (calleeSignature.name) {
+            "forLanguageTag" -> (invokeExpr.args.firstOrNull() as? SootStringConstant)?.value
+                ?.let(::normalizeLocaleSpec)
+            else -> null
+        }
+    }
+
+    private fun extractConstructedLocaleSpec(invokeExpr: AbstractInvokeExpr): String? {
+        val language = (invokeExpr.args.getOrNull(0) as? SootStringConstant)?.value ?: return null
+        val country = (invokeExpr.args.getOrNull(1) as? SootStringConstant)?.value
+        val variant = (invokeExpr.args.getOrNull(2) as? SootStringConstant)?.value
+        return normalizeLocaleSpec(listOfNotNull(language, country, variant).joinToString("_"))
+    }
+
+    private fun normalizeLocaleSpec(spec: String): String {
+        val parts = spec.split('_', '-').filter { it.isNotBlank() }
+        if (parts.isEmpty()) return ""
+        return buildList {
+            add(parts[0].lowercase())
+            if (parts.size > 1) add(parts[1].uppercase())
+            if (parts.size > 2) addAll(parts.drop(2))
+        }.joinToString("_")
+    }
+
+    private fun normalizeResourcePath(caller: MethodDescriptor, declaringClass: String, rawPath: String): String {
+        val trimmed = rawPath.trim()
+        if (trimmed.isEmpty()) return trimmed
+        if (declaringClass == "java.lang.ClassLoader") {
+            return trimmed.removePrefix("/")
+        }
+        if (trimmed.startsWith("/")) {
+            return trimmed.removePrefix("/")
+        }
+        val packagePath = caller.declaringClass.className.substringBeforeLast('.', "")
+            .replace('.', '/')
+        return if (packagePath.isEmpty()) trimmed else "$packagePath/$trimmed"
+    }
+
+    private fun linkValueAnnotatedField(binding: PlaceholderBinding?, fieldNode: FieldNode) {
+        if (binding == null) return
+        binding.key?.let { configKey ->
+            lookupResourceFiles(null).forEach { resourceFile ->
+                graphBuilder.addEdge(ResourceEdge(resourceFile.id, fieldNode.id, ResourceRelation.LOOKUP))
+            }
+        }
+        if (binding.hasDefaultValue) {
+            val defaultNode = getOrCreateConstantValue(binding.defaultValue)
+            graphBuilder.addEdge(
+                DataFlowEdge(
+                    from = defaultNode.id,
+                    to = fieldNode.id,
+                    kind = DataFlowKind.ASSIGN
+                )
+            )
+        }
+    }
+
+    private fun extractValueAnnotationBinding(annotations: Iterable<*>): PlaceholderBinding? {
+        val valueAnnotation = annotations.firstOrNull {
+            getAnnotationFullName(it) == "org.springframework.beans.factory.annotation.Value"
+        } ?: return null
+        val expression = normalizeAnnotationValue(getAnnotationValues(valueAnnotation)["value"]) as? String ?: return null
+        return extractPlaceholderBinding(expression)
+    }
+
+    private fun extractValueAnnotationBinding(fieldNode: AsmFieldNode): PlaceholderBinding? {
+        val annotations = (fieldNode.visibleAnnotations ?: emptyList()) + (fieldNode.invisibleAnnotations ?: emptyList())
+        val valueAnnotation = annotations.firstOrNull { it.desc == "Lorg/springframework/beans/factory/annotation/Value;" }
+            ?: return null
+        val rawValues = valueAnnotation.values ?: return null
+        var expression: String? = null
+        var index = 0
+        while (index + 1 < rawValues.size) {
+            val key = rawValues[index] as? String
+            val value = rawValues[index + 1]
+            if (key == "value") {
+                expression = value?.toString()
+                break
+            }
+            index += 2
+        }
+        return expression?.let { extractPlaceholderBinding(it) }
+    }
+
+    private fun extractPlaceholderBinding(expression: String): PlaceholderBinding {
+        val trimmed = expression.trim()
+        val match = Regex("""\$\{([^:}]+)(?::([^}]*))?}""").find(trimmed)
+        if (match != null) {
+            return PlaceholderBinding(
+                key = match.groupValues.getOrNull(1)?.takeIf { it.isNotBlank() },
+                defaultValue = match.groupValues.getOrNull(2)?.let(::parseScalar),
+                hasDefaultValue = match.groups[2] != null
+            )
+        }
+        return PlaceholderBinding(
+            key = null,
+            defaultValue = parseScalar(trimmed),
+            hasDefaultValue = true
+        )
+    }
+
+    private fun extractConfigurationPropertiesPrefix(sootClass: SootClass): String? {
+        if (sootClass is JavaSootClass) {
+            val fromSoot = extractConfigurationPropertiesPrefix(sootClass.annotations)
+            if (fromSoot != null) return fromSoot
+            val fromAsm = getAsmClassNode(sootClass)?.let { classNode ->
+                val annotations = buildList {
+                    classNode.visibleAnnotations?.let { addAll(AsmUtil.createAnnotationUsage(it).toList()) }
+                    classNode.invisibleAnnotations?.let { addAll(AsmUtil.createAnnotationUsage(it).toList()) }
+                }
+                extractConfigurationPropertiesPrefix(annotations)
+            }
+            if (fromAsm != null) return fromAsm
+        }
+        return null
+    }
+
+    private fun extractConfigurationPropertiesPrefix(annotations: Iterable<*>): String? {
+        val configAnnotation = annotations.firstOrNull {
+            getAnnotationFullName(it) == "org.springframework.boot.context.properties.ConfigurationProperties"
+        } ?: return null
+        val values = getAnnotationValues(configAnnotation)
+        return normalizeAnnotationValue(values["prefix"]) as? String
+            ?: normalizeAnnotationValue(values["value"]) as? String
+    }
+
+    private fun linkConfigurationPropertiesField(prefix: String?, fieldName: String, fieldNode: FieldNode) {
+        if (prefix.isNullOrBlank()) return
+        configurationPropertyKeys(prefix, fieldName).forEach { key ->
+            lookupResourceFiles(null).forEach { resourceFile ->
+                graphBuilder.addEdge(ResourceEdge(resourceFile.id, fieldNode.id, ResourceRelation.LOOKUP))
+            }
+        }
+    }
+
+    private fun configurationPropertyKeys(prefix: String, fieldName: String): Set<String> {
+        val kebab = fieldName
+            .replace(Regex("([a-z0-9])([A-Z])"), "$1-$2")
+            .lowercase()
+        val snake = fieldName
+            .replace(Regex("([a-z0-9])([A-Z])"), "$1_$2")
+            .lowercase()
+        return linkedSetOf(
+            "$prefix.$fieldName",
+            "$prefix.$kebab",
+            "$prefix.$snake"
+        )
+    }
+
+    private fun isResourceConfig(path: String): Boolean =
+        path.endsWith(".properties") ||
+            path.endsWith(".yml") ||
+            path.endsWith(".yaml") ||
+            path.endsWith(".json") ||
+            path.endsWith(".xml")
+
+    private fun resourceFormat(path: String): String = when {
+        path.endsWith(".properties") -> "properties"
+        path.endsWith(".yml") || path.endsWith(".yaml") -> "yaml"
+        path.endsWith(".json") -> "json"
+        path.endsWith(".xml") -> "xml"
+        else -> "text"
+    }
+
+    private fun resourceProfile(path: String): String? {
+        val fileName = path.substringAfterLast('/')
+        val match = Regex("""application-([^.]+)\.(properties|json|xml|ya?ml)""").matchEntire(fileName)
+        return match?.groupValues?.getOrNull(1)
+    }
+
+    private fun loadProperties(content: String): Map<String, Any?> {
+        val properties = Properties()
+        properties.load(content.reader())
+        return properties.stringPropertyNames().associateWith { parseScalar(properties.getProperty(it)) }
+    }
+
+    private fun loadYaml(content: String): Map<String, Any?> {
+        val result = linkedMapOf<String, Any?>()
+        val pathStack = mutableListOf<String>()
+        var previousIndent = 0
+
+        content.lineSequence().forEach { rawLine ->
+            val line = rawLine.substringBefore('#').trimEnd()
+            if (line.isBlank() || ':' !in line) return@forEach
+            val indent = rawLine.indexOfFirst { !it.isWhitespace() }.coerceAtLeast(0)
+            val level = indent / 2
+            while (pathStack.size > level) {
+                pathStack.removeAt(pathStack.lastIndex)
+            }
+            if (level < previousIndent / 2 && pathStack.size > level) {
+                while (pathStack.size > level) {
+                    pathStack.removeAt(pathStack.lastIndex)
+                }
+            }
+            previousIndent = indent
+
+            val key = line.substringBefore(':').trim()
+            val valuePart = line.substringAfter(':').trim()
+            if (valuePart.isEmpty()) {
+                if (pathStack.size == level) {
+                    pathStack.add(key)
+                } else {
+                    pathStack[level] = key
+                }
+            } else {
+                val fullKey = (pathStack + key).joinToString(".")
+                result[fullKey] = parseScalar(valuePart)
+            }
+        }
+
+        return result
+    }
+
+    private fun loadJson(content: String): Map<String, Any?> {
+        val element = JsonParser.parseString(content)
+        val result = linkedMapOf<String, Any?>()
+        flattenJson(element, emptyList(), result)
+        return result
+    }
+
+    private fun flattenJson(element: JsonElement?, path: List<String>, dest: MutableMap<String, Any?>) {
+        when {
+            element == null || element.isJsonNull -> {
+                if (path.isNotEmpty()) dest[path.joinToString(".")] = null
+            }
+            element.isJsonObject -> flattenJsonObject(element.asJsonObject, path, dest)
+            element.isJsonArray -> flattenJsonArray(element.asJsonArray, path, dest)
+            element.isJsonPrimitive -> {
+                if (path.isNotEmpty()) dest[path.joinToString(".")] = parseJsonPrimitive(element)
+            }
+        }
+    }
+
+    private fun flattenJsonObject(obj: JsonObject, path: List<String>, dest: MutableMap<String, Any?>) {
+        obj.entrySet().forEach { (key, value) ->
+            flattenJson(value, path + key, dest)
+        }
+    }
+
+    private fun flattenJsonArray(array: JsonArray, path: List<String>, dest: MutableMap<String, Any?>) {
+        array.forEachIndexed { index, element ->
+            val base = path.toMutableList()
+            if (base.isNotEmpty()) {
+                base[base.lastIndex] = "${base.last()}[$index]"
+            } else {
+                base += "[$index]"
+            }
+            flattenJson(element, base, dest)
+        }
+    }
+
+    private fun parseJsonPrimitive(element: JsonElement): Any? {
+        val primitive = element.asJsonPrimitive
+        return when {
+            primitive.isBoolean -> primitive.asBoolean
+            primitive.isNumber -> parseScalar(primitive.asString)
+            primitive.isString -> primitive.asString
+            else -> primitive.toString()
+        }
+    }
+
+    private fun loadXml(content: ByteArray): Map<String, Any?> {
+        val text = content.toString(Charsets.UTF_8)
+        val looksLikePropertiesXml = Regex("""<\s*properties(?:\s|>)""").containsMatchIn(text)
+        return if (looksLikePropertiesXml) {
+            runCatching { loadXmlProperties(content) }
+                .getOrElse { loadGenericXml(content) }
+        } else {
+            loadGenericXml(content)
+        }
+    }
+
+    private fun loadXmlProperties(content: ByteArray): Map<String, Any?> {
+        val properties = Properties()
+        ByteArrayInputStream(content).use(properties::loadFromXML)
+        return properties.stringPropertyNames().associateWith { parseScalar(properties.getProperty(it)) }
+    }
+
+    private fun loadGenericXml(content: ByteArray): Map<String, Any?> {
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = false
+            runCatching { setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true) }
+            runCatching { setFeature("http://apache.org/xml/features/disallow-doctype-decl", true) }
+            runCatching { setFeature("http://xml.org/sax/features/external-general-entities", false) }
+            runCatching { setFeature("http://xml.org/sax/features/external-parameter-entities", false) }
+        }
+        val document = ByteArrayInputStream(content).use { input ->
+            factory.newDocumentBuilder().parse(input).apply { documentElement.normalize() }
+        }
+        val result = linkedMapOf<String, Any?>()
+        val elements = document.getElementsByTagName("*")
+        for (index in 0 until elements.length) {
+            val element = elements.item(index) as? Element ?: continue
+            val elementKey = xmlElementPath(element) ?: continue
+            if (element.hasAttributes()) {
+                val attributes = element.attributes
+                for (attributeIndex in 0 until attributes.length) {
+                    val attribute = attributes.item(attributeIndex)
+                    if (attribute != null && attribute.nodeName.isNotBlank()) {
+                        result["$elementKey.@${attribute.nodeName}"] = parseScalar(attribute.nodeValue ?: "")
+                    }
+                }
+            }
+
+            val childElements = xmlChildElements(element)
+            val directTextContent = element.childNodes.toTextValue()
+            if (childElements.isEmpty()) {
+                element.textContent
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let { result[elementKey] = parseScalar(it) }
+            } else if (directTextContent != null) {
+                result["$elementKey.#text"] = parseScalar(directTextContent)
+            }
+        }
+        return result
+    }
+
+    private fun xmlChildElements(element: Element): List<Element> {
+        val children = mutableListOf<Element>()
+        for (index in 0 until element.childNodes.length) {
+            val node = element.childNodes.item(index)
+            if (node is Element) {
+                children += node
+            }
+        }
+        return children
+    }
+
+    private fun xmlElementPath(element: Element): String? {
+        val parts = mutableListOf<String>()
+        var current: Element? = element
+        while (current != null) {
+            val parent = current.parentNode as? Element
+            if (parent == null) {
+                if (parts.isEmpty() && xmlChildElements(current).isEmpty()) {
+                    parts += current.tagName
+                }
+                break
+            }
+            val sameNamedSiblings = xmlChildElements(parent).filter { it.tagName == current.tagName }
+            val name = if (sameNamedSiblings.size > 1) {
+                "${current.tagName}[${sameNamedSiblings.indexOf(current)}]"
+            } else {
+                current.tagName
+            }
+            parts += name
+            current = parent
+        }
+        return parts.asReversed().joinToString(".").takeIf { it.isNotBlank() }
+    }
+
+    private fun org.w3c.dom.NodeList.toTextValue(): String? {
+        val text = buildString {
+            for (index in 0 until length) {
+            val node = item(index)
+            if (node.nodeType == DomNode.TEXT_NODE || node.nodeType == DomNode.CDATA_SECTION_NODE) {
+                append(node.nodeValue)
+            }
+        }
+        }.trim()
+        return text.takeIf { it.isNotEmpty() }
+    }
+
+    private fun parseScalar(value: String): Any? {
+        val trimmed = value.trim()
+        return when {
+            trimmed.equals("true", ignoreCase = true) -> true
+            trimmed.equals("false", ignoreCase = true) -> false
+            trimmed.equals("null", ignoreCase = true) -> null
+            trimmed.toIntOrNull() != null -> trimmed.toInt()
+            trimmed.toLongOrNull() != null -> trimmed.toLong()
+            trimmed.toDoubleOrNull() != null -> trimmed.toDouble()
+            trimmed.startsWith("\"") && trimmed.endsWith("\"") -> trimmed.removeSurrounding("\"")
+            trimmed.startsWith("'") && trimmed.endsWith("'") -> trimmed.removeSurrounding("'")
+            else -> trimmed
         }
     }
 
@@ -1701,6 +3139,14 @@ class SootUpAdapter(
             localToParamIndex.remove(key)
             dynamicTargets.remove(key)
             arrayDynamicTargets.remove(key)
+            localeSpecsByLocal.remove(key)
+            localeBuilderSpecsByLocal.remove(key)
+            stringValuesByLocal.remove(key)
+            bundleControlFormatsByLocal.remove(key)
+            resourceHandlePathsByLocal.remove(key)
+            propertiesPathsByLocal.remove(key)
+            resourceBundlePaths.remove(key)
+            bundleControlSpecsByLocal.remove(key)
         }
         activeMethodParameters.forEach { parameterNodes.remove(it) }
         methodReturnNodes.remove(method)

--- a/graphite-sootup/src/test/java/org/springframework/boot/context/properties/ConfigurationProperties.java
+++ b/graphite-sootup/src/test/java/org/springframework/boot/context/properties/ConfigurationProperties.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.context.properties;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ConfigurationProperties {
+    String value() default "";
+    String prefix() default "";
+}

--- a/graphite-sootup/src/test/java/sample/resources/ClassOnlyControl.java
+++ b/graphite-sootup/src/test/java/sample/resources/ClassOnlyControl.java
@@ -1,0 +1,11 @@
+package sample.resources;
+
+import java.util.List;
+import java.util.ResourceBundle;
+
+public class ClassOnlyControl extends ResourceBundle.Control {
+    @Override
+    public List<String> getFormats(String baseName) {
+        return FORMAT_CLASS;
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/ConfigurationPropertiesConfig.java
+++ b/graphite-sootup/src/test/java/sample/resources/ConfigurationPropertiesConfig.java
@@ -1,0 +1,25 @@
+package sample.resources;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "service.cache")
+public class ConfigurationPropertiesConfig {
+    private boolean enabled;
+    private int ttlSeconds;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getTtlSeconds() {
+        return ttlSeconds;
+    }
+
+    public void setTtlSeconds(int ttlSeconds) {
+        this.ttlSeconds = ttlSeconds;
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/KoreanOnlyControl.java
+++ b/graphite-sootup/src/test/java/sample/resources/KoreanOnlyControl.java
@@ -1,0 +1,12 @@
+package sample.resources;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public class KoreanOnlyControl extends ResourceBundle.Control {
+    @Override
+    public List<Locale> getCandidateLocales(String baseName, Locale locale) {
+        return List.of(Locale.KOREA);
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/MessagesListBundle.java
+++ b/graphite-sootup/src/test/java/sample/resources/MessagesListBundle.java
@@ -1,0 +1,12 @@
+package sample.resources;
+
+import java.util.ListResourceBundle;
+
+public class MessagesListBundle extends ListResourceBundle {
+    @Override
+    protected Object[][] getContents() {
+        return new Object[][]{
+            {"hello", "world-list"}
+        };
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/MessagesListBundle_ko_KR.java
+++ b/graphite-sootup/src/test/java/sample/resources/MessagesListBundle_ko_KR.java
@@ -1,0 +1,12 @@
+package sample.resources;
+
+import java.util.ListResourceBundle;
+
+public class MessagesListBundle_ko_KR extends ListResourceBundle {
+    @Override
+    protected Object[][] getContents() {
+        return new Object[][]{
+            {"hello", "annyeong-list"}
+        };
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/MessagesProvider.java
+++ b/graphite-sootup/src/test/java/sample/resources/MessagesProvider.java
@@ -1,0 +1,18 @@
+package sample.resources;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.spi.ResourceBundleProvider;
+
+public class MessagesProvider implements ResourceBundleProvider {
+    @Override
+    public ResourceBundle getBundle(String baseName, Locale locale) {
+        if (!"sample.resources.ProviderMessagesBundle".equals(baseName)) {
+            return null;
+        }
+        if (Locale.KOREA.equals(locale)) {
+            return new ProviderMessagesBundle_ko_KR();
+        }
+        return new ProviderMessagesBundle();
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/ProviderMessagesBundle.java
+++ b/graphite-sootup/src/test/java/sample/resources/ProviderMessagesBundle.java
@@ -1,0 +1,12 @@
+package sample.resources;
+
+import java.util.ListResourceBundle;
+
+public class ProviderMessagesBundle extends ListResourceBundle {
+    @Override
+    protected Object[][] getContents() {
+        return new Object[][]{
+            {"hello", "world-provider"}
+        };
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/ProviderMessagesBundle_ko_KR.java
+++ b/graphite-sootup/src/test/java/sample/resources/ProviderMessagesBundle_ko_KR.java
@@ -1,0 +1,12 @@
+package sample.resources;
+
+import java.util.ListResourceBundle;
+
+public class ProviderMessagesBundle_ko_KR extends ListResourceBundle {
+    @Override
+    protected Object[][] getContents() {
+        return new Object[][]{
+            {"hello", "annyeong-provider"}
+        };
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/ResourceConfig.java
+++ b/graphite-sootup/src/test/java/sample/resources/ResourceConfig.java
@@ -1,0 +1,210 @@
+package sample.resources;
+
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.Properties;
+import java.util.ResourceBundle.Control;
+import java.util.ResourceBundle;
+
+public class ResourceConfig {
+    public String featureMode() {
+        Properties properties = new Properties();
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("application.properties")) {
+            if (input != null) {
+                properties.load(input);
+            }
+        } catch (IOException ignored) {
+        }
+        return properties.getProperty("feature.mode");
+    }
+
+    public String featureModeXml() {
+        Properties properties = new Properties();
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("application.xml")) {
+            if (input != null) {
+                properties.loadFromXML(input);
+            }
+        } catch (IOException ignored) {
+        }
+        return properties.getProperty("feature.mode");
+    }
+
+    public String featureModeReader() {
+        Properties properties = new Properties();
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("application.properties")) {
+            if (input != null) {
+                try (Reader reader = new InputStreamReader(input)) {
+                    properties.load(reader);
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return properties.getProperty("feature.mode");
+    }
+
+    @SuppressWarnings("unchecked")
+    public Boolean jsonFeatureEnabled() {
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("application.json")) {
+            if (input != null) {
+                try (Reader reader = new InputStreamReader(input)) {
+                    Object parsed = new Gson().fromJson(reader, Object.class);
+                    if (parsed instanceof java.util.Map<?, ?> root) {
+                        Object feature = root.get("feature");
+                        if (feature instanceof java.util.Map<?, ?> featureMap) {
+                            Object enabled = featureMap.get("enabled");
+                            if (enabled instanceof Boolean value) {
+                                return value;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    public String xmlServiceEndpoint() {
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("config.xml")) {
+            if (input != null) {
+                return javax.xml.parsers.DocumentBuilderFactory.newInstance()
+                    .newDocumentBuilder()
+                    .parse(input)
+                    .getElementsByTagName("endpoint")
+                    .item(0)
+                    .getTextContent();
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    public String message() {
+        return ResourceBundle.getBundle("messages").getString("hello");
+    }
+
+    public Object messageObject() {
+        return ResourceBundle.getBundle("messages").getObject("hello");
+    }
+
+    public String messageKeys() {
+        return ResourceBundle.getBundle("messages").getKeys().nextElement();
+    }
+
+    public String messageKo() {
+        return ResourceBundle.getBundle("messages", Locale.KOREA).getString("hello");
+    }
+
+    public String messageKoFromLocal() {
+        Locale locale = Locale.KOREA;
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageKoFromTag() {
+        Locale locale = Locale.forLanguageTag("ko-KR");
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageKoFromCtor() {
+        Locale locale = new Locale("ko", "KR");
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageKoWithClassLoader() {
+        return ResourceBundle.getBundle("messages", Locale.KOREA, ResourceConfig.class.getClassLoader()).getString("hello");
+    }
+
+    public String messageKoWithControl() {
+        Control control = Control.getNoFallbackControl(Control.FORMAT_PROPERTIES);
+        return ResourceBundle.getBundle("messages", Locale.KOREA, control).getString("hello");
+    }
+
+    public String messageKoFromBuilder() {
+        Locale locale = new Locale.Builder()
+            .setLanguage("ko")
+            .setRegion("KR")
+            .build();
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageKoFromBuilderTag() {
+        Locale.Builder builder = new Locale.Builder();
+        builder.setLanguageTag("ko-KR");
+        Locale locale = builder.build();
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageClassOnlyControlNoCandidate() {
+        try {
+            Control control = Control.getControl(Control.FORMAT_CLASS);
+            return ResourceBundle.getBundle("messages", Locale.KOREA, control).getString("hello");
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    public String messageClassOnlyCustomControlNoCandidate() {
+        try {
+            return ResourceBundle.getBundle("messages", Locale.KOREA, new ClassOnlyControl()).getString("hello");
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    public String messageKoWithCustomCandidateControl() {
+        return ResourceBundle.getBundle("messages", Locale.KOREA, new KoreanOnlyControl()).getString("hello");
+    }
+
+    public String messagePropertyBundle() {
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("messages.properties")) {
+            if (input != null) {
+                return new PropertyResourceBundle(input).getString("hello");
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    public String messagePropertyBundleReader() {
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("messages.properties")) {
+            if (input != null) {
+                try (Reader reader = new InputStreamReader(input)) {
+                    return new PropertyResourceBundle(reader).getString("hello");
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    public String messagePropertyBundleKeys() {
+        try (InputStream input = ResourceConfig.class.getClassLoader().getResourceAsStream("messages.properties")) {
+            if (input != null) {
+                return new PropertyResourceBundle(input).getKeys().nextElement();
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    public String listBundleMessage() {
+        return ResourceBundle.getBundle("sample.resources.MessagesListBundle", Locale.KOREA).getString("hello");
+    }
+
+    public String listBundleKeys() {
+        return ResourceBundle.getBundle("sample.resources.MessagesListBundle").getKeys().nextElement();
+    }
+
+    public String providerBundleMessage() {
+        return ResourceBundle.getBundle("sample.resources.ProviderMessagesBundle", Locale.KOREA).getString("hello");
+    }
+
+    public String providerBundleKeys() {
+        return ResourceBundle.getBundle("sample.resources.ProviderMessagesBundle").getKeys().nextElement();
+    }
+}

--- a/graphite-sootup/src/test/java/sample/resources/ResourceConfig.java
+++ b/graphite-sootup/src/test/java/sample/resources/ResourceConfig.java
@@ -124,6 +124,20 @@ public class ResourceConfig {
         return ResourceBundle.getBundle("messages", Locale.KOREA, control).getString("hello");
     }
 
+    public String messageKoWithControlAlias() {
+        java.util.List<String> formats = Control.FORMAT_PROPERTIES;
+        Control control = Control.getNoFallbackControl(formats);
+        Control alias = control;
+        return ResourceBundle.getBundle("messages", Locale.KOREA, alias).getString("hello");
+    }
+
+    public String messageKoWithDefaultControlAlias() {
+        java.util.List<String> formats = Control.FORMAT_DEFAULT;
+        Control control = Control.getControl(formats);
+        Control alias = control;
+        return ResourceBundle.getBundle("messages", Locale.KOREA, alias).getString("hello");
+    }
+
     public String messageKoFromBuilder() {
         Locale locale = new Locale.Builder()
             .setLanguage("ko")
@@ -135,6 +149,32 @@ public class ResourceConfig {
     public String messageKoFromBuilderTag() {
         Locale.Builder builder = new Locale.Builder();
         builder.setLanguageTag("ko-KR");
+        Locale locale = builder.build();
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageKoFromBuilderSetLocale() {
+        Locale.Builder builder = new Locale.Builder();
+        builder.setLocale(Locale.KOREA);
+        Locale locale = builder.build();
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageKoFromBuilderReset() {
+        Locale.Builder builder = new Locale.Builder();
+        builder.setLanguage("en");
+        builder.clear();
+        builder.setLanguage("ko");
+        builder.setRegion("KR");
+        Locale locale = builder.build();
+        return ResourceBundle.getBundle("messages", locale).getString("hello");
+    }
+
+    public String messageKoFromBuilderVariant() {
+        Locale.Builder builder = new Locale.Builder();
+        builder.setLanguage("ko");
+        builder.setRegion("KR");
+        builder.setVariant("POSIX");
         Locale locale = builder.build();
         return ResourceBundle.getBundle("messages", locale).getString("hello");
     }

--- a/graphite-sootup/src/test/java/sample/resources/SpringResourceConfig.java
+++ b/graphite-sootup/src/test/java/sample/resources/SpringResourceConfig.java
@@ -1,0 +1,23 @@
+package sample.resources;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+
+public class SpringResourceConfig {
+    @Value("${feature.mode}")
+    private String featureMode;
+
+    private final Environment environment;
+
+    public SpringResourceConfig(Environment environment) {
+        this.environment = environment;
+    }
+
+    public String serverPort() {
+        return environment.getProperty("server.port");
+    }
+
+    public String featureMode() {
+        return featureMode;
+    }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ArchiveResourceAccessorTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ArchiveResourceAccessorTest.kt
@@ -3,11 +3,14 @@ package io.johnsonlee.graphite.sootup
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ArchiveResourceAccessorTest {
@@ -204,6 +207,31 @@ class ArchiveResourceAccessorTest {
         }
     }
 
+    @Test
+    fun `close removes extracted nested jar temp directories`() {
+        val nestedJar = createTempJar(mapOf("sample/Inner.class" to "fake"))
+        val jarFile = createTempJar(
+            mapOf(
+                "BOOT-INF/classes/" to "",
+                "BOOT-INF/classes/application.yml" to "server.port: 8080"
+            ),
+            binaryEntries = mapOf("BOOT-INF/lib/nested.jar" to nestedJar.readBytes())
+        )
+        try {
+            val accessor = ArchiveResourceAccessor.create(jarFile.toPath())
+            val tempDirs = readTempDirs(accessor)
+            assertTrue(tempDirs.isNotEmpty())
+            tempDirs.forEach { assertTrue(Files.exists(it)) }
+
+            accessor.close()
+
+            tempDirs.forEach { assertFalse(Files.exists(it)) }
+        } finally {
+            nestedJar.delete()
+            jarFile.delete()
+        }
+    }
+
     // ========================================================================
     // EmptyResourceAccessor
     // ========================================================================
@@ -222,7 +250,7 @@ class ArchiveResourceAccessorTest {
     // Helpers
     // ========================================================================
 
-    private fun createTempJar(entries: Map<String, String>): File {
+    private fun createTempJar(entries: Map<String, String>, binaryEntries: Map<String, ByteArray> = emptyMap()): File {
         val file = File.createTempFile("test", ".jar")
         JarOutputStream(file.outputStream()).use { jos ->
             entries.forEach { (name, content) ->
@@ -230,7 +258,19 @@ class ArchiveResourceAccessorTest {
                 jos.write(content.toByteArray())
                 jos.closeEntry()
             }
+            binaryEntries.forEach { (name, content) ->
+                jos.putNextEntry(JarEntry(name))
+                jos.write(content)
+                jos.closeEntry()
+            }
         }
         return file
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun readTempDirs(accessor: ArchiveResourceAccessor): List<Path> {
+        val field = accessor.javaClass.getDeclaredField("tempDirs")
+        field.isAccessible = true
+        return field.get(accessor) as List<Path>
     }
 }

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/GraphiteContextTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/GraphiteContextTest.kt
@@ -3,10 +3,20 @@ package io.johnsonlee.graphite.sootup
 import io.johnsonlee.graphite.core.MethodDescriptor
 import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.input.EmptyResourceAccessor
+import java.nio.file.Path
+import kotlin.io.path.exists
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import sootup.core.inputlocation.AnalysisInputLocation
+import sootup.core.model.SourceType
+import sootup.java.bytecode.frontend.inputlocation.PathBasedAnalysisInputLocation
+import sootup.java.core.JavaIdentifierFactory
+import sootup.java.core.views.JavaView
 
 class GraphiteContextTest {
+    private val identifierFactory = JavaIdentifierFactory.getInstance()
 
     private fun createContext(captured: MutableList<String>): GraphiteContext {
         return GraphiteContext(
@@ -61,6 +71,49 @@ class GraphiteContextTest {
         val ctx = createContext(messages)
         ctx.log("no placeholders", "ignored")
         assertEquals(listOf("no placeholders"), messages)
+    }
+
+    @Test
+    fun `toMethodDescriptor delegates to factory`() {
+        val expected = MethodDescriptor(
+            declaringClass = TypeDescriptor("sample.resources.ResourceConfig"),
+            name = "featureMode",
+            parameterTypes = emptyList(),
+            returnType = TypeDescriptor("java.lang.String")
+        )
+        val sootMethod = resolveTestMethod("sample.resources.ResourceConfig", "featureMode")
+        val ctx = GraphiteContext(
+            methodDescriptorFactory = { expected },
+            logger = {},
+            resources = EmptyResourceAccessor
+        )
+
+        assertSame(expected, ctx.toMethodDescriptor(sootMethod))
+    }
+
+    @Test
+    fun `resources accessor is exposed`() {
+        val ctx = createContext(mutableListOf())
+        assertSame(EmptyResourceAccessor, ctx.resources)
+    }
+
+    private fun resolveTestMethod(className: String, methodName: String) =
+        JavaView(
+            listOf<AnalysisInputLocation>(
+                PathBasedAnalysisInputLocation.create(findTestClassesDir(), SourceType.Application)
+            )
+        ).getClass(identifierFactory.getClassType(className))
+            .orElseThrow()
+            .methods
+            .first { it.name == methodName }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        val path = if (submodulePath.exists()) submodulePath else rootPath
+        assertTrue(path.exists(), "Test classes directory should exist: $path")
+        return path
     }
 
 }

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
@@ -16,6 +16,7 @@ import kotlin.io.path.exists
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -322,6 +323,37 @@ class JavaProjectLoaderTest {
     }
 
     @Test
+    fun `should skip Spring Boot libraries that do not contain included packages`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val unrelatedLib = buildJarFromClasses(testClassesDir, "sample/generics/", "generics-lib.jar")
+        val jarPath = buildSpringBootJarWithLibs(testClassesDir, "sample/simple/", listOf(unrelatedLib))
+
+        try {
+            val logs = mutableListOf<String>()
+            val loader = JavaProjectLoader(
+                LoaderConfig(
+                    includePackages = listOf("sample.simple"),
+                    includeLibraries = true,
+                    buildCallGraph = false,
+                    verbose = { logs.add(it) }
+                )
+            )
+
+            val graph = loader.load(jarPath)
+            assertNotNull(graph)
+            assertTrue(logs.none { it.contains("+ Loading JAR: generics-lib.jar") })
+        } finally {
+            Files.deleteIfExists(jarPath)
+            Files.deleteIfExists(unrelatedLib)
+            File(System.getProperty("java.io.tmpdir")).listFiles()
+                ?.filter { it.name.startsWith("graphite-springboot") }
+                ?.forEach { it.deleteRecursively() }
+        }
+    }
+
+    @Test
     fun `should load with empty includePackages and include all classes`() {
         val testClassesDir = findTestClassesDir()
         assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
@@ -350,6 +382,54 @@ class JavaProjectLoaderTest {
     }
 
     @Test
+    fun `should report skipped WAR libraries by package`() {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+
+        val unrelatedLib = buildJarFromClasses(testClassesDir, "sample/generics/", "generics-lib.jar")
+        val warPath = buildWarFileWithLibs(testClassesDir, "sample/simple/", listOf(unrelatedLib))
+
+        try {
+            val logs = mutableListOf<String>()
+            val loader = JavaProjectLoader(
+                LoaderConfig(
+                    includePackages = listOf("sample.simple"),
+                    includeLibraries = true,
+                    buildCallGraph = false,
+                    verbose = { logs.add(it) }
+                )
+            )
+
+            val graph = loader.load(warPath)
+            assertNotNull(graph)
+            assertTrue(logs.any { it.contains("skipped: 0 by filter, 1 by package") })
+        } finally {
+            Files.deleteIfExists(warPath)
+            Files.deleteIfExists(unrelatedLib)
+            File(System.getProperty("java.io.tmpdir")).listFiles()
+                ?.filter { it.name.startsWith("graphite-war") }
+                ?.forEach { it.deleteRecursively() }
+        }
+    }
+
+    @Test
+    fun `jarContainsIncludedPackages returns false for unrelated jars`() {
+        val testClassesDir = findTestClassesDir()
+        val unrelatedJar = buildJarFromClasses(testClassesDir, "sample/generics/", "generics-lib.jar")
+        try {
+            val loader = JavaProjectLoader(
+                LoaderConfig(
+                    includePackages = listOf("sample.simple"),
+                    buildCallGraph = false
+                )
+            )
+            assertFalse(invokePrivate(loader, "jarContainsIncludedPackages", unrelatedJar))
+        } finally {
+            Files.deleteIfExists(unrelatedJar)
+        }
+    }
+
+    @Test
     fun `should handle loadSignatures failure gracefully`() {
         // Create a JAR with invalid content to trigger the catch in loadSignatures
         val tempJar = Files.createTempFile("invalid", ".jar")
@@ -371,6 +451,42 @@ class JavaProjectLoaderTest {
             assertNotNull(graph, "Should still produce a graph even with no class files")
         } finally {
             Files.deleteIfExists(tempJar)
+        }
+    }
+
+    @Test
+    fun `private helpers tolerate invalid archives`() {
+        val invalidJar = Files.createTempFile("invalid-signatures", ".jar")
+        val invalidBootJar = Files.createTempFile("invalid-boot", ".jar")
+        val invalidWar = Files.createTempFile("invalid-war", ".war")
+        try {
+            Files.writeString(invalidJar, "not-a-jar")
+            Files.writeString(invalidBootJar, "not-a-boot-jar")
+            Files.writeString(invalidWar, "not-a-war")
+
+            val loader = JavaProjectLoader(
+                LoaderConfig(
+                    includePackages = listOf("sample.simple"),
+                    includeLibraries = true,
+                    buildCallGraph = false
+                )
+            )
+
+            invokePrivate<Unit>(loader, "loadSignatures", invalidJar, BytecodeSignatureReader())
+            assertTrue(
+                invokePrivate<Boolean>(loader, "jarContainsIncludedPackages", invalidJar),
+                "Invalid jars should be included on error to stay fail-open"
+            )
+            assertFailsWith<Exception> {
+                invokePrivate<List<Any>>(loader, "createSpringBootInputLocations", invalidBootJar)
+            }
+            assertFailsWith<Exception> {
+                invokePrivate<List<Any>>(loader, "createWarInputLocations", invalidWar)
+            }
+        } finally {
+            Files.deleteIfExists(invalidJar)
+            Files.deleteIfExists(invalidBootJar)
+            Files.deleteIfExists(invalidWar)
         }
     }
 
@@ -708,5 +824,19 @@ class JavaProjectLoaderTest {
         val submodulePath = projectDir.resolve("build/classes/java/test")
         val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
         return if (submodulePath.exists()) submodulePath else rootPath
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> invokePrivate(target: Any, name: String, vararg args: Any?): T {
+        val parameterTypes = args.map {
+            when (it) {
+                is Path -> Path::class.java
+                is BytecodeSignatureReader -> BytecodeSignatureReader::class.java
+                else -> it!!::class.java
+            }
+        }.toTypedArray()
+        val method = target.javaClass.getDeclaredMethod(name, *parameterTypes)
+        method.isAccessible = true
+        return method.invoke(target, *args) as T
     }
 }

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ResourceConfigLinkingTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ResourceConfigLinkingTest.kt
@@ -1,0 +1,327 @@
+package io.johnsonlee.graphite.sootup
+
+import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.ResourceEdge
+import io.johnsonlee.graphite.core.ResourceFileNode
+import io.johnsonlee.graphite.core.ResourceRelation
+import io.johnsonlee.graphite.core.ResourceValueNode
+import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.input.LoaderConfig
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ResourceConfigLinkingTest {
+
+    @Test
+    fun `should keep only resource file nodes and file level generic links`() {
+        val fixtureDir = createFixtureDir()
+        try {
+            val loader = JavaProjectLoader(
+                LoaderConfig(
+                    includePackages = listOf("sample.resources"),
+                    buildCallGraph = false
+                )
+            )
+
+            val graph = loader.load(fixtureDir)
+            assertTrue(graph.nodes(ResourceValueNode::class.java).none(), "ResourceValueNode should not be created from file contents")
+
+            val appProperties = requireResourceFile(graph, "application.properties")
+            val appXml = requireResourceFile(graph, "application.xml")
+            val appJson = requireResourceFile(graph, "application.json")
+            val configXml = requireResourceFile(graph, "config.xml")
+
+            val featureMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "featureMode")).single()
+            val featureXmlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "featureModeXml")).single()
+            val featureReaderMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "featureModeReader")).single()
+            val jsonMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "jsonFeatureEnabled")).single()
+            val xmlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "xmlServiceEndpoint")).single()
+
+            val openPropertiesCall = requireCallSite(graph, featureMethod, "getResourceAsStream")
+            val lookupPropertiesCall = requireCallSite(graph, featureMethod, "getProperty")
+            val openXmlCall = requireCallSite(graph, featureXmlMethod, "getResourceAsStream")
+            val lookupXmlCall = requireCallSite(graph, featureXmlMethod, "getProperty")
+            val lookupReaderCall = requireCallSite(graph, featureReaderMethod, "getProperty")
+            val jsonLoadCall = requireCallSite(graph, jsonMethod, "fromJson")
+            val xmlLoadCall = requireCallSite(graph, xmlMethod, "parse")
+
+            assertHasResourceEdge(graph.incomingResourceEdges(openPropertiesCall.id), appProperties.id, ResourceRelation.OPENS, "application.properties should open into getResourceAsStream")
+            assertHasResourceEdge(graph.incomingResourceEdges(lookupPropertiesCall.id), appProperties.id, ResourceRelation.LOOKUP, "application.properties should link to Properties.getProperty")
+            assertHasResourceEdge(graph.incomingResourceEdges(openXmlCall.id), appXml.id, ResourceRelation.OPENS, "application.xml should open into getResourceAsStream")
+            assertHasResourceEdge(graph.incomingResourceEdges(lookupXmlCall.id), appXml.id, ResourceRelation.LOOKUP, "application.xml should link to Properties.getProperty")
+            assertHasResourceEdge(graph.incomingResourceEdges(lookupReaderCall.id), appProperties.id, ResourceRelation.LOOKUP, "Reader-backed Properties.getProperty should stay linked to application.properties")
+            assertHasResourceEdge(graph.incomingResourceEdges(jsonLoadCall.id), appJson.id, ResourceRelation.LOADS, "application.json should link to Gson.fromJson")
+            assertHasResourceEdge(graph.incomingResourceEdges(xmlLoadCall.id), configXml.id, ResourceRelation.LOADS, "config.xml should link to DocumentBuilder.parse")
+        } finally {
+            fixtureDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `should link ResourceBundle and PropertyResourceBundle by file path`() {
+        val fixtureDir = createFixtureDir()
+        try {
+            val loader = JavaProjectLoader(
+                LoaderConfig(
+                    includePackages = listOf("sample.resources"),
+                    buildCallGraph = false
+                )
+            )
+
+            val graph = loader.load(fixtureDir)
+            assertTrue(graph.nodes(ResourceValueNode::class.java).none(), "ResourceValueNode should not be created from bundle contents")
+
+            val bundleRoot = requireResourceFile(graph, "messages.properties")
+            val bundleKo = requireResourceFile(graph, "messages_ko.properties")
+            val bundleKoKr = requireResourceFile(graph, "messages_ko_KR.properties")
+            val listBundle = requireResourceFile(graph, "sample.resources.MessagesListBundle_ko_KR")
+            val listBundleBase = requireResourceFile(graph, "sample.resources.MessagesListBundle")
+            val providerBundle = requireResourceFile(graph, "sample.resources.ProviderMessagesBundle_ko_KR")
+            val providerBundleBase = requireResourceFile(graph, "sample.resources.ProviderMessagesBundle")
+
+            val messageMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "message")).single()
+            val messageObjectMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageObject")).single()
+            val messageKeysMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKeys")).single()
+            val messageKoMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKo")).single()
+            val messageKoFromLocalMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromLocal")).single()
+            val messageKoFromTagMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromTag")).single()
+            val messageKoFromCtorMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromCtor")).single()
+            val messageKoWithClassLoaderMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithClassLoader")).single()
+            val messageKoWithControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithControl")).single()
+            val messageKoFromBuilderMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromBuilder")).single()
+            val messageKoFromBuilderTagMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromBuilderTag")).single()
+            val messageClassOnlyControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageClassOnlyControlNoCandidate")).single()
+            val messageClassOnlyCustomControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageClassOnlyCustomControlNoCandidate")).single()
+            val messageKoCustomCandidateControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithCustomCandidateControl")).single()
+            val propertyBundleMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messagePropertyBundle")).single()
+            val propertyBundleReaderMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messagePropertyBundleReader")).single()
+            val propertyBundleKeysMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messagePropertyBundleKeys")).single()
+            val listBundleMessageMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "listBundleMessage")).single()
+            val listBundleKeysMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "listBundleKeys")).single()
+            val providerBundleMessageMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "providerBundleMessage")).single()
+            val providerBundleKeysMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "providerBundleKeys")).single()
+
+            val messageBundleCall = requireCallSite(graph, messageMethod, "getBundle")
+            val messageLookupCall = requireCallSite(graph, messageMethod, "getString")
+            val messageObjectCall = requireCallSite(graph, messageObjectMethod, "getObject")
+            val messageKeysCall = requireCallSite(graph, messageKeysMethod, "getKeys")
+
+            assertHasResourceEdge(graph.incomingResourceEdges(messageBundleCall.id), bundleRoot.id, ResourceRelation.BUNDLE_CANDIDATE, "messages.properties should be a ResourceBundle candidate")
+            assertHasResourceEdge(graph.incomingResourceEdges(messageLookupCall.id), bundleRoot.id, ResourceRelation.LOOKUP, "messages.properties should link to ResourceBundle.getString")
+            assertHasResourceEdge(graph.incomingResourceEdges(messageObjectCall.id), bundleRoot.id, ResourceRelation.LOOKUP, "messages.properties should link to ResourceBundle.getObject")
+            assertHasResourceEdge(graph.incomingResourceEdges(messageKeysCall.id), bundleRoot.id, ResourceRelation.ENUMERATES, "messages.properties should enumerate into ResourceBundle.getKeys")
+
+            assertLocaleAwareBundle(graph, messageKoMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromLocalMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromTagMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromCtorMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoWithClassLoaderMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoWithControlMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromBuilderMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromBuilderTagMethod, bundleRoot, bundleKo, bundleKoKr)
+
+            val classOnlyControlCall = requireCallSite(graph, messageClassOnlyControlMethod, "getBundle")
+            val classOnlyControlEdges = graph.incomingResourceEdges(classOnlyControlCall.id)
+            assertTrue(classOnlyControlEdges.none { it.kind == ResourceRelation.BUNDLE_CANDIDATE }, "FORMAT_CLASS control should not point at .properties bundle files")
+
+            val customClassOnlyControlCall = requireCallSite(graph, messageClassOnlyCustomControlMethod, "getBundle")
+            val customClassOnlyControlEdges = graph.incomingResourceEdges(customClassOnlyControlCall.id)
+            assertTrue(customClassOnlyControlEdges.none { it.kind == ResourceRelation.BUNDLE_CANDIDATE }, "Custom class-only control should not point at .properties bundle files")
+
+            val customCandidateControlCall = requireCallSite(graph, messageKoCustomCandidateControlMethod, "getBundle")
+            val customCandidateEdges = graph.incomingResourceEdges(customCandidateControlCall.id)
+            assertHasResourceEdge(customCandidateEdges, bundleKoKr.id, ResourceRelation.BUNDLE_CANDIDATE, "Custom candidate control should keep ko_KR bundle candidate")
+            assertTrue(customCandidateEdges.none { it.from == bundleKo.id && it.kind == ResourceRelation.BUNDLE_CANDIDATE }, "Custom candidate control should drop intermediate ko bundle")
+            assertTrue(customCandidateEdges.none { it.from == bundleRoot.id && it.kind == ResourceRelation.BUNDLE_CANDIDATE }, "Custom candidate control should drop root bundle")
+
+            val propertyBundleLookupCall = requireCallSite(graph, propertyBundleMethod, "getString")
+            val propertyBundleReaderLookupCall = requireCallSite(graph, propertyBundleReaderMethod, "getString")
+            val propertyBundleKeysCall = requireCallSite(graph, propertyBundleKeysMethod, "getKeys")
+            assertHasResourceEdge(graph.incomingResourceEdges(propertyBundleLookupCall.id), bundleRoot.id, ResourceRelation.LOOKUP, "PropertyResourceBundle(InputStream) should link to messages.properties")
+            assertHasResourceEdge(graph.incomingResourceEdges(propertyBundleReaderLookupCall.id), bundleRoot.id, ResourceRelation.LOOKUP, "PropertyResourceBundle(Reader) should link to messages.properties")
+            assertHasResourceEdge(graph.incomingResourceEdges(propertyBundleKeysCall.id), bundleRoot.id, ResourceRelation.ENUMERATES, "PropertyResourceBundle.getKeys should enumerate messages.properties")
+
+            val listBundleMessageCall = requireCallSite(graph, listBundleMessageMethod, "getString")
+            val listBundleKeysCall = requireCallSite(graph, listBundleKeysMethod, "getKeys")
+            assertHasResourceEdge(graph.incomingResourceEdges(listBundleMessageCall.id), listBundle.id, ResourceRelation.LOOKUP, "ListResourceBundle lookup should link by bundle class path")
+            assertHasResourceEdge(graph.incomingResourceEdges(listBundleKeysCall.id), listBundleBase.id, ResourceRelation.ENUMERATES, "ListResourceBundle getKeys should enumerate base bundle path")
+
+            val providerBundleMessageCall = requireCallSite(graph, providerBundleMessageMethod, "getString")
+            val providerBundleKeysCall = requireCallSite(graph, providerBundleKeysMethod, "getKeys")
+            assertHasResourceEdge(graph.incomingResourceEdges(providerBundleMessageCall.id), providerBundle.id, ResourceRelation.LOOKUP, "Provider-backed bundle lookup should link by bundle class path")
+            assertHasResourceEdge(graph.incomingResourceEdges(providerBundleKeysCall.id), providerBundleBase.id, ResourceRelation.ENUMERATES, "Provider-backed bundle getKeys should enumerate base bundle path")
+        } finally {
+            fixtureDir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun assertLocaleAwareBundle(
+        graph: Graph,
+        method: io.johnsonlee.graphite.core.MethodDescriptor,
+        root: ResourceFileNode,
+        language: ResourceFileNode,
+        locale: ResourceFileNode
+    ) {
+        val bundleCall = requireCallSite(graph, method, "getBundle")
+        val lookupCall = requireCallSite(graph, method, "getString")
+        val bundleEdges = graph.incomingResourceEdges(bundleCall.id)
+        assertHasResourceEdge(bundleEdges, locale.id, ResourceRelation.BUNDLE_CANDIDATE, "${method.name} should keep ko_KR candidate")
+        assertHasResourceEdge(bundleEdges, language.id, ResourceRelation.BUNDLE_CANDIDATE, "${method.name} should keep ko candidate")
+        assertHasResourceEdge(bundleEdges, root.id, ResourceRelation.BUNDLE_CANDIDATE, "${method.name} should keep root candidate")
+        assertHasResourceEdge(graph.incomingResourceEdges(lookupCall.id), locale.id, ResourceRelation.LOOKUP, "${method.name} should link lookup to ko_KR bundle path")
+    }
+
+    private fun requireCallSite(graph: Graph, method: io.johnsonlee.graphite.core.MethodDescriptor, calleeName: String): CallSiteNode =
+        graph.nodes(CallSiteNode::class.java)
+            .filter { it.caller == method && it.callee.name == calleeName }
+            .singleOrNull()
+            .also { assertNotNull(it, "Should create call site for ${method.signature} -> $calleeName") }!!
+
+    private fun requireResourceFile(graph: Graph, path: String): ResourceFileNode =
+        graph.nodes(ResourceFileNode::class.java)
+            .firstOrNull { it.path == path }
+            .also { assertNotNull(it, "Should create ResourceFileNode for $path") }!!
+
+    private fun createFixtureDir(): Path {
+        val compiledClass = findCompiledTestClass("sample/resources/ResourceConfig.class")
+        val compiledSpringClass = findCompiledTestClass("sample/resources/SpringResourceConfig.class")
+        val compiledConfigurationPropertiesClass =
+            findCompiledTestClass("sample/resources/ConfigurationPropertiesConfig.class")
+        val compiledMessagesListBundleClass = findCompiledTestClass("sample/resources/MessagesListBundle.class")
+        val compiledMessagesListBundleKoClass = findCompiledTestClass("sample/resources/MessagesListBundle_ko_KR.class")
+        val compiledProviderBundleClass = findCompiledTestClass("sample/resources/ProviderMessagesBundle.class")
+        val compiledProviderBundleKoClass = findCompiledTestClass("sample/resources/ProviderMessagesBundle_ko_KR.class")
+        val compiledProviderClass = findCompiledTestClass("sample/resources/MessagesProvider.class")
+        val compiledClassOnlyControl = findCompiledTestClass("sample/resources/ClassOnlyControl.class")
+        val compiledKoreanOnlyControl = findCompiledTestClass("sample/resources/KoreanOnlyControl.class")
+        val providerService = findCompiledTestResource("META-INF/services/java.util.spi.ResourceBundleProvider")
+        val fixtureDir = Files.createTempDirectory("graphite-resource-config")
+        val targetClass = fixtureDir.resolve("sample/resources/ResourceConfig.class")
+        val targetSpringClass = fixtureDir.resolve("sample/resources/SpringResourceConfig.class")
+        val targetConfigurationPropertiesClass =
+            fixtureDir.resolve("sample/resources/ConfigurationPropertiesConfig.class")
+        Files.createDirectories(targetClass.parent)
+        Files.copy(compiledClass, targetClass)
+        Files.copy(compiledSpringClass, targetSpringClass)
+        Files.copy(compiledConfigurationPropertiesClass, targetConfigurationPropertiesClass)
+        Files.copy(compiledMessagesListBundleClass, fixtureDir.resolve("sample/resources/MessagesListBundle.class"))
+        Files.copy(compiledMessagesListBundleKoClass, fixtureDir.resolve("sample/resources/MessagesListBundle_ko_KR.class"))
+        Files.copy(compiledProviderBundleClass, fixtureDir.resolve("sample/resources/ProviderMessagesBundle.class"))
+        Files.copy(compiledProviderBundleKoClass, fixtureDir.resolve("sample/resources/ProviderMessagesBundle_ko_KR.class"))
+        Files.copy(compiledProviderClass, fixtureDir.resolve("sample/resources/MessagesProvider.class"))
+        Files.copy(compiledClassOnlyControl, fixtureDir.resolve("sample/resources/ClassOnlyControl.class"))
+        Files.copy(compiledKoreanOnlyControl, fixtureDir.resolve("sample/resources/KoreanOnlyControl.class"))
+        val serviceTarget = fixtureDir.resolve("META-INF/services/java.util.spi.ResourceBundleProvider")
+        Files.createDirectories(serviceTarget.parent)
+        Files.copy(providerService, serviceTarget)
+        Files.writeString(
+            fixtureDir.resolve("application.properties"),
+            """
+            feature.mode=shadow
+            feature.enabled=true
+            service.cache.enabled=true
+            service.cache.ttl-seconds=30
+            """.trimIndent()
+        )
+        Files.writeString(
+            fixtureDir.resolve("application.yml"),
+            """
+            server:
+              port: 8080
+            feature:
+              enabled: true
+              ttl: 30
+            """.trimIndent()
+        )
+        Files.writeString(
+            fixtureDir.resolve("application.json"),
+            """
+            {
+              "feature": {
+                "enabled": true,
+                "modes": ["light", "dark"]
+              },
+              "server": {
+                "port": 9090
+              }
+            }
+            """.trimIndent()
+        )
+        Files.writeString(
+            fixtureDir.resolve("messages.properties"),
+            """
+            hello=world
+            """.trimIndent()
+        )
+        Files.writeString(
+            fixtureDir.resolve("messages_ko.properties"),
+            """
+            hello=annyeong
+            """.trimIndent()
+        )
+        Files.writeString(
+            fixtureDir.resolve("messages_ko_KR.properties"),
+            """
+            hello=annyeong-hanguk
+            """.trimIndent()
+        )
+        Files.writeString(
+            fixtureDir.resolve("application.xml"),
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+            <properties>
+              <entry key="feature.mode">xml-shadow</entry>
+            </properties>
+            """.trimIndent()
+        )
+        Files.writeString(
+            fixtureDir.resolve("config.xml"),
+            """
+            <config>
+              <service enabled="true">
+                <endpoint>https://api.example.com</endpoint>
+                <timeout>30</timeout>
+              </service>
+            </config>
+            """.trimIndent()
+        )
+        return fixtureDir
+    }
+
+    private fun findCompiledTestClass(relativePath: String): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test").resolve(relativePath)
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test").resolve(relativePath)
+        val classFile = if (submodulePath.exists()) submodulePath else rootPath
+        assertTrue(classFile.exists(), "Compiled test class should exist: $classFile")
+        return classFile
+    }
+
+    private fun findCompiledTestResource(relativePath: String): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/resources/test").resolve(relativePath)
+        val rootPath = projectDir.resolve("graphite-sootup/build/resources/test").resolve(relativePath)
+        val resourceFile = if (submodulePath.exists()) submodulePath else rootPath
+        assertTrue(resourceFile.exists(), "Compiled test resource should exist: $resourceFile")
+        return resourceFile
+    }
+
+    private fun Graph.incomingResourceEdges(nodeId: NodeId): List<ResourceEdge> =
+        incoming(nodeId, ResourceEdge::class.java).toList()
+
+    private fun assertHasResourceEdge(
+        edges: List<ResourceEdge>,
+        from: NodeId,
+        kind: ResourceRelation,
+        message: String
+    ) {
+        assertTrue(edges.any { it.from == from && it.kind == kind }, message)
+    }
+}

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ResourceConfigLinkingTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ResourceConfigLinkingTest.kt
@@ -94,8 +94,13 @@ class ResourceConfigLinkingTest {
             val messageKoFromCtorMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromCtor")).single()
             val messageKoWithClassLoaderMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithClassLoader")).single()
             val messageKoWithControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithControl")).single()
+            val messageKoWithControlAliasMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithControlAlias")).single()
+            val messageKoWithDefaultControlAliasMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithDefaultControlAlias")).single()
             val messageKoFromBuilderMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromBuilder")).single()
             val messageKoFromBuilderTagMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromBuilderTag")).single()
+            val messageKoFromBuilderSetLocaleMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromBuilderSetLocale")).single()
+            val messageKoFromBuilderResetMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromBuilderReset")).single()
+            val messageKoFromBuilderVariantMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoFromBuilderVariant")).single()
             val messageClassOnlyControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageClassOnlyControlNoCandidate")).single()
             val messageClassOnlyCustomControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageClassOnlyCustomControlNoCandidate")).single()
             val messageKoCustomCandidateControlMethod = graph.methods(MethodPattern("sample.resources.ResourceConfig", "messageKoWithCustomCandidateControl")).single()
@@ -123,8 +128,13 @@ class ResourceConfigLinkingTest {
             assertLocaleAwareBundle(graph, messageKoFromCtorMethod, bundleRoot, bundleKo, bundleKoKr)
             assertLocaleAwareBundle(graph, messageKoWithClassLoaderMethod, bundleRoot, bundleKo, bundleKoKr)
             assertLocaleAwareBundle(graph, messageKoWithControlMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoWithControlAliasMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoWithDefaultControlAliasMethod, bundleRoot, bundleKo, bundleKoKr)
             assertLocaleAwareBundle(graph, messageKoFromBuilderMethod, bundleRoot, bundleKo, bundleKoKr)
             assertLocaleAwareBundle(graph, messageKoFromBuilderTagMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromBuilderSetLocaleMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromBuilderResetMethod, bundleRoot, bundleKo, bundleKoKr)
+            assertLocaleAwareBundle(graph, messageKoFromBuilderVariantMethod, bundleRoot, bundleKo, bundleKoKr)
 
             val classOnlyControlCall = requireCallSite(graph, messageClassOnlyControlMethod, "getBundle")
             val classOnlyControlEdges = graph.incomingResourceEdges(classOnlyControlCall.id)
@@ -190,9 +200,6 @@ class ResourceConfigLinkingTest {
 
     private fun createFixtureDir(): Path {
         val compiledClass = findCompiledTestClass("sample/resources/ResourceConfig.class")
-        val compiledSpringClass = findCompiledTestClass("sample/resources/SpringResourceConfig.class")
-        val compiledConfigurationPropertiesClass =
-            findCompiledTestClass("sample/resources/ConfigurationPropertiesConfig.class")
         val compiledMessagesListBundleClass = findCompiledTestClass("sample/resources/MessagesListBundle.class")
         val compiledMessagesListBundleKoClass = findCompiledTestClass("sample/resources/MessagesListBundle_ko_KR.class")
         val compiledProviderBundleClass = findCompiledTestClass("sample/resources/ProviderMessagesBundle.class")
@@ -203,13 +210,8 @@ class ResourceConfigLinkingTest {
         val providerService = findCompiledTestResource("META-INF/services/java.util.spi.ResourceBundleProvider")
         val fixtureDir = Files.createTempDirectory("graphite-resource-config")
         val targetClass = fixtureDir.resolve("sample/resources/ResourceConfig.class")
-        val targetSpringClass = fixtureDir.resolve("sample/resources/SpringResourceConfig.class")
-        val targetConfigurationPropertiesClass =
-            fixtureDir.resolve("sample/resources/ConfigurationPropertiesConfig.class")
         Files.createDirectories(targetClass.parent)
         Files.copy(compiledClass, targetClass)
-        Files.copy(compiledSpringClass, targetSpringClass)
-        Files.copy(compiledConfigurationPropertiesClass, targetConfigurationPropertiesClass)
         Files.copy(compiledMessagesListBundleClass, fixtureDir.resolve("sample/resources/MessagesListBundle.class"))
         Files.copy(compiledMessagesListBundleKoClass, fixtureDir.resolve("sample/resources/MessagesListBundle_ko_KR.class"))
         Files.copy(compiledProviderBundleClass, fixtureDir.resolve("sample/resources/ProviderMessagesBundle.class"))
@@ -225,8 +227,6 @@ class ResourceConfigLinkingTest {
             """
             feature.mode=shadow
             feature.enabled=true
-            service.cache.enabled=true
-            service.cache.ttl-seconds=30
             """.trimIndent()
         )
         Files.writeString(

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapterInternalCoverageTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapterInternalCoverageTest.kt
@@ -1,0 +1,560 @@
+package io.johnsonlee.graphite.sootup
+
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.input.EmptyResourceAccessor
+import io.johnsonlee.graphite.input.LoaderConfig
+import io.johnsonlee.graphite.input.ResourceAccessor
+import io.johnsonlee.graphite.input.ResourceEntry
+import java.nio.file.Path
+import java.util.Locale
+import java.util.ResourceBundle
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import io.johnsonlee.graphite.core.MethodDescriptor
+import io.johnsonlee.graphite.core.FieldDescriptor
+import io.johnsonlee.graphite.core.FieldNode
+import io.johnsonlee.graphite.core.LocalVariable
+import io.johnsonlee.graphite.core.ResourceFileNode
+import io.johnsonlee.graphite.core.TypeDescriptor
+import io.johnsonlee.graphite.core.NodeId
+import kotlin.io.path.exists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.InsnNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.MethodNode
+import sootup.core.jimple.basic.StmtPositionInfo
+import sootup.core.jimple.common.constant.MethodHandle
+import sootup.core.jimple.common.constant.StringConstant as SootStringConstant
+import sootup.core.jimple.common.expr.JDynamicInvokeExpr
+import sootup.core.jimple.common.expr.JStaticInvokeExpr
+import sootup.core.jimple.common.ref.JStaticFieldRef
+import sootup.core.jimple.common.stmt.JAssignStmt
+import sootup.core.inputlocation.AnalysisInputLocation
+import sootup.core.model.SourceType
+import sootup.core.signatures.MethodSignature
+import sootup.core.types.VoidType
+import sootup.java.bytecode.frontend.inputlocation.PathBasedAnalysisInputLocation
+import sootup.java.core.JavaIdentifierFactory
+import sootup.java.core.JavaSootClass
+import sootup.java.core.jimple.basic.JavaLocal
+import sootup.java.core.views.JavaView
+
+class SootUpAdapterInternalCoverageTest {
+    private val identifierFactory = JavaIdentifierFactory.getInstance()
+
+    @Test
+    fun `literal helpers resolve locale and control constants`() {
+        val adapter = createAdapter()
+
+        assertEquals(listOf("java.class"), invokePrivate<Any?>(adapter, "resolveStaticLiteral", arrayOf(String::class.java, String::class.java), "java.util.ResourceBundle\$Control", "FORMAT_CLASS"))
+        assertEquals(listOf("java.properties"), invokePrivate<Any?>(adapter, "resolveStaticLiteral", arrayOf(String::class.java, String::class.java), "java.util.ResourceBundle\$Control", "FORMAT_PROPERTIES"))
+        assertEquals(listOf("java.class", "java.properties"), invokePrivate<Any?>(adapter, "resolveStaticLiteral", arrayOf(String::class.java, String::class.java), "java.util.ResourceBundle\$Control", "FORMAT_DEFAULT"))
+        assertEquals("ko_KR", invokePrivate<String?>(adapter, "resolveStaticLiteral", arrayOf(String::class.java, String::class.java), "java.util.Locale", "KOREA"))
+        assertEquals("", invokePrivate<String?>(adapter, "resolveStaticLiteral", arrayOf(String::class.java, String::class.java), "java.util.Locale", "ROOT"))
+
+        assertEquals("zh_CN", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "SIMPLIFIED_CHINESE"))
+        assertEquals("zh_TW", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "TRADITIONAL_CHINESE"))
+        assertEquals("fr_CA", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "CANADA_FRENCH"))
+        assertEquals("en", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "ENGLISH"))
+        assertEquals("en_US", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "US"))
+        assertEquals("en_GB", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "UK"))
+        assertEquals("en_CA", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "CANADA"))
+        assertEquals("fr", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "FRENCH"))
+        assertEquals("fr_FR", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "FRANCE"))
+        assertEquals("de", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "GERMAN"))
+        assertEquals("de_DE", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "GERMANY"))
+        assertEquals("it", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "ITALIAN"))
+        assertEquals("it_IT", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "ITALY"))
+        assertEquals("ja", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "JAPANESE"))
+        assertEquals("ja_JP", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "JAPAN"))
+        assertEquals("ko", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "KOREAN"))
+        assertEquals("zh", invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "CHINESE"))
+        assertNull(invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(String::class.java), "UNKNOWN"))
+
+        assertEquals(setOf("java.class"), invokePrivate<Set<String>>(adapter, "controlFormats", arrayOf(String::class.java), "java.class"))
+        assertEquals(setOf("java.properties"), invokePrivate<Set<String>>(adapter, "controlFormats", arrayOf(String::class.java), "java.properties"))
+        assertEquals(setOf("java.properties", "java.class"), invokePrivate<Set<String>>(adapter, "controlFormats", arrayOf(String::class.java), null))
+
+        assertEquals(Locale("ko", "KR"), invokePrivate<Locale>(adapter, "toLocale", arrayOf(String::class.java), "ko_KR"))
+        assertEquals(Locale.ROOT, invokePrivate<Locale>(adapter, "toLocale", arrayOf(String::class.java), ""))
+
+        assertTrue(invokePrivate<Boolean>(adapter, "matchesBundleClassPath", arrayOf(String::class.java, String::class.java), "sample.resources.MessagesListBundle_ko_KR", "sample.resources.MessagesListBundle"))
+        assertFalse(invokePrivate<Boolean>(adapter, "matchesBundleClassPath", arrayOf(String::class.java, String::class.java), "other.Bundle", "sample.resources.MessagesListBundle"))
+
+        val caller = MethodDescriptor(TypeDescriptor("sample.resources.ResourceConfig"), "lookup", emptyList(), TypeDescriptor("java.lang.String"))
+        assertEquals("application.properties", invokePrivate<String>(adapter, "normalizeResourcePath", arrayOf(MethodDescriptor::class.java, String::class.java, String::class.java), caller, "java.lang.ClassLoader", "/application.properties"))
+        assertEquals("application.properties", invokePrivate<String>(adapter, "normalizeResourcePath", arrayOf(MethodDescriptor::class.java, String::class.java, String::class.java), caller, "java.lang.Class", "/application.properties"))
+        assertEquals("sample/resources/messages.properties", invokePrivate<String>(adapter, "normalizeResourcePath", arrayOf(MethodDescriptor::class.java, String::class.java, String::class.java), caller, "java.lang.Class", "messages.properties"))
+    }
+
+    @Test
+    fun `compiled resource bundle helpers inspect bytecode and control specs`() {
+        val adapter = createAdapter()
+        val resourceBackedAdapter = createResourceBackedAdapter()
+        val classOnlyControl = resolveJavaSootClass(adapter, "sample.resources.ClassOnlyControl")
+        val koreanOnlyControl = resolveJavaSootClass(adapter, "sample.resources.KoreanOnlyControl")
+        val listBundle = resolveJavaSootClass(adapter, "sample.resources.MessagesListBundle_ko_KR")
+
+        val directLoadedMethods = invokePrivate<List<MethodNode>?>(resourceBackedAdapter, "loadMethodNodesFromResource", arrayOf(JavaSootClass::class.java), resolveJavaSootClass(resourceBackedAdapter, "sample.resources.MessagesListBundle_ko_KR"))
+        val controlMethods = invokePrivate<List<MethodNode>?>(adapter, "getAsmMethodNodes", arrayOf(JavaSootClass::class.java), classOnlyControl)
+            ?: invokePrivate<List<MethodNode>?>(adapter, "loadMethodNodesFromResource", arrayOf(JavaSootClass::class.java), classOnlyControl)
+        val candidateMethods = invokePrivate<List<MethodNode>?>(adapter, "getAsmMethodNodes", arrayOf(JavaSootClass::class.java), koreanOnlyControl)
+            ?: invokePrivate<List<MethodNode>?>(adapter, "loadMethodNodesFromResource", arrayOf(JavaSootClass::class.java), koreanOnlyControl)
+        assertNotNull(directLoadedMethods)
+        assertTrue(directLoadedMethods.isNotEmpty())
+        assertNotNull(controlMethods)
+        assertNotNull(candidateMethods)
+        val streamedMethods = invokePrivate<Sequence<*>>(resourceBackedAdapter, "streamMethodsOrNull", arrayOf(sootup.core.model.SootClass::class.java), resolveJavaSootClass(resourceBackedAdapter, "sample.resources.MessagesListBundle_ko_KR"))
+        assertNotNull(streamedMethods)
+        assertTrue(streamedMethods.any())
+
+        val getFormats = controlMethods.first { it.name == "getFormats" }
+        val getCandidateLocales = candidateMethods.first { it.name == "getCandidateLocales" }
+        assertEquals(setOf("java.class"), invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), getFormats))
+        assertEquals(listOf("ko_KR"), invokePrivate<List<String>?>(adapter, "extractCandidateLocalesFromMethod", arrayOf(MethodNode::class.java), getCandidateLocales))
+        assertTrue(invokePrivate<Boolean>(adapter, "returnsNullLiteral", arrayOf(MethodNode::class.java), nullReturnMethod()))
+
+        val classOnlySpec = invokePrivate<Any?>(adapter, "resolveBundleControlSpec", arrayOf(String::class.java), "sample.resources.ClassOnlyControl")
+        val koreanOnlySpec = invokePrivate<Any?>(adapter, "resolveBundleControlSpec", arrayOf(String::class.java), "sample.resources.KoreanOnlyControl")
+        assertNotNull(classOnlySpec)
+        assertNotNull(koreanOnlySpec)
+        assertEquals(setOf("java.class"), readProperty<Set<String>>(classOnlySpec, "formats"))
+        assertEquals(listOf("ko_KR"), readProperty<List<String>?>(koreanOnlySpec, "candidateLocales"))
+        val resourceFilesByPath = readField<MutableMap<String, MutableList<ResourceFileNode>>>(adapter, "resourceFilesByPath")
+        resourceFilesByPath["messages.properties"] = mutableListOf(ResourceFileNode(NodeId.next(), "messages.properties", "test", "properties", null))
+        resourceFilesByPath["messages_ko.properties"] = mutableListOf(ResourceFileNode(NodeId.next(), "messages_ko.properties", "test", "properties", null))
+        resourceFilesByPath["messages_ko_KR.properties"] = mutableListOf(ResourceFileNode(NodeId.next(), "messages_ko_KR.properties", "test", "properties", null))
+        resourceFilesByPath["sample.resources.MessagesListBundle_ko_KR"] = mutableListOf(ResourceFileNode(NodeId.next(), "sample.resources.MessagesListBundle_ko_KR", "test", "listbundle", null))
+        assertEquals(
+            linkedSetOf("messages_ko_KR.properties", "messages_ko.properties", "messages.properties"),
+            invokePrivate<LinkedHashSet<String>>(adapter, "collectMatchingResourceBundlePaths", arrayOf(String::class.java, String::class.java, classOnlySpec.javaClass), "messages", "messages", null)
+        )
+        assertEquals(
+            linkedSetOf("sample.resources.MessagesListBundle_ko_KR"),
+            invokePrivate<LinkedHashSet<String>>(adapter, "collectMatchingResourceBundlePaths", arrayOf(String::class.java, String::class.java, classOnlySpec.javaClass), "sample.resources.MessagesListBundle", "sample/resources/MessagesListBundle", classOnlySpec)
+        )
+
+        val methods = invokePrivate<Set<*>>(adapter, "resolveMethodsOrEmpty", arrayOf(sootup.core.model.SootClass::class.java), listBundle)
+        assertTrue(methods.isNotEmpty())
+    }
+
+    @Test
+    fun `runtime bundle indexing records localized parent chain and literal evaluation`() {
+        val adapter = createAdapter()
+
+        assertEquals(
+            listOf("java.class", "java.properties"),
+            invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), listOfMethod())
+        )
+        assertEquals(
+            listOf("java.properties"),
+            invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), singletonListMethod())
+        )
+        assertEquals(
+            "ko_KR",
+            invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), languageTagMethod())
+        )
+        assertEquals(42, invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), intPushMethod(Opcodes.BIPUSH, 42)))
+        assertEquals(1024, invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), intPushMethod(Opcodes.SIPUSH, 1024)))
+        assertEquals(-1, invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), iconstReturnMethod(Opcodes.ICONST_M1)))
+        assertEquals(5, invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), iconstReturnMethod(Opcodes.ICONST_5)))
+        assertNull(invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), localeCtorMethod()))
+        assertEquals(listOf("java.class", "java.properties"), invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), arraysAsListMethod()))
+        assertEquals(setOf("java.class"), invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), singleFormatMethod("java.class")))
+        assertEquals(setOf("java.properties"), invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), singleFormatMethod("java.properties")))
+        assertNull(invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), singleIntListOfMethod(7)))
+        assertNull(invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), singleFormatMethod("ignored")))
+
+        val bundle = ResourceBundle.getBundle("sample.resources.MessagesListBundle", Locale.KOREA)
+        invokePrivate<Unit>(adapter, "indexRuntimeBundle", arrayOf(ResourceBundle::class.java), bundle)
+        val indexed = readField<MutableMap<String, *>>(adapter, "resourceFilesByPath")
+        assertTrue(indexed.containsKey("sample.resources.MessagesListBundle_ko_KR"))
+        val parent = SimpleBundle("parent")
+        val child = SimpleBundle("child").withParent(parent)
+        assertNull(invokePrivate<ResourceBundle?>(adapter, "bundleParent", arrayOf(ResourceBundle::class.java), child))
+    }
+
+    @Test
+    fun `control and string extraction resolve locals static fields and bundle classes`() {
+        val adapter = createAdapter(listOf("sample.resources", "sample.resolution"))
+        val caller = MethodDescriptor(TypeDescriptor("sample.resources.ResourceConfig"), "lookup", emptyList(), TypeDescriptor("java.lang.String"))
+        val controlLocal = JavaLocal("control", identifierFactory.getType("java.lang.String"), emptyList())
+        val textLocal = JavaLocal("text", identifierFactory.getType("java.lang.String"), emptyList())
+        val wrongOwnerRef = JStaticFieldRef(identifierFactory.getFieldSignature("FORMAT_CLASS", identifierFactory.getClassType("java.lang.String"), identifierFactory.getType("java.lang.Object")))
+        val classFormatRef = JStaticFieldRef(identifierFactory.getFieldSignature("FORMAT_CLASS", identifierFactory.getClassType("java.util.ResourceBundle\$Control"), identifierFactory.getType("java.lang.Object")))
+        val propertiesFormatRef = JStaticFieldRef(identifierFactory.getFieldSignature("FORMAT_PROPERTIES", identifierFactory.getClassType("java.util.ResourceBundle\$Control"), identifierFactory.getType("java.lang.Object")))
+        val defaultFormatRef = JStaticFieldRef(identifierFactory.getFieldSignature("FORMAT_DEFAULT", identifierFactory.getClassType("java.util.ResourceBundle\$Control"), identifierFactory.getType("java.lang.Object")))
+
+        readField<MutableMap<Any, String>>(adapter, "bundleControlFormatsByLocal")[
+            invokePrivate(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, controlLocal.name)
+        ] = "java.class"
+        readField<MutableMap<Any, String>>(adapter, "stringValuesByLocal")[
+            invokePrivate(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, textLocal.name)
+        ] = "hello"
+
+        assertEquals("java.class", invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, controlLocal))
+        assertEquals("java.class", invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, classFormatRef))
+        assertEquals("java.properties", invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, propertiesFormatRef))
+        assertNull(invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, defaultFormatRef))
+        assertNull(invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, wrongOwnerRef))
+        assertNull(invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), null, controlLocal))
+
+        assertEquals("direct", invokePrivate<String?>(adapter, "extractStringValue", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, SootStringConstant("direct", identifierFactory.getType("java.lang.String"))))
+        assertEquals("hello", invokePrivate<String?>(adapter, "extractStringValue", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, textLocal))
+        assertNull(invokePrivate<String?>(adapter, "extractStringValue", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, null))
+
+        assertTrue(invokePrivate(adapter, "isResourceBundleControlClass", arrayOf(sootup.core.model.SootClass::class.java), resolveJavaSootClass(adapter, "sample.resources.ClassOnlyControl")))
+        assertFalse(invokePrivate(adapter, "isResourceBundleControlClass", arrayOf(sootup.core.model.SootClass::class.java), resolveJavaSootClass(adapter, "sample.resources.MessagesListBundle")))
+    }
+
+    @Test
+    fun `dynamic invoke helpers resolve locals fields fallback and defining classes`() {
+        val adapter = createAdapter(listOf("sample.resources", "sample.resolution", "sample.lambda"), buildCallGraph = true)
+        val caller = MethodDescriptor(TypeDescriptor("sample.lambda.LambdaExample"), "useFactory", emptyList(), TypeDescriptor("java.lang.String"))
+        val argLocal = JavaLocal("input", identifierFactory.getType("java.lang.String"), emptyList())
+        val targetSig = identifierFactory.getMethodSignature("sample.lambda.LambdaExample", "transform", "java.lang.String", listOf("java.lang.String"))
+        val bootstrapSig = identifierFactory.getMethodSignature("java.lang.invoke.LambdaMetafactory", "metafactory", "java.lang.Object", emptyList())
+        val applySig = identifierFactory.getMethodSignature(JDynamicInvokeExpr.INVOKEDYNAMIC_DUMMY_CLASS_NAME, "apply", "java.lang.Object", listOf("java.lang.Object"))
+        val methodHandle = MethodHandle(targetSig, MethodHandle.Kind.REF_INVOKE_STATIC, identifierFactory.getType("java.lang.String"))
+
+        val localResult = LocalVariable(NodeId.next(), "fn", TypeDescriptor("java.util.function.Function"), caller)
+        invokePrivate<Unit>(
+            adapter,
+            "processDynamicInvoke",
+            arrayOf(JDynamicInvokeExpr::class.java, MethodDescriptor::class.java, io.johnsonlee.graphite.core.ValueNode::class.java, sootup.core.jimple.common.stmt.Stmt::class.java),
+            JDynamicInvokeExpr(bootstrapSig, listOf(methodHandle), applySig, listOf(argLocal)),
+            caller,
+            localResult,
+            null
+        )
+        val dynamicTargets = readField<MutableMap<Any, List<MethodDescriptor>>>(adapter, "dynamicTargets")
+        val resultKey = invokePrivate<Any>(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, "fn")
+        assertEquals(listOf(invokePrivate<MethodDescriptor>(adapter, "toMethodDescriptor", arrayOf(MethodSignature::class.java), targetSig)), dynamicTargets[resultKey])
+
+        val fieldSig = identifierFactory.getFieldSignature("callback", identifierFactory.getClassType("sample.lambda.FieldCallbackExample"), identifierFactory.getType("java.lang.Object"))
+        val fieldNode = FieldNode(NodeId.next(), FieldDescriptor(TypeDescriptor("sample.lambda.FieldCallbackExample"), "callback", TypeDescriptor("java.lang.Object")), true)
+        invokePrivate<Unit>(
+            adapter,
+            "processDynamicInvoke",
+            arrayOf(JDynamicInvokeExpr::class.java, MethodDescriptor::class.java, io.johnsonlee.graphite.core.ValueNode::class.java, sootup.core.jimple.common.stmt.Stmt::class.java),
+            JDynamicInvokeExpr(bootstrapSig, listOf(methodHandle), applySig, listOf(argLocal)),
+            caller,
+            fieldNode,
+            JAssignStmt(JStaticFieldRef(fieldSig), JDynamicInvokeExpr(bootstrapSig, listOf(methodHandle), applySig, listOf(argLocal)), StmtPositionInfo.getNoStmtPositionInfo())
+        )
+        val fieldTargets = readField<MutableMap<String, MutableList<MethodDescriptor>>>(adapter, "fieldDynamicTargets")
+        assertTrue(fieldTargets[fieldSig.toString()].orEmpty().isNotEmpty())
+
+        invokePrivate<Unit>(
+            adapter,
+            "processDynamicInvoke",
+            arrayOf(JDynamicInvokeExpr::class.java, MethodDescriptor::class.java, io.johnsonlee.graphite.core.ValueNode::class.java, sootup.core.jimple.common.stmt.Stmt::class.java),
+            JDynamicInvokeExpr(bootstrapSig, listOf(SootStringConstant("template", identifierFactory.getType("java.lang.String"))), applySig, emptyList()),
+            caller,
+            null,
+            null
+        )
+        val builtGraph = readField<DefaultGraph.Builder>(adapter, "graphBuilder").build()
+        assertTrue(builtGraph.nodes(io.johnsonlee.graphite.core.CallSiteNode::class.java).any { it.callee.name == "apply" })
+
+        val concreteProcess = identifierFactory.getMethodSignature("sample.resolution.ConcreteService", "process", "int", listOf("int"))
+        val defaultGreet = identifierFactory.getMethodSignature("sample.resolution.FormalGreeter", "greet", "java.lang.String", listOf("java.lang.String"))
+        assertEquals("sample.resolution.ConcreteService", invokePrivate<MethodSignature>(adapter, "resolveMethodDefiningClass", arrayOf(MethodSignature::class.java), concreteProcess).declClassType.fullyQualifiedName)
+        assertEquals("sample.resolution.Greeter", invokePrivate<MethodSignature>(adapter, "resolveMethodDefiningClass", arrayOf(MethodSignature::class.java), defaultGreet).declClassType.fullyQualifiedName)
+    }
+
+    @Test
+    fun `functional dispatch propagation resolves return parameter and unresolved locals`() {
+        val adapter = createAdapter(listOf("sample.lambda"), buildCallGraph = true)
+        val caller = MethodDescriptor(TypeDescriptor("sample.lambda.CallbackExample"), "useCallback", emptyList(), TypeDescriptor("java.lang.String"))
+        val callee = MethodDescriptor(TypeDescriptor("sample.lambda.CallbackExample"), "processWithCallback", emptyList(), TypeDescriptor("java.lang.String"))
+        val target = MethodDescriptor(TypeDescriptor("sample.lambda.CallbackExample"), "transform", listOf(TypeDescriptor("java.lang.String")), TypeDescriptor("java.lang.String"))
+        val resultKey = invokePrivate<Any>(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, "result")
+        val fieldLocalKey = invokePrivate<Any>(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, "fieldLocal")
+        val callSite = io.johnsonlee.graphite.core.CallSiteNode(NodeId.next(), caller, callee, 10, null, listOf(NodeId.next()))
+        val unresolved = io.johnsonlee.graphite.core.CallSiteNode(NodeId.next(), caller, callee, 11, null, emptyList())
+
+        readField<MutableMap<MethodDescriptor, List<MethodDescriptor>>>(adapter, "returnDynamicTargets")[callee] = listOf(target)
+        readField<MutableMap<MethodDescriptor, MutableList<Any>>>(adapter, "callResultLocals")[callee] = mutableListOf(resultKey)
+        readField<MutableMap<MethodDescriptor, MutableList<Pair<Int, io.johnsonlee.graphite.core.CallSiteNode>>>>(adapter, "parameterVirtualCalls")[callee] = mutableListOf(0 to callSite)
+        readField<MutableMap<MethodDescriptor, MutableList<Pair<Int, List<MethodDescriptor>>>>>(adapter, "callSiteDynamicArgs")[callee] = mutableListOf(0 to listOf(target))
+        readField<MutableMap<String, MutableList<MethodDescriptor>>>(adapter, "fieldDynamicTargets")["sample.lambda.CallbackExample.callback"] = mutableListOf(target)
+        readField<MutableMap<String, MutableList<Any>>>(adapter, "fieldLoadLocals")["sample.lambda.CallbackExample.callback"] = mutableListOf(fieldLocalKey)
+        readField<MutableMap<Any, MutableList<io.johnsonlee.graphite.core.CallSiteNode>>>(adapter, "unresolvedLocalVirtualCalls")[fieldLocalKey] = mutableListOf(unresolved)
+
+        invokePrivate<Unit>(adapter, "resolveFunctionalDispatch", emptyArray())
+
+        val dynamicTargets = readField<MutableMap<Any, List<MethodDescriptor>>>(adapter, "dynamicTargets")
+        assertEquals(listOf(target), dynamicTargets[resultKey])
+        assertEquals(listOf(target), dynamicTargets[fieldLocalKey])
+        val builtGraph = readField<DefaultGraph.Builder>(adapter, "graphBuilder").build()
+        assertTrue(builtGraph.nodes(io.johnsonlee.graphite.core.CallSiteNode::class.java).count() >= 2)
+    }
+
+    @Test
+    fun `helper fallbacks cover unresolved values and bundle paths`() {
+        val adapter = createAdapter(listOf("sample.resources", "sample.resolution"))
+        val caller = MethodDescriptor(TypeDescriptor("sample.resources.ResourceConfig"), "messageKo", emptyList(), TypeDescriptor("java.lang.String"))
+        val local = JavaLocal("value", identifierFactory.getType("java.lang.String"), emptyList())
+        val integerValueOf = identifierFactory.getMethodSignature("java.lang.Integer", "valueOf", "java.lang.Integer", listOf("int"))
+        val stringValueOf = identifierFactory.getMethodSignature("java.lang.String", "valueOf", "java.lang.String", listOf("java.lang.Object"))
+        val resourceBundleGetBundle = identifierFactory.getMethodSignature("java.util.ResourceBundle", "getBundle", "java.util.ResourceBundle", listOf("java.lang.String", "java.util.Locale"))
+        val listBundle = resolveJavaSootClass(adapter, "sample.resources.MessagesListBundle")
+
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "extractValueFromArg",
+                arrayOf(sootup.core.jimple.basic.Value::class.java, Map::class.java),
+                JStaticFieldRef(identifierFactory.getFieldSignature("KOREA", identifierFactory.getClassType("java.util.Locale"), identifierFactory.getType("java.util.Locale"))),
+                emptyMap<String, Any?>()
+            )
+        )
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "extractBoxedValue",
+                arrayOf(JStaticInvokeExpr::class.java),
+                JStaticInvokeExpr(stringValueOf, listOf(local))
+            )
+        )
+        assertNull(
+            invokePrivate<List<String>?>(
+                adapter,
+                "extractCandidateLocalesFromMethod",
+                arrayOf(MethodNode::class.java),
+                singleFormatMethod("ignored")
+            )
+        )
+        assertNull(
+            invokePrivate<List<String>?>(
+                adapter,
+                "extractCandidateLocalesFromMethod",
+                arrayOf(MethodNode::class.java),
+                singletonIntListMethod(7)
+            )
+        )
+        assertEquals(Locale("ko", "KR", "POSIX"), invokePrivate<Locale>(adapter, "toLocale", arrayOf(String::class.java), "ko_KR_POSIX"))
+        assertNull(invokePrivate<Any?>(adapter, "resolveStaticLiteral", arrayOf(String::class.java, String::class.java), "java.lang.String", "MISSING"))
+        assertNull(
+            invokePrivate<LinkedHashSet<String>?>(
+                adapter,
+                "extractResourceBundlePaths",
+                arrayOf(MethodDescriptor::class.java, MethodSignature::class.java, sootup.core.jimple.common.expr.AbstractInvokeExpr::class.java),
+                caller,
+                resourceBundleGetBundle,
+                JStaticInvokeExpr(resourceBundleGetBundle, listOf(local, local))
+            )
+        )
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "firstMethod",
+                arrayOf(sootup.core.model.SootClass::class.java, kotlin.jvm.functions.Function1::class.java),
+                listBundle,
+                { _: Any? -> false }
+            )
+        )
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "bundleParent",
+                arrayOf(ResourceBundle::class.java),
+                SimpleBundle("orphan")
+            )
+        )
+        assertEquals(
+            7,
+            invokePrivate<Any?>(
+                adapter,
+                "extractBoxedValue",
+                arrayOf(JStaticInvokeExpr::class.java),
+                JStaticInvokeExpr(integerValueOf, listOf(sootup.core.jimple.common.constant.IntConstant.getInstance(7)))
+            )
+        )
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "extractBoxedValue",
+                arrayOf(JStaticInvokeExpr::class.java),
+                JStaticInvokeExpr(integerValueOf, emptyList())
+            )
+        )
+    }
+
+    private fun createAdapter(includePackages: List<String> = listOf("sample.resources"), buildCallGraph: Boolean = false): SootUpAdapter {
+        val testClassesDir = findTestClassesDir()
+        assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
+        val inputLocations: List<AnalysisInputLocation> = listOf(
+            PathBasedAnalysisInputLocation.create(testClassesDir, SourceType.Application)
+        )
+        return SootUpAdapter(
+            view = JavaView(inputLocations),
+            config = LoaderConfig(includePackages = includePackages, buildCallGraph = buildCallGraph),
+            signatureReader = BytecodeSignatureReader(),
+            extensions = emptyList(),
+            resourceAccessor = EmptyResourceAccessor,
+            graphBuilder = DefaultGraph.Builder()
+        )
+    }
+
+    private fun createResourceBackedAdapter(): SootUpAdapter {
+        val testClassesDir = findTestClassesDir()
+        val resources = mapOf(
+            "sample/resources/MessagesListBundle_ko_KR.class" to findCompiledClassBytes("sample/resources/MessagesListBundle_ko_KR.class"),
+            "sample/resources/ClassOnlyControl.class" to findCompiledClassBytes("sample/resources/ClassOnlyControl.class"),
+            "sample/resources/KoreanOnlyControl.class" to findCompiledClassBytes("sample/resources/KoreanOnlyControl.class")
+        )
+            val inputLocations: List<AnalysisInputLocation> = listOf(
+            PathBasedAnalysisInputLocation.create(testClassesDir, SourceType.Application)
+        )
+        val resourceAccessor = object : ResourceAccessor {
+            override fun list(pattern: String): Sequence<ResourceEntry> = emptySequence()
+            override fun open(path: String) = resources[path]?.inputStream() ?: error("Missing resource $path")
+        }
+        return SootUpAdapter(
+            view = JavaView(inputLocations),
+            config = LoaderConfig(includePackages = listOf("sample.resources"), buildCallGraph = false),
+            signatureReader = BytecodeSignatureReader(),
+            extensions = emptyList(),
+            resourceAccessor = resourceAccessor,
+            graphBuilder = DefaultGraph.Builder()
+        )
+    }
+
+    private fun resolveJavaSootClass(adapter: SootUpAdapter, className: String): JavaSootClass =
+        invokePrivate<JavaSootClass?>(adapter, "resolveClassByName", arrayOf(String::class.java), className)
+            ?: error("Unable to resolve $className")
+
+    private fun nullReturnMethod(): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC, "getFallbackLocale", "(Ljava/lang/String;Ljava/util/Locale;)Ljava/util/Locale;", null, null).apply {
+            instructions.add(InsnNode(Opcodes.ACONST_NULL))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun listOfMethod(): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/util/List;", null, null).apply {
+            instructions.add(LdcInsnNode("java.class"))
+            instructions.add(LdcInsnNode("java.properties"))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/List", "of", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/List;", true))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun singletonListMethod(): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/util/List;", null, null).apply {
+            instructions.add(LdcInsnNode("java.properties"))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/Collections", "singletonList", "(Ljava/lang/Object;)Ljava/util/List;", false))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun languageTagMethod(): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "locale", "()Ljava/lang/Object;", null, null).apply {
+            instructions.add(LdcInsnNode("ko-KR"))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/Locale", "forLanguageTag", "(Ljava/lang/String;)Ljava/util/Locale;", false))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun intPushMethod(opcode: Int, operand: Int): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "literal", "()Ljava/lang/Object;", null, null).apply {
+            instructions.add(org.objectweb.asm.tree.IntInsnNode(opcode, operand))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun iconstReturnMethod(opcode: Int): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "literal", "()Ljava/lang/Object;", null, null).apply {
+            instructions.add(InsnNode(opcode))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun localeCtorMethod(): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "locale", "()Ljava/lang/Object;", null, null).apply {
+            instructions.add(LdcInsnNode("ko"))
+            instructions.add(LdcInsnNode("KR"))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESPECIAL, "java/util/Locale", "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", false))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun arraysAsListMethod(): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/util/List;", null, null).apply {
+            instructions.add(LdcInsnNode("java.class"))
+            instructions.add(LdcInsnNode("java.properties"))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/List", "of", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/List;", true))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/Arrays", "asList", "(Ljava/lang/Object;)Ljava/util/List;", false))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun singleFormatMethod(value: String): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/lang/Object;", null, null).apply {
+            instructions.add(LdcInsnNode(value))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun singletonLiteralListMethod(value: String): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/util/List;", null, null).apply {
+            instructions.add(LdcInsnNode(value))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/Collections", "singletonList", "(Ljava/lang/Object;)Ljava/util/List;", false))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun singletonIntListMethod(value: Int): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/util/List;", null, null).apply {
+            instructions.add(org.objectweb.asm.tree.IntInsnNode(Opcodes.BIPUSH, value))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;", false))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/Collections", "singletonList", "(Ljava/lang/Object;)Ljava/util/List;", false))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    private fun singleIntListOfMethod(value: Int): MethodNode =
+        MethodNode(Opcodes.ASM9, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/util/List;", null, null).apply {
+            instructions.add(org.objectweb.asm.tree.IntInsnNode(Opcodes.BIPUSH, value))
+            instructions.add(MethodInsnNode(Opcodes.INVOKESTATIC, "java/util/List", "of", "(Ljava/lang/Object;)Ljava/util/List;", true))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> readField(target: Any, name: String): T {
+        val field = target.javaClass.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(target) as T
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> readProperty(target: Any, name: String): T {
+        val field = target.javaClass.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(target) as T
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> invokePrivate(target: Any, name: String, parameterTypes: Array<Class<*>>, vararg args: Any?): T {
+        val method = target.javaClass.getDeclaredMethod(name, *parameterTypes)
+        method.isAccessible = true
+        return method.invoke(target, *args) as T
+    }
+
+    private fun findTestClassesDir(): Path {
+        val projectDir = Path.of(System.getProperty("user.dir"))
+        val submodulePath = projectDir.resolve("build/classes/java/test")
+        val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
+        return if (submodulePath.exists()) submodulePath else rootPath
+    }
+
+    private fun findCompiledClassBytes(relativePath: String): ByteArray =
+        findTestClassesDir().resolve(relativePath).toFile().readBytes()
+
+    private class SimpleBundle(private val value: String) : ResourceBundle() {
+        override fun handleGetObject(key: String): Any = value
+        override fun getKeys(): java.util.Enumeration<String> = java.util.Collections.enumeration(listOf("hello"))
+        fun withParent(parent: ResourceBundle): SimpleBundle {
+            setParent(parent)
+            return this
+        }
+    }
+}

--- a/graphite-sootup/src/test/resources/META-INF/services/java.util.spi.ResourceBundleProvider
+++ b/graphite-sootup/src/test/resources/META-INF/services/java.util.spi.ResourceBundleProvider
@@ -1,0 +1,1 @@
+sample.resources.MessagesProvider

--- a/graphite-webgraph/build.gradle.kts
+++ b/graphite-webgraph/build.gradle.kts
@@ -7,12 +7,6 @@ plugins {
 }
 
 kover {
-    currentProject {
-        instrumentation {
-            disabledForTestTasks.add("test")
-        }
-    }
-
     reports {
         filters {
             excludes {

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BenchmarkCorpus.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BenchmarkCorpus.kt
@@ -62,7 +62,13 @@ internal object BenchmarkCorpus {
         outputDir.toFile().deleteRecursively()
         Files.createDirectories(outputDir)
 
-        val graph = JavaProjectLoader(LoaderConfig(buildCallGraph = false)).load(jarPath)
+        val graph = JavaProjectLoader(
+            LoaderConfig(
+                buildCallGraph = false,
+                extractAnnotations = false,
+                trackCrossMethodFunctionalDispatch = false
+            )
+        ).load(jarPath)
         try {
             GraphStore.save(graph, outputDir)
         } finally {

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -131,6 +131,9 @@ private const val LABELS_FILE = "graph.labels"
         DataOutputStream(BufferedOutputStream(dir.resolve(METADATA_FILE).toFile().outputStream())).use { dos ->
             NodeSerializer.saveMetadata(metadata, dos, stringTable)
         }
+
+        // 8. Save persisted text resources for loaded-graph access
+        PersistedResourceStore.save(graph, dir)
     }
 
     /**
@@ -201,7 +204,17 @@ private const val LABELS_FILE = "graph.labels"
             NodeSerializer.loadMetadata(dis, stringTable)
         }
 
-        return WebGraphBackedGraph(forward, backward, nodesById, labelBytes, cumulativeOutdeg, comparisonMap, metadata)
+        return WebGraphBackedGraph(
+            forward,
+            backward,
+            nodesById,
+            nodeDataVersion,
+            labelBytes,
+            cumulativeOutdeg,
+            comparisonMap,
+            metadata,
+            PersistedResourceStore.load(dir)
+        )
     }
 
     /**
@@ -248,7 +261,8 @@ private const val LABELS_FILE = "graph.labels"
             forwardLabels = labelBytes,
             cumulativeOutdeg = cumulativeOutdeg,
             comparisonMap = comparisonMap,
-            metadata = metadata
+            metadata = metadata,
+            resources = PersistedResourceStore.load(dir)
         )
     }
 
@@ -301,7 +315,8 @@ private const val LABELS_FILE = "graph.labels"
             forwardLabels = labelBytes,
             cumulativeOutdeg = cumulativeOutdeg,
             comparisonMap = comparisonMap,
-            metadata = metadata
+            metadata = metadata,
+            resources = PersistedResourceStore.load(dir)
         )
     }
 
@@ -523,7 +538,9 @@ private const val LABELS_FILE = "graph.labels"
             10 to ParameterNode::class.java,
             11 to ReturnNode::class.java,
             12 to CallSiteNode::class.java,
-            13 to AnnotationNode::class.java
+            13 to AnnotationNode::class.java,
+            14 to ResourceValueNode::class.java,
+            15 to ResourceFileNode::class.java
         )
         for ((tag, ids) in nodeTypeByTag) {
             val cls = tagToClass[tag] ?: continue

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -3,7 +3,6 @@ package io.johnsonlee.graphite.webgraph
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
-import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import it.unimi.dsi.webgraph.ImmutableGraph
@@ -38,7 +37,8 @@ internal class LazyWebGraphBackedGraph(
     private val forwardLabels: ByteArray,
     private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,
-    private val metadata: GraphMetadata
+    private val metadata: GraphMetadata,
+    override val resources: ResourceAccessor
 ) : Graph, Closeable {
 
     private val openRafs = java.util.Collections.synchronizedList(mutableListOf<RandomAccessFile>())
@@ -91,7 +91,7 @@ internal class LazyWebGraphBackedGraph(
             val label = forwardLabels[(labelStart + i).toInt()].toInt() and 0xFF
             val key = nodeIdx.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
             val comparison = comparisonMap[key]
-            NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison)
+            NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison, nodeDataVersion)
         }
     }
 
@@ -105,7 +105,7 @@ internal class LazyWebGraphBackedGraph(
             val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl 32 or (nodeIdx.toLong() and 0xFFFFFFFFL)
             val comparison = comparisonMap[key]
-            NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison)
+            NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison, nodeDataVersion)
         }
     }
 
@@ -141,8 +141,6 @@ internal class LazyWebGraphBackedGraph(
 
     override fun memberAnnotations(className: String, memberName: String): Map<String, Map<String, Any?>> =
         metadata.memberAnnotations["$className#$memberName"] ?: emptyMap()
-
-    override val resources: ResourceAccessor = EmptyResourceAccessor
 
     override fun branchScopes(): Sequence<BranchScope> =
         branchScopeIndex.values.asSequence().flatMap { it.asSequence() }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -3,7 +3,6 @@ package io.johnsonlee.graphite.webgraph
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
-import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import it.unimi.dsi.webgraph.ImmutableGraph
@@ -45,7 +44,8 @@ internal class MappedWebGraphBackedGraph(
     private val forwardLabels: ByteArray,
     private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,
-    private val metadata: GraphMetadata
+    private val metadata: GraphMetadata,
+    override val resources: ResourceAccessor
 ) : Graph, Closeable {
 
     private val branchScopeIndex: Map<Int, List<BranchScope>> by lazy {
@@ -92,7 +92,7 @@ internal class MappedWebGraphBackedGraph(
             val label = forwardLabels[(labelStart + i).toInt()].toInt() and 0xFF
             val key = nodeIdx.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
             val comparison = comparisonMap[key]
-            NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison)
+            NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison, nodeDataVersion)
         }
     }
 
@@ -106,7 +106,7 @@ internal class MappedWebGraphBackedGraph(
             val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl 32 or (nodeIdx.toLong() and 0xFFFFFFFFL)
             val comparison = comparisonMap[key]
-            NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison)
+            NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison, nodeDataVersion)
         }
     }
 
@@ -142,8 +142,6 @@ internal class MappedWebGraphBackedGraph(
 
     override fun memberAnnotations(className: String, memberName: String): Map<String, Map<String, Any?>> =
         metadata.memberAnnotations["$className#$memberName"] ?: emptyMap()
-
-    override val resources: ResourceAccessor = EmptyResourceAccessor
 
     override fun branchScopes(): Sequence<BranchScope> =
         branchScopeIndex.values.asSequence().flatMap { it.asSequence() }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
@@ -13,10 +13,17 @@ import java.io.*
  * inline UTF strings. This provides significant size reduction through both
  * deduplication and front-coding compression.
  *
- * Edge type encoding fits in 8 bits:
- * - Bits 0-1: edge type (0=DataFlow, 1=Call, 2=Type, 3=ControlFlow)
+ * Edge type encoding fits in 8 bits.
+ *
+ * v1/v2:
+ * - Bits 0-1: edge family (0=DataFlow, 1=Call, 2=Type, 3=ControlFlow)
  * - Bits 2-5: subkind ordinal (DataFlowKind, ControlFlowKind, TypeRelation, or call flags)
  * - Bits 6-7: extra flags (isVirtual, isDynamic for CallEdge)
+ *
+ * v3:
+ * - Bits 0-2: edge family (0=DataFlow, 1=Call, 2=Type, 3=ControlFlow, 4=Resource)
+ * - Bits 3-6: subkind ordinal or call flags
+ * - Bit 7: reserved
  *
  * [ControlFlowEdge.comparison] is stored separately since it does not fit in 8 bits.
  */
@@ -29,8 +36,9 @@ internal object NodeSerializer {
     internal const val MAGIC_COMPARISONS = 0x47524300  // "GRC"
 
     /** Current format version (occupies the low byte of the 4-byte header int). */
-    const val FORMAT_VERSION: Int = 2
+    const val FORMAT_VERSION: Int = 3
     private const val LEGACY_FORMAT_VERSION: Int = 1
+    private const val TRANSITIONAL_FORMAT_VERSION: Int = 2
 
     /** Write a 4-byte file header: 3-byte magic prefix | 1-byte version. */
     fun writeHeader(dos: DataOutputStream, magic: Int) {
@@ -62,9 +70,9 @@ internal object NodeSerializer {
     }
 
     private fun validateVersion(version: Int, expectedMagic: Int) {
-        require(version == LEGACY_FORMAT_VERSION || version == FORMAT_VERSION) {
+        require(version == LEGACY_FORMAT_VERSION || version == TRANSITIONAL_FORMAT_VERSION || version == FORMAT_VERSION) {
             "Unsupported GraphStore format version $version for 0x${expectedMagic.toString(16)}. " +
-                "This build supports versions $LEGACY_FORMAT_VERSION and $FORMAT_VERSION."
+                "This build supports versions $LEGACY_FORMAT_VERSION, $TRANSITIONAL_FORMAT_VERSION and $FORMAT_VERSION."
         }
     }
 
@@ -83,6 +91,8 @@ internal object NodeSerializer {
     private const val TAG_RETURN_NODE = 11
     private const val TAG_CALL_SITE_NODE = 12
     private const val TAG_ANNOTATION_NODE = 13
+    private const val TAG_RESOURCE_VALUE_NODE = 14
+    private const val TAG_RESOURCE_FILE_NODE = 15
 
     // Value type tags (for heterogeneous value lists like enum constructor args)
     private const val VAL_INT = 0
@@ -102,20 +112,21 @@ internal object NodeSerializer {
     /**
      * Encode an edge type into an 8-bit label.
      *
-     * Layout:
+     * v3 layout:
      * ```
-     * bits 0-1: edge family (0=DataFlow, 1=Call, 2=Type, 3=ControlFlow)
-     * bits 2-5: subkind ordinal
-     * bits 6-7: extra flags (Call: bit6=isVirtual, bit7=isDynamic)
+     * bits 0-2: edge family (0=DataFlow, 1=Call, 2=Type, 3=ControlFlow, 4=Resource)
+     * bits 3-6: subkind ordinal or call flags (bit3=isVirtual, bit4=isDynamic)
+     * bit 7: reserved
      * ```
      */
     fun encodeEdge(edge: Edge): Int = when (edge) {
-        is DataFlowEdge -> 0 or (edge.kind.ordinal shl 2)
+        is DataFlowEdge -> 0 or (edge.kind.ordinal shl 3)
         is CallEdge -> 1 or
-                ((if (edge.isVirtual) 1 else 0) shl 6) or
-                ((if (edge.isDynamic) 1 else 0) shl 7)
-        is TypeEdge -> 2 or (edge.kind.ordinal shl 2)
-        is ControlFlowEdge -> 3 or (edge.kind.ordinal shl 2)
+                ((if (edge.isVirtual) 1 else 0) shl 3) or
+                ((if (edge.isDynamic) 1 else 0) shl 4)
+        is TypeEdge -> 2 or (edge.kind.ordinal shl 3)
+        is ControlFlowEdge -> 3 or (edge.kind.ordinal shl 3)
+        is ResourceEdge -> 4 or (edge.kind.ordinal shl 3)
     }
 
     /**
@@ -124,7 +135,17 @@ internal object NodeSerializer {
      * [comparison] must be supplied externally for [ControlFlowEdge] edges that
      * carried a non-null comparison at save time.
      */
-    fun decodeEdge(label: Int, from: NodeId, to: NodeId, comparison: BranchComparison? = null): Edge {
+    fun decodeEdge(
+        label: Int,
+        from: NodeId,
+        to: NodeId,
+        comparison: BranchComparison? = null,
+        version: Int = FORMAT_VERSION
+    ): Edge {
+        return if (version >= FORMAT_VERSION) decodeEdgeV3(label, from, to, comparison) else decodeEdgeV2(label, from, to, comparison)
+    }
+
+    private fun decodeEdgeV2(label: Int, from: NodeId, to: NodeId, comparison: BranchComparison?): Edge {
         val family = label and 0x3
         return when (family) {
             0 -> DataFlowEdge(from, to, DataFlowKind.entries[(label shr 2) and 0xF])
@@ -135,6 +156,22 @@ internal object NodeSerializer {
             )
             2 -> TypeEdge(from, to, TypeRelation.entries[(label shr 2) and 0xF])
             3 -> ControlFlowEdge(from, to, ControlFlowKind.entries[(label shr 2) and 0xF], comparison)
+            else -> throw IllegalArgumentException("Unknown edge family: $family")
+        }
+    }
+
+    private fun decodeEdgeV3(label: Int, from: NodeId, to: NodeId, comparison: BranchComparison?): Edge {
+        val family = label and 0x7
+        return when (family) {
+            0 -> DataFlowEdge(from, to, DataFlowKind.entries[(label shr 3) and 0xF])
+            1 -> CallEdge(
+                from, to,
+                isVirtual = ((label shr 3) and 1) == 1,
+                isDynamic = ((label shr 4) and 1) == 1
+            )
+            2 -> TypeEdge(from, to, TypeRelation.entries[(label shr 3) and 0xF])
+            3 -> ControlFlowEdge(from, to, ControlFlowKind.entries[(label shr 3) and 0xF], comparison)
+            4 -> ResourceEdge(from, to, ResourceRelation.entries[(label shr 3) and 0xF])
             else -> throw IllegalArgumentException("Unknown edge family: $family")
         }
     }
@@ -172,6 +209,19 @@ internal object NodeSerializer {
                 is ReturnNode -> {
                     collectMethodDescriptorStrings(node.method, dest)
                     node.actualType?.let { dest.add(it.className) }
+                }
+                is ResourceFileNode -> {
+                    dest.add(node.path)
+                    dest.add(node.source)
+                    dest.add(node.format)
+                    node.profile?.let(dest::add)
+                }
+                is ResourceValueNode -> {
+                    dest.add(node.path)
+                    dest.add(node.key)
+                    dest.add(node.format)
+                    node.profile?.let(dest::add)
+                    collectAnyValueString(node.value, dest)
                 }
                 is CallSiteNode -> {
                     collectMethodDescriptorStrings(node.caller, dest)
@@ -281,6 +331,8 @@ internal object NodeSerializer {
             is ReturnNode -> TAG_RETURN_NODE
             is CallSiteNode -> TAG_CALL_SITE_NODE
             is AnnotationNode -> TAG_ANNOTATION_NODE
+            is ResourceFileNode -> TAG_RESOURCE_FILE_NODE
+            is ResourceValueNode -> TAG_RESOURCE_VALUE_NODE
         }
         dos.writeByte(tag)
         // Type-specific fields
@@ -318,6 +370,21 @@ internal object NodeSerializer {
                 writeMethodDescriptor(dos, node.method, strings)
                 dos.writeBoolean(node.actualType != null)
                 if (node.actualType != null) dos.writeInt(strings.indexOf(node.actualType!!.className))
+            }
+            is ResourceFileNode -> {
+                dos.writeInt(strings.indexOf(node.path))
+                dos.writeInt(strings.indexOf(node.source))
+                dos.writeInt(strings.indexOf(node.format))
+                dos.writeBoolean(node.profile != null)
+                if (node.profile != null) dos.writeInt(strings.indexOf(node.profile!!))
+            }
+            is ResourceValueNode -> {
+                dos.writeInt(strings.indexOf(node.path))
+                dos.writeInt(strings.indexOf(node.key))
+                writeAnyValue(dos, node.value, strings)
+                dos.writeInt(strings.indexOf(node.format))
+                dos.writeBoolean(node.profile != null)
+                if (node.profile != null) dos.writeInt(strings.indexOf(node.profile!!))
             }
             is CallSiteNode -> {
                 writeMethodDescriptor(dos, node.caller, strings)
@@ -382,6 +449,21 @@ internal object NodeSerializer {
                 val hasActualType = dis.readBoolean()
                 val actualType = if (hasActualType) TypeDescriptor(strings.get(dis.readInt())) else null
                 ReturnNode(id, method, actualType)
+            }
+            TAG_RESOURCE_FILE_NODE -> {
+                val path = strings.get(dis.readInt())
+                val source = strings.get(dis.readInt())
+                val format = strings.get(dis.readInt())
+                val profile = if (dis.readBoolean()) strings.get(dis.readInt()) else null
+                ResourceFileNode(id, path, source, format, profile)
+            }
+            TAG_RESOURCE_VALUE_NODE -> {
+                val path = strings.get(dis.readInt())
+                val key = strings.get(dis.readInt())
+                val value = readAnyValue(dis, strings, formatVersion)
+                val format = strings.get(dis.readInt())
+                val profile = if (dis.readBoolean()) strings.get(dis.readInt()) else null
+                ResourceValueNode(id, path, key, value, format, profile)
             }
             TAG_CALL_SITE_NODE -> {
                 val caller = readMethodDescriptor(dis, strings)
@@ -627,7 +709,7 @@ internal object NodeSerializer {
         VAL_NULL -> null
         VAL_ENUM_REF -> EnumValueReference(strings.get(dis.readInt()), strings.get(dis.readInt()))
         VAL_LIST -> {
-            require(formatVersion >= FORMAT_VERSION) {
+            require(formatVersion >= TRANSITIONAL_FORMAT_VERSION) {
                 "Encountered list value in GraphStore format version $formatVersion. Re-save the graph with a current Graphite build."
             }
             List(dis.readInt()) { readAnyValue(dis, strings, formatVersion) }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
@@ -1,0 +1,127 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.input.EmptyResourceAccessor
+import io.johnsonlee.graphite.input.ResourceAccessor
+import io.johnsonlee.graphite.input.ResourceEntry
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.ByteArrayInputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal data class PersistedResource(
+    val path: String,
+    val source: String,
+    val content: ByteArray
+)
+
+internal class PersistedResourceAccessor(
+    private val resources: Map<String, PersistedResource>
+) : ResourceAccessor {
+
+    override fun list(pattern: String): Sequence<ResourceEntry> {
+        val matcher = FileSystems.getDefault().getPathMatcher("glob:$pattern")
+        return resources.values.asSequence()
+            .filter { matcher.matches(Path.of(it.path)) }
+            .map { ResourceEntry(it.path, it.source) }
+    }
+
+    override fun open(path: String): InputStream =
+        resources[path]?.let { ByteArrayInputStream(it.content) }
+            ?: throw java.io.IOException("Resource not found: $path")
+}
+
+internal object PersistedResourceStore {
+    private const val FILE_NAME = "graph.resources"
+    private const val MAGIC = 0x47525200 // "GRR" + version byte
+    private const val VERSION = 1
+    private val PERSISTED_SUFFIXES = setOf(".properties", ".yml", ".yaml", ".json", ".xml", ".txt")
+
+    fun save(graph: Graph, dir: Path) {
+        val resources = collect(graph)
+        if (resources.isEmpty()) return
+
+        DataOutputStream(BufferedOutputStream(Files.newOutputStream(dir.resolve(FILE_NAME)))).use { dos ->
+            writeHeader(dos)
+            dos.writeInt(resources.size)
+            resources.forEach { resource ->
+                writeString(dos, resource.path)
+                writeString(dos, resource.source)
+                dos.writeInt(resource.content.size)
+                dos.write(resource.content)
+            }
+        }
+    }
+
+    fun load(dir: Path): ResourceAccessor {
+        val file = dir.resolve(FILE_NAME)
+        if (!Files.exists(file)) return EmptyResourceAccessor
+        DataInputStream(BufferedInputStream(Files.newInputStream(file))).use { dis ->
+            readHeader(dis)
+            val count = dis.readInt()
+            val resources = LinkedHashMap<String, PersistedResource>(count)
+            repeat(count) {
+                val path = readString(dis)
+                val source = readString(dis)
+                val size = dis.readInt()
+                val bytes = ByteArray(size)
+                dis.readFully(bytes)
+                resources[path] = PersistedResource(path, source, bytes)
+            }
+            return PersistedResourceAccessor(resources)
+        }
+    }
+
+    private fun collect(graph: Graph): List<PersistedResource> {
+        val resources = linkedMapOf<String, PersistedResource>()
+
+        graph.resources.list("**")
+            .filter { shouldPersist(it.path) }
+            .forEach { entry ->
+                runCatching {
+                    graph.resources.open(entry.path).use { input ->
+                        PersistedResource(
+                            path = entry.path,
+                            source = entry.source,
+                            content = input.readBytes()
+                        )
+                    }
+                }.getOrNull()?.let { resources.putIfAbsent(it.path, it) }
+            }
+
+        return resources.values.toList()
+    }
+
+    private fun shouldPersist(path: String): Boolean =
+        PERSISTED_SUFFIXES.any { path.endsWith(it, ignoreCase = true) }
+
+    private fun writeHeader(dos: DataOutputStream) {
+        dos.writeInt(MAGIC or VERSION)
+    }
+
+    private fun readHeader(dis: DataInputStream) {
+        val header = dis.readInt()
+        require(header and 0xFFFFFF00.toInt() == MAGIC) { "Invalid resource file magic: 0x${header.toUInt().toString(16)}" }
+        val version = header and 0xFF
+        require(version == VERSION) { "Unsupported resource file version: $version" }
+    }
+
+    private fun writeString(dos: DataOutputStream, value: String) {
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        dos.writeInt(bytes.size)
+        dos.write(bytes)
+    }
+
+    private fun readString(dis: DataInputStream): String {
+        val size = dis.readInt()
+        val bytes = ByteArray(size)
+        dis.readFully(bytes)
+        return String(bytes, StandardCharsets.UTF_8)
+    }
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
@@ -3,7 +3,6 @@ package io.johnsonlee.graphite.webgraph
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
-import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import it.unimi.dsi.webgraph.ImmutableGraph
@@ -20,10 +19,12 @@ internal class WebGraphBackedGraph(
     private val forward: ImmutableGraph,
     private val backward: ImmutableGraph,
     private val nodesById: Map<Int, Node>,
+    private val nodeDataVersion: Int,
     private val forwardLabels: ByteArray,
     private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,
-    private val metadata: GraphMetadata
+    private val metadata: GraphMetadata,
+    override val resources: ResourceAccessor
 ) : Graph {
 
     /** Pre-computed index: concrete node class -> list of nodes of that class. */
@@ -65,7 +66,7 @@ internal class WebGraphBackedGraph(
             val label = forwardLabels[(labelStart + i).toInt()].toInt() and 0xFF
             val key = nodeIdx.toLong() shl 32 or (to.toLong() and 0xFFFFFFFFL)
             val comparison = comparisonMap[key]
-            NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison)
+            NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison, nodeDataVersion)
         }
     }
 
@@ -79,7 +80,7 @@ internal class WebGraphBackedGraph(
             val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl 32 or (nodeIdx.toLong() and 0xFFFFFFFFL)
             val comparison = comparisonMap[key]
-            NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison)
+            NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison, nodeDataVersion)
         }
     }
 
@@ -115,8 +116,6 @@ internal class WebGraphBackedGraph(
 
     override fun memberAnnotations(className: String, memberName: String): Map<String, Map<String, Any?>> =
         metadata.memberAnnotations["$className#$memberName"] ?: emptyMap()
-
-    override val resources: ResourceAccessor = EmptyResourceAccessor
 
     override fun branchScopes(): Sequence<BranchScope> =
         branchScopeIndex.values.asSequence().flatMap { it.asSequence() }

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
@@ -60,6 +60,12 @@ class AndroidSdkIntegrationTest {
     }
 
     private fun loadGraph(): Graph {
-        return JavaProjectLoader(LoaderConfig(buildCallGraph = false)).load(androidJar!!)
+        return JavaProjectLoader(
+            LoaderConfig(
+                buildCallGraph = false,
+                extractAnnotations = false,
+                trackCrossMethodFunctionalDispatch = false
+            )
+        ).load(androidJar!!)
     }
 }

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/ElasticsearchIntegrationTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/ElasticsearchIntegrationTest.kt
@@ -77,6 +77,12 @@ class ElasticsearchIntegrationTest {
     }
 
     private fun loadGraph(): Graph {
-        return JavaProjectLoader(LoaderConfig(buildCallGraph = false)).load(esJar!!)
+        return JavaProjectLoader(
+            LoaderConfig(
+                buildCallGraph = false,
+                extractAnnotations = false,
+                trackCrossMethodFunctionalDispatch = false
+            )
+        ).load(esJar!!)
     }
 }

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/ElasticsearchIntegrationTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/ElasticsearchIntegrationTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Integration test using Elasticsearch JAR (968K nodes, 1M edges).
+ * Integration test using the current Elasticsearch core JAR fixture.
  */
 class ElasticsearchIntegrationTest {
 
@@ -33,7 +33,7 @@ class ElasticsearchIntegrationTest {
     fun `load Elasticsearch and verify graph has many nodes`() {
         val graph = loadGraph()
         val nodeCount = graph.nodes(Node::class.java).count()
-        assertTrue(nodeCount > 100000, "ES graph should have >100K nodes, got $nodeCount")
+        assertTrue(nodeCount > 500, "ES graph should have >500 nodes, got $nodeCount")
     }
 
     @Test
@@ -73,7 +73,7 @@ class ElasticsearchIntegrationTest {
         val result = graph.query("MATCH (n:CallSiteNode) RETURN count(*)")
         assertTrue(result.rows.isNotEmpty())
         val count = result.rows[0].values.first()
-        assertTrue((count as Number).toLong() > 1000, "Should have >1000 call sites")
+        assertTrue((count as Number).toLong() > 100, "Should have >100 call sites, got $count")
     }
 
     private fun loadGraph(): Graph {

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -11,7 +11,9 @@ import java.io.ByteArrayOutputStream
 import java.io.Closeable
 import java.io.DataInputStream
 import java.io.DataOutputStream
+import java.io.OutputStream
 import java.io.RandomAccessFile
+import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -208,7 +210,6 @@ class GraphStoreTest {
         builder.addNode(resourceFileNode)
         builder.addNode(resourceNode)
         builder.addNode(callSite)
-        builder.addEdge(ResourceEdge(resourceFileNode.id, resourceNode.id, ResourceRelation.CONTAINS))
         builder.addEdge(ResourceEdge(resourceNode.id, callSite.id, ResourceRelation.LOOKUP))
 
         val graph = builder.build()
@@ -221,9 +222,6 @@ class GraphStoreTest {
             val loadedNode = loaded.node(resourceNode.id) as ResourceValueNode
             assertEquals(resourceFileNode, loadedFile)
             assertEquals(resourceNode, loadedNode)
-            assertTrue(loaded.incoming(resourceNode.id, ResourceEdge::class.java).any {
-                it.from == resourceFileNode.id && it.kind == ResourceRelation.CONTAINS
-            })
             assertTrue(loaded.incoming(callSite.id, ResourceEdge::class.java).any {
                 it.from == resourceNode.id && it.kind == ResourceRelation.LOOKUP
             })
@@ -794,6 +792,151 @@ class GraphStoreTest {
             assertTrue(decodedResource is ResourceEdge)
             assertEquals(relation, (decodedResource as ResourceEdge).kind)
         }
+    }
+
+    @Test
+    fun `decodeEdge supports legacy v2 labels`() {
+        val from = NodeId(1)
+        val to = NodeId(2)
+        val comparison = BranchComparison(ComparisonOp.EQ, NodeId(3))
+
+        val dataFlow = NodeSerializer.decodeEdge(0 or (DataFlowKind.FIELD_LOAD.ordinal shl 2), from, to, version = 2)
+        assertEquals(DataFlowKind.FIELD_LOAD, (dataFlow as DataFlowEdge).kind)
+
+        val call = NodeSerializer.decodeEdge(1 or (1 shl 6) or (1 shl 7), from, to, version = 2)
+        assertTrue((call as CallEdge).isVirtual)
+        assertTrue(call.isDynamic)
+
+        val type = NodeSerializer.decodeEdge(2 or (TypeRelation.IMPLEMENTS.ordinal shl 2), from, to, version = 2)
+        assertEquals(TypeRelation.IMPLEMENTS, (type as TypeEdge).kind)
+
+        val control = NodeSerializer.decodeEdge(3 or (ControlFlowKind.BRANCH_FALSE.ordinal shl 2), from, to, comparison, version = 2)
+        assertEquals(ControlFlowKind.BRANCH_FALSE, (control as ControlFlowEdge).kind)
+        assertEquals(comparison, control.comparison)
+    }
+
+    @Test
+    fun `node serializer helpers cover value io and direct edge decoders`() {
+        val dir = Files.createTempDirectory("webgraph-node-helpers")
+        try {
+            val strings = StringTable.build(
+                setOf("fallback", "enum.Owner", "VALUE", "hello", "java.class"),
+                dir
+            )
+            val serializerClass = NodeSerializer::class.java
+            val collectAnyValueString = serializerClass.getDeclaredMethod("collectAnyValueString", Any::class.java, MutableSet::class.java).apply { isAccessible = true }
+            val writeAnyValue = serializerClass.getDeclaredMethod("writeAnyValue", DataOutputStream::class.java, Any::class.java, StringTable::class.java).apply { isAccessible = true }
+            val readAnyValue = serializerClass.getDeclaredMethod("readAnyValue", DataInputStream::class.java, StringTable::class.java, Int::class.javaPrimitiveType).apply { isAccessible = true }
+            val decodeEdgeV2 = serializerClass.declaredMethods.first { it.name.startsWith("decodeEdgeV2") }.apply { isAccessible = true }
+            val decodeEdgeV3 = serializerClass.declaredMethods.first { it.name.startsWith("decodeEdgeV3") }.apply { isAccessible = true }
+
+            val dest = linkedSetOf<String>()
+            collectAnyValueString.invoke(NodeSerializer, EnumValueReference("enum.Owner", "VALUE"), dest)
+            collectAnyValueString.invoke(NodeSerializer, listOf("hello", true), dest)
+            collectAnyValueString.invoke(NodeSerializer, object { override fun toString() = "fallback" }, dest)
+            assertTrue(dest.containsAll(listOf("enum.Owner", "VALUE", "hello")))
+            assertTrue(dest.contains("fallback"))
+
+            val baos = ByteArrayOutputStream()
+            DataOutputStream(baos).use { dos ->
+                writeAnyValue.invoke(NodeSerializer, dos, listOf("hello", 7), strings)
+                dos.writeByte(99)
+                dos.writeInt(strings.indexOf("fallback"))
+            }
+            DataInputStream(ByteArrayInputStream(baos.toByteArray())).use { dis ->
+                assertEquals(listOf("hello", 7), readAnyValue.invoke(NodeSerializer, dis, strings, NodeSerializer.FORMAT_VERSION))
+                assertEquals("fallback", readAnyValue.invoke(NodeSerializer, dis, strings, NodeSerializer.FORMAT_VERSION))
+            }
+
+            val unsupportedOut = ByteArrayOutputStream()
+            DataOutputStream(unsupportedOut).use { dos ->
+                writeAnyValue.invoke(NodeSerializer, dos, object { override fun toString() = "fallback" }, strings)
+            }
+            DataInputStream(ByteArrayInputStream(unsupportedOut.toByteArray())).use { dis ->
+                assertEquals("fallback", readAnyValue.invoke(NodeSerializer, dis, strings, NodeSerializer.FORMAT_VERSION))
+            }
+
+            val from = NodeId(11)
+            val to = NodeId(12)
+            val comparison = BranchComparison(ComparisonOp.GT, NodeId(13))
+            assertEquals(
+                DataFlowKind.PARAMETER_PASS,
+                (decodeEdgeV2.invoke(NodeSerializer, 0 or (DataFlowKind.PARAMETER_PASS.ordinal shl 2), from.value, to.value, null) as DataFlowEdge).kind
+            )
+            val legacyCall = decodeEdgeV2.invoke(NodeSerializer, 1 or (1 shl 6) or (1 shl 7), from.value, to.value, null) as CallEdge
+            assertTrue(legacyCall.isVirtual)
+            assertTrue(legacyCall.isDynamic)
+            val legacyStaticCall = decodeEdgeV2.invoke(NodeSerializer, 1, from.value, to.value, null) as CallEdge
+            assertFalse(legacyStaticCall.isVirtual)
+            assertFalse(legacyStaticCall.isDynamic)
+            assertEquals(
+                TypeRelation.EXTENDS,
+                (decodeEdgeV2.invoke(NodeSerializer, 2 or (TypeRelation.EXTENDS.ordinal shl 2), from.value, to.value, null) as TypeEdge).kind
+            )
+            assertEquals(
+                comparison,
+                (decodeEdgeV2.invoke(NodeSerializer, 3 or (ControlFlowKind.SEQUENTIAL.ordinal shl 2), from.value, to.value, comparison) as ControlFlowEdge).comparison
+            )
+            val v3Call = decodeEdgeV3.invoke(NodeSerializer, 1 or (1 shl 3) or (1 shl 4), from.value, to.value, null) as CallEdge
+            assertTrue(v3Call.isVirtual)
+            assertTrue(v3Call.isDynamic)
+            val v3StaticCall = decodeEdgeV3.invoke(NodeSerializer, 1, from.value, to.value, null) as CallEdge
+            assertFalse(v3StaticCall.isVirtual)
+            assertFalse(v3StaticCall.isDynamic)
+            assertEquals(
+                ResourceRelation.OPENS,
+                (decodeEdgeV3.invoke(NodeSerializer, 4 or (ResourceRelation.OPENS.ordinal shl 3), from.value, to.value, null) as ResourceEdge).kind
+            )
+            val decodeFailure = assertFailsWith<java.lang.reflect.InvocationTargetException> {
+                decodeEdgeV3.invoke(NodeSerializer, 5, from.value, to.value, null)
+            }
+            assertTrue(decodeFailure.targetException is IllegalArgumentException)
+
+            val boolOut = ByteArrayOutputStream()
+            DataOutputStream(boolOut).use { dos -> writeAnyValue.invoke(NodeSerializer, dos, true, strings) }
+            DataInputStream(ByteArrayInputStream(boolOut.toByteArray())).use { dis ->
+                assertEquals(true, readAnyValue.invoke(NodeSerializer, dis, strings, NodeSerializer.FORMAT_VERSION))
+            }
+
+            val legacyListOut = ByteArrayOutputStream()
+            DataOutputStream(legacyListOut).use { dos -> writeAnyValue.invoke(NodeSerializer, dos, listOf("hello"), strings) }
+            DataInputStream(ByteArrayInputStream(legacyListOut.toByteArray())).use { dis ->
+                val legacyFailure = assertFailsWith<java.lang.reflect.InvocationTargetException> {
+                    readAnyValue.invoke(NodeSerializer, dis, strings, 1)
+                }
+                assertTrue(legacyFailure.targetException is IllegalArgumentException)
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `byte buffer input stream available and counting output stream flush delegate correctly`() {
+        val byteBufferInputStreamClass = Class.forName("io.johnsonlee.graphite.webgraph.ByteBufferInputStream")
+        val inputCtor = byteBufferInputStreamClass.getDeclaredConstructor(ByteBuffer::class.java).apply { isAccessible = true }
+        val input = inputCtor.newInstance(ByteBuffer.wrap(byteArrayOf(1, 2, 3))) as java.io.InputStream
+        assertEquals(3, input.available())
+        assertEquals(1, input.read())
+        assertEquals(2, input.available())
+        val buffer = ByteArray(4)
+        assertEquals(2, input.read(buffer, 1, 2))
+        assertEquals(byteArrayOf(0, 2, 3, 0).toList(), buffer.toList())
+        assertEquals(-1, input.read(buffer, 0, buffer.size))
+
+        val flushed = mutableListOf<Boolean>()
+        val delegate = object : OutputStream() {
+            override fun write(b: Int) = Unit
+            override fun flush() { flushed += true }
+        }
+        val countingOutputStreamClass = Class.forName("io.johnsonlee.graphite.webgraph.CountingOutputStream")
+        val outputCtor = countingOutputStreamClass.getDeclaredConstructor(OutputStream::class.java).apply { isAccessible = true }
+        val output = outputCtor.newInstance(delegate) as OutputStream
+        output.write(byteArrayOf(1, 2, 3))
+        output.flush()
+        val bytesWritten = countingOutputStreamClass.getDeclaredMethod("getBytesWritten").invoke(output) as Long
+        assertEquals(3L, bytesWritten)
+        assertEquals(listOf(true), flushed)
     }
 
     @Test

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -3,9 +3,9 @@ package io.johnsonlee.graphite.webgraph
 import io.johnsonlee.graphite.core.*
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.MethodPattern
-import io.johnsonlee.graphite.graph.nodes
 import io.johnsonlee.graphite.graph.Graph
-import io.johnsonlee.graphite.input.EmptyResourceAccessor
+import io.johnsonlee.graphite.input.ResourceAccessor
+import io.johnsonlee.graphite.input.ResourceEntry
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
@@ -191,6 +191,42 @@ class GraphStoreTest {
             val loadedNode = loaded.node(annotationNode.id) as AnnotationNode
             assertEquals(annotationNode.values, loadedNode.values)
             assertEquals(annotationNode.values, loaded.memberAnnotations("com.example.Foo", "bar")["com.example.Http"])
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `round-trip preserves ResourceValueNode`() {
+        val builder = DefaultGraph.Builder()
+        val method = MethodDescriptor(TypeDescriptor("com.example.Foo"), "bar", emptyList(), TypeDescriptor("void"))
+        val resourceFileNode = ResourceFileNode(NodeId.next(), "application.yml", "BOOT-INF/classes", "yaml", "prod")
+        val resourceNode = ResourceValueNode(NodeId.next(), "application.yml", "server.port", 8080, "yaml", "prod")
+        val callSite = CallSiteNode(NodeId.next(), method, method, 12, null, emptyList())
+        builder.addMethod(method)
+        builder.addNode(ReturnNode(NodeId.next(), method))
+        builder.addNode(resourceFileNode)
+        builder.addNode(resourceNode)
+        builder.addNode(callSite)
+        builder.addEdge(ResourceEdge(resourceFileNode.id, resourceNode.id, ResourceRelation.CONTAINS))
+        builder.addEdge(ResourceEdge(resourceNode.id, callSite.id, ResourceRelation.LOOKUP))
+
+        val graph = builder.build()
+        val dir = Files.createTempDirectory("webgraph-resource-value-test")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.load(dir)
+
+            val loadedFile = loaded.node(resourceFileNode.id) as ResourceFileNode
+            val loadedNode = loaded.node(resourceNode.id) as ResourceValueNode
+            assertEquals(resourceFileNode, loadedFile)
+            assertEquals(resourceNode, loadedNode)
+            assertTrue(loaded.incoming(resourceNode.id, ResourceEdge::class.java).any {
+                it.from == resourceFileNode.id && it.kind == ResourceRelation.CONTAINS
+            })
+            assertTrue(loaded.incoming(callSite.id, ResourceEdge::class.java).any {
+                it.from == resourceNode.id && it.kind == ResourceRelation.LOOKUP
+            })
         } finally {
             dir.toFile().deleteRecursively()
         }
@@ -469,26 +505,26 @@ class GraphStoreTest {
             GraphStore.save(graph, dir)
             val loaded = GraphStore.load(dir)
 
-            val intConstants = loaded.nodes<IntConstant>().toList()
+            val intConstants = loaded.nodes(IntConstant::class.java).toList()
             assertEquals(1, intConstants.size)
             assertEquals(42, intConstants[0].value)
 
-            val callSites = loaded.nodes<CallSiteNode>().toList()
+            val callSites = loaded.nodes(CallSiteNode::class.java).toList()
             assertEquals(1, callSites.size)
 
-            val fields = loaded.nodes<FieldNode>().toList()
+            val fields = loaded.nodes(FieldNode::class.java).toList()
             assertEquals(1, fields.size)
 
-            val params = loaded.nodes<ParameterNode>().toList()
+            val params = loaded.nodes(ParameterNode::class.java).toList()
             assertEquals(1, params.size)
 
-            val locals = loaded.nodes<LocalVariable>().toList()
+            val locals = loaded.nodes(LocalVariable::class.java).toList()
             assertEquals(1, locals.size)
 
-            val returns = loaded.nodes<ReturnNode>().toList()
+            val returns = loaded.nodes(ReturnNode::class.java).toList()
             assertEquals(1, returns.size)
 
-            val enums = loaded.nodes<EnumConstant>().toList()
+            val enums = loaded.nodes(EnumConstant::class.java).toList()
             assertEquals(1, enums.size)
         } finally {
             dir.toFile().deleteRecursively()
@@ -500,14 +536,18 @@ class GraphStoreTest {
     // ========================================================================
 
     @Test
-    fun `loaded graph resources returns EmptyResourceAccessor`() {
+    fun `loaded graph resources preserves persisted text resources`() {
         val graph = buildTestGraph()
         val dir = Files.createTempDirectory("webgraph-resources-test")
         try {
             GraphStore.save(graph, dir)
             val loaded = GraphStore.load(dir)
 
-            assertTrue(loaded.resources === EmptyResourceAccessor)
+            val entries = loaded.resources.list("**").toList()
+            assertEquals(1, entries.size)
+            assertEquals("application.properties", entries.single().path)
+            val content = loaded.resources.open("application.properties").bufferedReader().readText()
+            assertTrue(content.contains("feature.mode=shadow"))
         } finally {
             dir.toFile().deleteRecursively()
         }
@@ -620,7 +660,7 @@ class GraphStoreTest {
             val loaded = GraphStore.load(dir)
 
             // The local node has incoming DataFlowEdges (from param and constant)
-            val locals = loaded.nodes<LocalVariable>().toList()
+            val locals = loaded.nodes(LocalVariable::class.java).toList()
             assertEquals(1, locals.size)
             val localId = locals[0].id
 
@@ -746,6 +786,14 @@ class GraphStoreTest {
         val decoded = NodeSerializer.decodeEdge(encoded, from, to, comp)
         assertTrue(decoded is ControlFlowEdge)
         assertEquals(comp, (decoded as ControlFlowEdge).comparison)
+
+        for (relation in ResourceRelation.entries) {
+            val edge = ResourceEdge(from, to, relation)
+            val encodedResource = NodeSerializer.encodeEdge(edge)
+            val decodedResource = NodeSerializer.decodeEdge(encodedResource, from, to)
+            assertTrue(decodedResource is ResourceEdge)
+            assertEquals(relation, (decodedResource as ResourceEdge).kind)
+        }
     }
 
     @Test
@@ -1458,14 +1506,16 @@ class GraphStoreTest {
     }
 
     @Test
-    fun `lazy graph resources returns EmptyResourceAccessor`() {
+    fun `lazy graph resources preserves persisted text resources`() {
         val graph = buildTestGraph()
         val dir = Files.createTempDirectory("webgraph-lazy-resources-test")
         try {
             GraphStore.save(graph, dir)
             val loaded = GraphStore.loadLazy(dir)
             try {
-                assertTrue(loaded.resources === EmptyResourceAccessor)
+                assertEquals(1, loaded.resources.list("**").count())
+                val content = loaded.resources.open("application.properties").bufferedReader().readText()
+                assertTrue(content.contains("feature.enabled=true"))
             } finally {
                 (loaded as Closeable).close()
             }
@@ -1475,14 +1525,16 @@ class GraphStoreTest {
     }
 
     @Test
-    fun `mapped graph resources returns EmptyResourceAccessor`() {
+    fun `mapped graph resources preserves persisted text resources`() {
         val graph = buildTestGraph()
         val dir = Files.createTempDirectory("webgraph-mapped-resources-test")
         try {
             GraphStore.save(graph, dir)
             val loaded = GraphStore.loadMapped(dir)
             try {
-                assertTrue(loaded.resources === EmptyResourceAccessor)
+                assertEquals(1, loaded.resources.list("**").count())
+                val content = loaded.resources.open("application.properties").bufferedReader().readText()
+                assertTrue(content.contains("feature.mode=shadow"))
             } finally {
                 (loaded as Closeable).close()
             }
@@ -1609,7 +1661,10 @@ class GraphStoreTest {
         assertTrue(types.contains("com.example.Child"))
 
         // resources
-        assertTrue(loaded.resources === EmptyResourceAccessor)
+        val resourceEntries = loaded.resources.list("**").toList()
+        assertEquals(1, resourceEntries.size)
+        assertEquals("application.properties", resourceEntries.single().path)
+        assertTrue(loaded.resources.open("application.properties").bufferedReader().readText().contains("feature.mode=shadow"))
     }
 
     // ========================================================================
@@ -1704,13 +1759,13 @@ class GraphStoreTest {
     fun `readHeader with unknown version throws`() {
         val baos = ByteArrayOutputStream()
         val dos = DataOutputStream(baos)
-        dos.writeInt(NodeSerializer.MAGIC_METADATA or 0x03)
+        dos.writeInt(NodeSerializer.MAGIC_METADATA or 0x04)
         dos.flush()
         val dis = DataInputStream(ByteArrayInputStream(baos.toByteArray()))
         val error = assertFailsWith<IllegalArgumentException> {
             NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA)
         }
-        assertTrue(error.message!!.contains("Unsupported GraphStore format version 3"))
+        assertTrue(error.message!!.contains("Unsupported GraphStore format version 4"))
     }
 
     // ========================================================================
@@ -1824,15 +1879,15 @@ class GraphStoreTest {
                 (mapped as Closeable).close()
             }
 
-            val migratedDir = Files.createTempDirectory("legacy-v2-migrated")
+            val migratedDir = Files.createTempDirectory("legacy-v3-migrated")
             try {
                 GraphStore.save(loaded, migratedDir)
 
                 DataInputStream(migratedDir.resolve("graph.nodedata").toFile().inputStream()).use { dis ->
-                    assertEquals(2, NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA))
+                    assertEquals(NodeSerializer.FORMAT_VERSION, NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEDATA))
                 }
                 DataInputStream(migratedDir.resolve("graph.metadata").toFile().inputStream()).use { dis ->
-                    assertEquals(2, NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA))
+                    assertEquals(NodeSerializer.FORMAT_VERSION, NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_METADATA))
                 }
 
                 val migrated = GraphStore.load(migratedDir)
@@ -2035,7 +2090,20 @@ class GraphStoreTest {
     // ========================================================================
 
     private fun buildTestGraph(): Graph {
-        val builder = DefaultGraph.Builder()
+        val builder = DefaultGraph.Builder().setResources(
+            object : ResourceAccessor {
+                private val resources = mapOf(
+                    "application.properties" to "feature.mode=shadow\nfeature.enabled=true\n"
+                )
+
+                override fun list(pattern: String): Sequence<ResourceEntry> =
+                    resources.keys.asSequence().map { ResourceEntry(it, "test-fixture") }
+
+                override fun open(path: String) =
+                    resources[path]?.let { ByteArrayInputStream(it.toByteArray()) }
+                        ?: throw java.io.IOException("Resource not found: $path")
+            }
+        )
 
         val fooType = TypeDescriptor("com.example.Foo")
         val parentType = TypeDescriptor("com.example.Parent")


### PR DESCRIPTION
## Summary
- add path-level resource graphing with `ResourceFileNode`/`ResourceEdge` so Cypher can query resources without parsing file contents into the graph
- expose discoverable explorer specs via `/openapi.json` and `/swagger.json`, and make raw resource content available at `GET /api/resources/{path}`
- persist text resources so loaded graphs can still serve `/api/resources` and raw content reads
- tighten Android resource indexing by excluding `.class` entries and using `classesByName` lookups instead of repeated class scans
- remove unreleased legacy resource edge kinds and align tests/serializers with the path-level model
- restore strict CI coverage enforcement for every module and raise `sootup`/`webgraph` coverage above `98%`

## Validation
- `./gradlew :core:test :core:koverXmlReport`
- `./gradlew :cypher:test :cypher:koverXmlReport`
- `./gradlew :explore:test :explore:koverXmlReport`
- `./gradlew :query:test :query:koverXmlReport`
- `./gradlew :sootup:test --tests "io.johnsonlee.graphite.sootup.ResourceConfigLinkingTest" --tests "io.johnsonlee.graphite.sootup.SootUpAdapterInternalCoverageTest" --tests "io.johnsonlee.graphite.sootup.GraphiteContextTest" --tests "io.johnsonlee.graphite.sootup.ArchiveResourceAccessorTest" --tests "io.johnsonlee.graphite.sootup.JavaProjectLoaderTest"`
- `./gradlew :sootup:koverXmlReport`
- `./gradlew :webgraph:test --tests "io.johnsonlee.graphite.webgraph.GraphStoreTest"`
- `./gradlew :webgraph:koverXmlReport -x :webgraph:test`
- `./gradlew :webgraph:test --tests "io.johnsonlee.graphite.webgraph.ElasticsearchIntegrationTest"`
- `./gradlew :webgraph:test --tests "io.johnsonlee.graphite.webgraph.AndroidSdkIntegrationTest"`
- `./gradlew :webgraph:jmh -Pjmh.filter=GraphEndToEndBenchmark.android_build_save_load_query --rerun-tasks`

## Module Coverage

| Module | Line coverage |
|---|---:|
| `core` | `98.0309%` |
| `cypher` | `98.1704%` |
| `explore` | `99.1507%` |
| `query` | `100.0%` |
| `sootup` | `98.0485%` |
| `webgraph` | `98.2877%` |

## Android Benchmark vs PR #71

| Metric | PR #71 | Current branch | Delta vs PR #71 |
|---|---:|---:|---:|
| Android e2e JMH (best rerun) | `109071.761 ms/op` | `113146.848 ms/op` | `3.7% slower` |
| Android e2e JMH (latest rerun) | `109071.761 ms/op` | `138953.202 ms/op` | `27.4% slower` |

## Android Phase Breakdown vs PR #71

| Phase | PR #71 (ms) | Current branch (ms) | Delta vs PR #71 |
|---|---:|---:|---:|
| `build` | `93481` | `106480` | `13.9% slower` |
| `save` | `9978` | `13446` | `34.8% slower` |
| `load` | `2450` | `2468` | `0.7% slower` |
| `query` | `2040` | `2276` | `11.6% slower` |

## Why Current Is Still Slower Than PR #71

| Difference vs PR #71 | Why it costs time/memory | Evidence in this branch |
|---|---|---|
| resource path graphing is now part of the default build | PR #71 did not build resource graph nodes/edges for Android jars; this branch creates `ResourceFileNode`s and resource edges as part of `buildGraph()` | Android phase probe shows `resource_file_nodes=15557` |
| text resources are now persisted with the graph | PR #71 did not carry the extra persisted resource payload needed for `/api/resources` and `GET /api/resources/{path}` on loaded graphs | persisted `graph.resources=2377627` bytes in the Android probe output |
| resource-related lookups now run during build | even after fixing the `.class` indexing bug, this branch still does path-level resource indexing, bundle matching, and resource linkage that PR #71 simply never did | the extra cost is concentrated in `build` |
| save also carries extra persisted payload | this branch writes resource metadata/content in addition to the old graph files | `save` rises from `9978 ms` to `13446 ms`; `graph.resources` is new in this branch |

## Why Android Is A Special Case For Resources

The Android fixture here is `org.robolectric:android-all:14-robolectric-10818077`, which is not a typical application jar/war. It is a merged Android framework jar that contains both framework code and a large amount of framework resource/data payload.

| Entry type | Count | Share |
|---|---:|---:|
| total file entries | `63761` | `100%` |
| `.class` entries | `48226` | `75.6%` |
| non-`.class` entries | `15535` | `24.4%` |

Non-`.class` entries are dominated by Android framework assets rather than ordinary application config files:

| Non-class category | Count | Share of non-class |
|---|---:|---:|
| `res/*` | `7865` | `50.6%` |
| files under `android/*` | `5251` | `33.8%` |
| files under `com/*` | `2390` | `15.4%` |
| `.png` | `6243` | `40.2%` |
| `.res` | `3700` | `23.8%` |
| `.xml` | `1704` | `11.0%` |
| `.uau` | `1626` | `10.5%` |
| `assets/*` | `13` | `0.1%` |
| `META-INF/*` | `7` | `<0.1%` |

Representative examples from the jar:
- `res/anim-ldrtl/activity_open_enter.xml`
- `android/icu/impl/data/icudt72b/af.res`
- `android/app/Activity_compat_config.xml`
- `android/accounts/Account.uau`
- `assets/geoid_height_map/tile-1.pb`

## Android Memory Gate

| Check | Result |
|---|---|
| `3g` gate | `OutOfMemoryError` |
| `4g` gate | pass |

## Android GC Snapshot (`4g`)

| Metric | Value |
|---|---:|
| `young_gc_count` | `532` |
| `full_gc_count` | `4` |
| `concurrent_mark_cycles` | `24` |
| `total_pause_ms` | `3487.187` |
| `max_pause_ms` | `348.179` |
| `peak_heap_before_gc_mb` | `4093` |
| `peak_heap_after_gc_mb` | `4093` |

## Notes
- Elasticsearch integration assertions were updated to the current fixture shape. The resolved `org.elasticsearch:elasticsearch:8.17.0` jar now builds a graph with `860` nodes, not the older large-fixture counts that the stale test expected.
- local-only files intentionally excluded from this PR: `AGENTS.md`, `.kotlin/`, and `AndroidPhaseProbeTest`
