### PR TITLE
Support Cypher predicate functions in WHERE

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,20 @@
+# Conventions
+
+## Unit Tests
+
+- New or changed unit tests must verify the behavior that matters, not only that code executes.
+- Parser and adapter tests must assert the concrete AST shape: operator names, variable bindings, arguments, literals, and nested expressions.
+- Execution tests must assert meaningful result values, not only row counts, when the result content is part of the behavior.
+- After tightening or fixing one unit test, review adjacent tests added in the same change for the same assertion quality issue.
+
+## Verification and Benchmarks
+
+- After fixing or tightening unit tests for a performance-sensitive path, rerun the relevant module tests and lint gate.
+- Every PR body must include benchmark testing results.
+- Benchmark evidence in the PR body must include the benchmark command, environment summary, exact benchmark names, result table, and a comparison against `main`.
+- The PR body must include both method-level and end-to-end benchmark data.
+- Method-level benchmark data must come from the most relevant JMH class for the touched code. For Cypher query changes, include `CypherBenchmark`.
+- End-to-end benchmark data must include `GraphEndToEndBenchmark`, which covers `JAR -> build -> save -> mapped load -> Cypher query`.
+- If a change touches persisted graph loading or large-corpus query behavior, also include the relevant `GraphBenchmark` load/query benchmark class, such as `EsQueryBenchmark`, `AndroidQueryBenchmark`, `EsLoadBenchmark`, or `AndroidLoadBenchmark`.
+- The PR body must explicitly state whether the benchmark comparison indicates a performance regression, including separate conclusions for method-level and end-to-end results.
+- If benchmark results cannot be produced, state the blocker in the PR description rather than leaving performance unaddressed.

--- a/graphite-cypher/src/main/antlr/CypherParser.g4
+++ b/graphite-cypher/src/main/antlr/CypherParser.g4
@@ -263,6 +263,7 @@ atomExpression
     | caseExpression                                                       # CaseAtom
     | COUNT LPAREN MULT RPAREN                                             # CountStarAtom
     | listComprehension                                                    # ListComprehensionAtom
+    | predicateFunction                                                    # PredicateFunctionAtom
     | EXISTS LPAREN expression RPAREN                                      # ExistsAtom
     | functionInvocation                                                   # FunctionAtom
     | LPAREN expression RPAREN                                             # ParenAtom
@@ -293,6 +294,10 @@ caseElse
 
 listComprehension
     : LBRACK variable IN expression (WHERE expression)? (STICK expression)? RBRACK
