### PR TITLE
docs: update examples for 1.2.0-beta.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:graphite-core:1.1.0")
-    implementation("io.johnsonlee.graphite:graphite-sootup:1.1.0")
+    implementation("io.johnsonlee.graphite:graphite-core:1.2.0-beta.1")
+    implementation("io.johnsonlee.graphite:graphite-sootup:1.2.0-beta.1")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:core:1.1.0")
-    implementation("io.johnsonlee.graphite:sootup:1.1.0")
+    implementation("io.johnsonlee.graphite:core:1.2.0-beta.1")
+    implementation("io.johnsonlee.graphite:sootup:1.2.0-beta.1")
     // Optional: Cypher query support (graph.query("MATCH ..."))
-    implementation("io.johnsonlee.graphite:cypher:1.1.0")
+    implementation("io.johnsonlee.graphite:cypher:1.2.0-beta.1")
     // Optional: disk persistence (WebGraph format)
-    implementation("io.johnsonlee.graphite:webgraph:1.1.0")
+    implementation("io.johnsonlee.graphite:webgraph:1.2.0-beta.1")
 }
 ```
 


### PR DESCRIPTION
## Summary

- Updates README dependency examples to `1.2.0-beta.1` after publishing the beta tag.
- Updates the CLAUDE.md published-artifact dependency example to `1.2.0-beta.1`.

## Validation

- `git diff --check`

## Benchmark Testing Result

This is a docs-only version-reference update. No production code, tests, benchmark code, build logic, or runtime behavior changed.

| Benchmark scope | Result |
| --- | --- |
| Method-level benchmark | Not run; no benchmarkable code delta in this docs-only PR. |
| End-to-end benchmark | Not run; no runtime or graph loading/query behavior changed in this docs-only PR. |

Regression assessment: no performance regression is indicated because the PR only changes documentation text. The release tag `v1.2.0-beta.1` was already published from `c8d449c` and its Publish workflow completed successfully across Maven, GitHub Release/Homebrew, npm, and Docker.