### PR TITLE
docs: update examples for 1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Specify the version via command line property:
 ./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.1.1-alpha.1
 
 # Publish release version
-./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.1.0
+./gradlew clean publishAllPublicationsToGitHubPackagesRepository -Pversion=1.2.0
 ```
 
 ### Automated Publishing (GitHub Actions)
@@ -137,8 +137,8 @@ Publishing is triggered by creating a git tag. GitHub Actions automatically deri
 
 ```bash
 # Create and push a tag to trigger release
-git tag v1.1.0
-git push origin v1.1.0
+git tag v1.2.0
+git push origin v1.2.0
 ```
 
 ### Using Published Artifacts
@@ -157,8 +157,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:graphite-core:1.2.0-beta.1")
-    implementation("io.johnsonlee.graphite:graphite-sootup:1.2.0-beta.1")
+    implementation("io.johnsonlee.graphite:graphite-core:1.2.0")
+    implementation("io.johnsonlee.graphite:graphite-sootup:1.2.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.johnsonlee.graphite:core:1.2.0-beta.1")
-    implementation("io.johnsonlee.graphite:sootup:1.2.0-beta.1")
+    implementation("io.johnsonlee.graphite:core:1.2.0")
+    implementation("io.johnsonlee.graphite:sootup:1.2.0")
     // Optional: Cypher query support (graph.query("MATCH ..."))
-    implementation("io.johnsonlee.graphite:cypher:1.2.0-beta.1")
+    implementation("io.johnsonlee.graphite:cypher:1.2.0")
     // Optional: disk persistence (WebGraph format)
-    implementation("io.johnsonlee.graphite:webgraph:1.2.0-beta.1")
+    implementation("io.johnsonlee.graphite:webgraph:1.2.0")
 }
 ```
 


### PR DESCRIPTION
## Summary

- Updates README dependency examples from `1.2.0-beta.1` to `1.2.0`.
- Updates CLAUDE.md release and published-artifact examples to `1.2.0`.

## Validation

- `git diff --check`

## Benchmark Testing Result

This is a docs-only version-reference update. No production code, tests, benchmark code, build logic, or runtime behavior changed.

| Benchmark scope | Result |
| --- | --- |
| Method-level benchmark | Not run; no benchmarkable code delta in this docs-only PR. |
| End-to-end benchmark | Not run; no runtime or graph loading/query behavior changed in this docs-only PR. |

Regression assessment: no performance regression is indicated because the PR only changes documentation text. After this PR merges, `v1.2.0` will be tagged from the merged `main` commit and published via GitHub Actions.