+    ;
+
+predicateFunction
+    : (ANY | ALL | NONE | SINGLE) LPAREN variable IN expression (WHERE expression)? RPAREN
     ;
 
 parameter

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherDslAdapter.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherDslAdapter.kt
@@ -650,6 +650,7 @@ private class CypherAstVisitor {
             is CypherParser.CaseAtomContext -> visitCaseExpr(ctx.caseExpression())
             is CypherParser.CountStarAtomContext -> CypherExpr.CountStar
             is CypherParser.ListComprehensionAtomContext -> visitListComprehensionExpr(ctx.listComprehension())
+            is CypherParser.PredicateFunctionAtomContext -> visitPredicateFunctionExpr(ctx.predicateFunction())
             is CypherParser.ExistsAtomContext -> {
                 val expr = visitExpr(ctx.expression())
                 CypherExpr.FunctionCall("exists", listOf(expr))
@@ -699,6 +700,20 @@ private class CypherAstVisitor {
         val distinct = ctx.DISTINCT() != null
         val args = ctx.expressionList()?.expression()?.map { visitExpr(it) } ?: emptyList()
         return CypherExpr.FunctionCall(name, args, distinct)
+    }
+
+    private fun visitPredicateFunctionExpr(ctx: CypherParser.PredicateFunctionContext): CypherExpr {
+        val name = when {
+            ctx.ANY() != null -> "any"
+            ctx.ALL() != null -> "all"
+            ctx.NONE() != null -> "none"
+            ctx.SINGLE() != null -> "single"
+            else -> throw CypherParseException("Unknown predicate function")
+        }
+        val expressions = ctx.expression()
+        val listExpr = visitExpr(expressions[0])
+        val predicate = expressions.getOrNull(1)?.let { visitExpr(it) }
+        return CypherExpr.PredicateFunction(name, getSymbolicName(ctx.variable()), listExpr, predicate)
     }
 
     private fun visitCaseExpr(ctx: CypherParser.CaseExpressionContext): CypherExpr {

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/ExpressionEvaluator.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/ExpressionEvaluator.kt
@@ -8,6 +8,12 @@ import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.ResourceEdge
 import io.johnsonlee.graphite.core.TypeEdge
 
+private const val PREDICATE_ANY = "any"
+private const val PREDICATE_ALL = "all"
+private const val PREDICATE_NONE = "none"
+private const val PREDICATE_SINGLE = "single"
+private const val UNKNOWN_PREDICATE_FUNCTION = "Unknown predicate function"
+
 /**
  * Evaluates Cypher expressions against a variable binding context.
  * Supports all openCypher expression types: arithmetic, boolean, comparison,
@@ -45,6 +51,9 @@ class ExpressionEvaluator {
         is CypherExpr.ListLiteral -> expr.elements.map { evaluate(it, bindings) }
         is CypherExpr.MapLiteral -> expr.entries.mapValues { evaluate(it.value, bindings) }
         is CypherExpr.ListComprehension -> evaluateListComprehension(expr, bindings)
+        is CypherExpr.PredicateFunction -> evaluatePredicateFunction(expr, bindings) { expression, row ->
+            evaluate(expression, row)
+        }
         is CypherExpr.Subscript -> evaluateSubscript(expr, bindings)
         is CypherExpr.Slice -> evaluateSlice(expr, bindings)
         is CypherExpr.Not -> {
@@ -351,6 +360,54 @@ class ExpressionEvaluator {
     }
 }
 
+private fun evaluatePredicateFunction(
+    expr: CypherExpr.PredicateFunction,
+    bindings: Map<String, Any?>,
+    evaluate: (CypherExpr, Map<String, Any?>) -> Any?
+): Any? {
+    val list = evaluate(expr.listExpr, bindings) as? List<*> ?: return null
+    val results = list.map { element ->
+        val innerBindings = bindings + (expr.variable to element)
+        val value = expr.predicate?.let { evaluate(it, innerBindings) } ?: element
+        value as? Boolean
+    }
+    return evaluatePredicateResults(expr.name, results)
+}
+
+private fun evaluatePredicateResults(name: String, results: List<Boolean?>): Any? {
+    return when (name.lowercase()) {
+        PREDICATE_ANY -> evaluateAnyPredicate(results)
+        PREDICATE_ALL -> evaluateAllPredicate(results)
+        PREDICATE_NONE -> evaluateNonePredicate(results)
+        PREDICATE_SINGLE -> evaluateSinglePredicate(results)
+        else -> throw CypherException("$UNKNOWN_PREDICATE_FUNCTION: $name")
+    }
+}
+
+private fun evaluateAnyPredicate(results: List<Boolean?>): Boolean? = when {
+    results.any { it == true } -> true
+    results.any { it == null } -> null
+    else -> false
+}
+
+private fun evaluateAllPredicate(results: List<Boolean?>): Boolean? = when {
+    results.any { it == false } -> false
+    results.any { it == null } -> null
+    else -> true
+}
+
+private fun evaluateNonePredicate(results: List<Boolean?>): Boolean? = when {
+    results.any { it == true } -> false
+    results.any { it == null } -> null
+    else -> true
+}
+
+private fun evaluateSinglePredicate(results: List<Boolean?>): Boolean? = when {
+    results.count { it == true } > 1 -> false
+    results.any { it == null } -> null
+    else -> results.count { it == true } == 1
+}
+
 /**
  * AST for Cypher expressions.
  * Produced by the ANTLR-based Cypher parser adapter.
@@ -389,6 +446,12 @@ sealed class CypherExpr {
         val listExpr: CypherExpr,
         val predicate: CypherExpr?,
         val mapExpr: CypherExpr?
+    ) : CypherExpr()
+    data class PredicateFunction(
+        val name: String,
+        val variable: String,
+        val listExpr: CypherExpr,
+        val predicate: CypherExpr?
     ) : CypherExpr()
     data class Subscript(val expression: CypherExpr, val index: CypherExpr) : CypherExpr()
     data class Slice(val expression: CypherExpr, val from: CypherExpr?, val to: CypherExpr?) : CypherExpr()
@@ -444,6 +507,11 @@ fun CypherExpr.toCypherString(): String = when (this) {
         if (predicate != null) append(" WHERE ${predicate.toCypherString()}")
         if (mapExpr != null) append(" | ${mapExpr.toCypherString()}")
         append("]")
+    }
+    is CypherExpr.PredicateFunction -> buildString {
+        append("${name.lowercase()}($variable IN ${listExpr.toCypherString()}")
+        if (predicate != null) append(" WHERE ${predicate.toCypherString()}")
+        append(")")
     }
     is CypherExpr.Subscript -> "${expression.toCypherString()}[${index.toCypherString()}]"
     is CypherExpr.Slice -> buildString {

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -572,6 +572,8 @@ class QueryPipeline(private val graph: Graph) {
             CypherFunctions.isAggregation(expr.name) || expr.args.any { containsAggregation(it) }
         is CypherExpr.CountStar -> true
         is CypherExpr.Property -> containsAggregation(expr.expression)
+        is CypherExpr.PredicateFunction -> containsAggregation(expr.listExpr) ||
+            expr.predicate?.let { containsAggregation(it) } == true
         is CypherExpr.BinaryOp -> containsAggregation(expr.left) || containsAggregation(expr.right)
         is CypherExpr.Comparison -> containsAggregation(expr.left) || containsAggregation(expr.right)
         is CypherExpr.Distinct -> containsAggregation(expr.expression)

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherCompatibilityTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherCompatibilityTest.kt
@@ -331,6 +331,15 @@ class CypherCompatibilityTest {
     }
 
     @Test
+    fun `WHERE - untyped node equality with double quoted string`() {
+        val result = executor.execute(
+            "MATCH (n) WHERE n.callee_class = \"com.example.Repository\" RETURN n.callee_name"
+        )
+        assertEquals(1, result.rows.size)
+        assertEquals("save", result.rows[0]["n.callee_name"])
+    }
+
+    @Test
     fun `WHERE - inequality`() {
         val result = executor.execute("MATCH (n:IntConstant) WHERE n.value <> 42 RETURN n.value")
         assertEquals(1, result.rows.size)
@@ -396,6 +405,51 @@ class CypherCompatibilityTest {
             "MATCH (n:CallSiteNode) WHERE n.callee_class CONTAINS 'example' RETURN n.callee_name"
         )
         assertEquals(2, result.rows.size)
+    }
+
+    @Test
+    fun `WHERE - labels function with IN`() {
+        val result = executor.execute(
+            "MATCH (n) WHERE 'CallSiteNode' IN labels(n) RETURN n.callee_name"
+        )
+        assertEquals(2, result.rows.size)
+        assertEquals(setOf("save", "log"), result.rows.map { it["n.callee_name"] }.toSet())
+    }
+
+    @Test
+    fun `WHERE - ANY over labels function`() {
+        val result = executor.execute(
+            "MATCH (n) WHERE ANY(label IN labels(n) WHERE label = 'CallSiteNode') RETURN n.callee_name"
+        )
+        assertEquals(2, result.rows.size)
+        assertEquals(setOf("save", "log"), result.rows.map { it["n.callee_name"] }.toSet())
+    }
+
+    @Test
+    fun `RETURN - ANY over labels function projects boolean values`() {
+        val result = executor.execute(
+            "MATCH (n:CallSiteNode) RETURN ANY(label IN labels(n) WHERE label = 'CallSiteNode') AS isCallSite"
+        )
+        assertEquals(2, result.rows.size)
+        assertEquals(setOf(true), result.rows.map { it["isCallSite"] }.toSet())
+    }
+
+    @Test
+    fun `WHERE - ALL over labels function`() {
+        val result = executor.execute(
+            "MATCH (n:IntConstant) WHERE ALL(label IN labels(n) WHERE label CONTAINS 'Constant') RETURN n.value"
+        )
+        assertEquals(2, result.rows.size)
+        assertEquals(setOf(42, 7), result.rows.map { it["n.value"] }.toSet())
+    }
+
+    @Test
+    fun `WITH - inline WHERE filters projected rows`() {
+        val result = executor.execute(
+            "MATCH (n:CallSiteNode) WITH n WHERE n.callee_class CONTAINS 'Repository' RETURN n.callee_name"
+        )
+        assertEquals(1, result.rows.size)
+        assertEquals("save", result.rows[0]["n.callee_name"])
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherDslAdapterTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherDslAdapterTest.kt
@@ -595,6 +595,48 @@ class CypherDslAdapterTest {
     }
 
     @Test
+    fun `predicate function ANY`() {
+        val clauses = CypherDslAdapter.parse(
+            "MATCH (n) WHERE ANY(label IN labels(n) WHERE label = 'CallSiteNode') RETURN n"
+        )
+        val predicate = assertIs<CypherExpr.PredicateFunction>(
+            assertIs<CypherClause.Where>(clauses[1]).condition
+        )
+
+        assertEquals("any", predicate.name)
+        assertEquals("label", predicate.variable)
+        val labelsCall = assertIs<CypherExpr.FunctionCall>(predicate.listExpr)
+        assertEquals("labels", labelsCall.name)
+        assertEquals(listOf(CypherExpr.Variable("n")), labelsCall.args)
+
+        val condition = assertIs<CypherExpr.Comparison>(predicate.predicate)
+        assertEquals("=", condition.op)
+        assertEquals(CypherExpr.Variable("label"), condition.left)
+        assertEquals(CypherExpr.Literal("CallSiteNode"), condition.right)
+    }
+
+    @Test
+    fun `predicate function ALL`() {
+        val clauses = CypherDslAdapter.parse(
+            "MATCH (n) WHERE ALL(label IN labels(n) WHERE label CONTAINS 'Constant') RETURN n"
+        )
+        val predicate = assertIs<CypherExpr.PredicateFunction>(
+            assertIs<CypherClause.Where>(clauses[1]).condition
+        )
+
+        assertEquals("all", predicate.name)
+        assertEquals("label", predicate.variable)
+        val labelsCall = assertIs<CypherExpr.FunctionCall>(predicate.listExpr)
+        assertEquals("labels", labelsCall.name)
+        assertEquals(listOf(CypherExpr.Variable("n")), labelsCall.args)
+
+        val condition = assertIs<CypherExpr.StringOp>(predicate.predicate)
+        assertEquals("CONTAINS", condition.op)
+        assertEquals(CypherExpr.Variable("label"), condition.left)
+        assertEquals(CypherExpr.Literal("Constant"), condition.right)
+    }
+
+    @Test
     fun `60 - CountStar`() {
         val clauses = CypherDslAdapter.parse("RETURN count(*)")
         assertIs<CypherExpr.CountStar>(assertIs<CypherClause.Return>(clauses[0]).items[0].expression)

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/ExpressionEvaluatorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/ExpressionEvaluatorTest.kt
@@ -532,6 +532,45 @@ class ExpressionEvaluatorTest {
         assertNull(eval(expr))
     }
 
+    @Test
+    fun `predicate function ANY`() {
+        val listExpr = CypherExpr.ListLiteral(listOf(lit("A"), lit("B")))
+        val matching = CypherExpr.Comparison("=", variable("x"), lit("B"))
+        val missing = CypherExpr.Comparison("=", variable("x"), lit("C"))
+
+        assertEquals(true, eval(CypherExpr.PredicateFunction("any", "x", listExpr, matching)))
+        assertEquals(false, eval(CypherExpr.PredicateFunction("any", "x", listExpr, missing)))
+    }
+
+    @Test
+    fun `predicate function ALL`() {
+        val listExpr = CypherExpr.ListLiteral(listOf(lit("AX"), lit("BX")))
+        val matching = CypherExpr.StringOp("CONTAINS", variable("x"), lit("X"))
+        val partial = CypherExpr.StringOp("CONTAINS", variable("x"), lit("A"))
+
+        assertEquals(true, eval(CypherExpr.PredicateFunction("all", "x", listExpr, matching)))
+        assertEquals(false, eval(CypherExpr.PredicateFunction("all", "x", listExpr, partial)))
+    }
+
+    @Test
+    fun `predicate function NONE and SINGLE`() {
+        val listExpr = CypherExpr.ListLiteral(listOf(lit("A"), lit("B")))
+        val isA = CypherExpr.Comparison("=", variable("x"), lit("A"))
+        val isC = CypherExpr.Comparison("=", variable("x"), lit("C"))
+
+        assertEquals(true, eval(CypherExpr.PredicateFunction("none", "x", listExpr, isC)))
+        assertEquals(false, eval(CypherExpr.PredicateFunction("none", "x", listExpr, isA)))
+        assertEquals(true, eval(CypherExpr.PredicateFunction("single", "x", listExpr, isA)))
+        assertEquals(false, eval(CypherExpr.PredicateFunction("single", "x", listExpr, CypherExpr.Literal(true))))
+    }
+
+    @Test
+    fun `predicate function on null list returns null`() {
+        val expr = CypherExpr.PredicateFunction("any", "x", lit(null), CypherExpr.Literal(true))
+
+        assertNull(eval(expr))
+    }
+
     // ========================================================================
     // 18. Subscript
     // ========================================================================
@@ -1087,6 +1126,17 @@ class ExpressionEvaluatorTest {
     fun `toCypherString - ListComprehension without filter or map`() {
         val expr = CypherExpr.ListComprehension("x", CypherExpr.Variable("list"), null, null)
         assertEquals("[x IN list]", expr.toCypherString())
+    }
+
+    @Test
+    fun `toCypherString - PredicateFunction`() {
+        val expr = CypherExpr.PredicateFunction(
+            "any",
+            "x",
+            CypherExpr.Variable("list"),
+            CypherExpr.Comparison("=", CypherExpr.Variable("x"), CypherExpr.Literal("A"))
+        )
+        assertEquals("any(x IN list WHERE x = 'A')", expr.toCypherString())
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR fills the remaining unsupported Cypher WHERE cases around predicate functions and labels-based filtering.

- Adds grammar and AST adapter support for `ANY`, `ALL`, `NONE`, and `SINGLE` predicate functions.
- Evaluates predicate functions over list expressions, including `labels(n)` results.
- Keeps existing support for `WHERE`, `CONTAINS`, `STARTS WITH`, and `=~` covered with regression tests, including untyped `MATCH (n)` filtering by `callee_class`.
- Adds `CONVENTIONS.md` guidance requiring precise UT assertions and requiring every PR body to include concrete benchmark testing results, including method-level and end-to-end benchmarks, `main` comparison, and explicit regression assessment.

## Validation

- `./gradlew :cypher:test :cypher:detekt :query:test --tests "io.johnsonlee.graphite.cli.QueryCommandTest"`
- `./gradlew :cypher:clean :cypher:test :cypher:koverLog --no-daemon --no-build-cache` (`cypher` line coverage: 98.0033%)
- `git diff --check`
- Method-level benchmark: `./gradlew :cypher:jmh` on GitHub `main` (`1533711`) and PR production code (`099ba45`; current head `3a4d7c6` only adds cypher coverage tests) in the same local benchmark clone.
- End-to-end benchmark: `GraphEndToEndBenchmark` via `java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar '.*GraphEndToEndBenchmark.*'` on GitHub `main` (`1533711`) and PR production code (`099ba45`; current head `3a4d7c6` only adds cypher coverage tests) in the same local benchmark clone.

## Method-Level Benchmark Result

Benchmark class: `CypherBenchmark`. Environment: JMH 1.37, JDK 17.0.18, 1 fork, 3 warmup iterations, 5 measurement iterations, average time in microseconds/op. Lower is better.

| Benchmark | main `1533711` | PR production code `099ba45` | Delta |
| --- | ---: | ---: | ---: |
| `CypherBenchmark.aggregationCountGroupBy` | 34.362 | 32.932 | -4.16% |
| `CypherBenchmark.countStar` | 25.855 | 26.195 | +1.32% |
| `CypherBenchmark.functionCalls` | 23.212 | 22.822 | -1.68% |
| `CypherBenchmark.nodeMatchWithWhere` | 52.815 | 52.234 | -1.10% |
| `CypherBenchmark.regexFilter` | 61.130 | 60.384 | -1.22% |
| `CypherBenchmark.returnDistinct` | 82.448 | 81.988 | -0.56% |
| `CypherBenchmark.simpleNodeMatch` | 17.075 | 17.459 | +2.25% |
| `CypherBenchmark.singleHopRelationship` | 31.667 | 30.970 | -2.20% |
| `CypherBenchmark.variableLengthPath` | 25.520 | 26.469 | +3.72% |
| `CypherBenchmark.withPipeline` | 74.416 | 74.500 | +0.11% |

Method-level regression assessment: no performance regression is indicated for the touched WHERE/regex filtering paths. `nodeMatchWithWhere` improved by 1.10%, and `regexFilter` improved by 1.22%. The full method-level suite shows small mixed movement in unrelated benchmarks, with the largest observed slowdown at +3.72% for `variableLengthPath` in this single-fork JMH run.

## End-To-End Benchmark Result

Benchmark class: `GraphEndToEndBenchmark`. This covers `JAR -> build -> save -> mapped load -> Cypher query`. Environment: JMH 1.37, JDK 17.0.18, 1 fork, no warmup, 1 single-shot measurement, milliseconds/op. Lower is better.

| Benchmark | main `1533711` | PR production code `099ba45` | Delta |
| --- | ---: | ---: | ---: |
| `GraphEndToEndBenchmark.android_build_save_load_query` | 112569.101 | 111589.052 | -0.87% |
| `GraphEndToEndBenchmark.elasticsearch_build_save_load_query` | 19291.304 | 19693.467 | +2.08% |
| `GraphEndToEndBenchmark.elasticsearch_build_save_load_query` repeat | 19157.037 | 19124.367 | -0.17% |

End-to-end regression assessment: no performance regression is indicated. Android e2e improved by 0.87%. The first Elasticsearch e2e single-shot run showed PR +2.08%, so Elasticsearch was repeated; the repeat showed PR -0.17% versus `main`, consistent with single-shot noise rather than a regression.