### PR TITLE
Optimize mapped graph load and bounded queries

### DIFF
--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -490,3 +490,44 @@ The fast path scans candidate nodes, evaluates node constraints and `WHERE`, pro
 **Conclusion:** effective but not enough for the load-side order-of-magnitude goal. It removes measurable node-index parsing overhead and reduces boxed integer allocation, but the remaining mapped-load path is still dominated by other eager structures.
 
 **Root cause:** node-index parsing is a real cost, but not the dominant remaining load cost after lazy backward adjacency. `loadMapped` still eagerly loads forward BVGraph adjacency, edge labels, cumulative outdegree, comparison metadata, graph metadata, resources, string table, and node offsets before a graph is considered open. For node-only touch/query paths, much of that work is still paid upfront.
+
+### 2026-07-18 — Attempt 008: Lazy edge, metadata, and resource loading
+
+**Hypothesis:** `loadMapped` should not eagerly load edge traversal structures or metadata when a graph is opened for node-only queries. The Android load benchmark only touches one node, so eager forward BVGraph load, edge labels, cumulative outdegree, comparison metadata, graph metadata, and resources are all upfront work that can be deferred without changing build/save.
+
+**Change:** make `loadLazy` and `loadMapped` pass lazy handles for:
+
+```
+forward BVGraph
+backward transpose
+edge labels
+cumulative outdegree
+comparison map
+graph metadata
+persisted resources
+```
+
+Node offset/type indexes and the string table still load at graph open because node lookup and node deserialization need them. Edge traversal and metadata APIs pay their load cost on first use.
+
+**Build/save impact:** none. Persisted files and the save path are unchanged.
+
+**Validation commands:**
+
+```
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidQueryBenchmark.mapped_singleHopRelationship'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 008 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidLoadBenchmark.mapped_load` | `1284.409 ms/op` | `176.097 ms/op` | `-1108.312 ms` / `~7.3x faster` |
+| `AndroidQueryBenchmark.mapped_singleHopRelationship` | `0.658 ms/op` | `0.667 ms/op` | roughly unchanged after JMH warmup |
+
+Compared with the original Android mapped-load baseline (`2292.892 ms/op`), `176.097 ms/op` is `~13.0x faster`.
+
+**Conclusion:** effective for the load-side order-of-magnitude goal when measured against the original Android-scale mapped-load baseline. It also materially reduces open-time heap for multi-graph serving because edge labels and BVGraph structures are no longer resident until an edge query needs them.
+
+**Root cause:** after lazy backward adjacency and primitive node-index loading, the dominant remaining mapped-load costs were unrelated to opening a node-readable graph: forward BVGraph, edge labels, cumulative outdegree, comparisons, metadata, and resources. Deferring those structures moves their cost to the APIs that actually need them, while node-only load/query paths avoid the work entirely.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -570,3 +570,65 @@ This is a verification summary of the current mapped Android-scale state after A
 **Build/save impact:** no optimization in Attempts 001-008 changes the graph save format or adds build-time indexes. The load-side wins come from deferring runtime structures; the query-side wins come from execution control flow and existing type indexes.
 
 **Operational note for multi-graph serving:** opening many mapped graphs now keeps edge structures, metadata, and resources unloaded until first use. The first edge or metadata query for a graph pays that lazy initialization cost once; services that need predictable first-edge latency can explicitly prewarm edge APIs for selected graphs, while node-only query workloads avoid the cost entirely.
+
+### 2026-07-18 — Attempt 009: SootUp Android build JMH harness repair
+
+**Goal:** verify that the load/query work did not compromise the build side. The relevant Android-scale build benchmark is `GraphBuildBenchmark.buildAndroidSdkGraph`, but the `:sootup:jmh` harness had to produce a real JMH score before it could be used as evidence.
+
+**Initial failure:**
+
+```
+./gradlew :sootup:jmh -Pjmh.filter='GraphBuildBenchmark.buildAndroidSdkGraph' --rerun-tasks
+```
+
+The Gradle task reported `BUILD SUCCESSFUL`, but JMH produced no benchmark score. The fork failed immediately with:
+
+```
+java.lang.NoSuchMethodError: 'int org.objectweb.asm.Type.getArgumentCount(java.lang.String)'
+    at org.objectweb.asm.tree.MethodNode.visitParameterAnnotation(MethodNode.java:304)
+```
+
+**Control check:** running the generated JMH fat jar directly with an explicit Android fixture path completed successfully:
+
+```
+java -Dandroid.jar.path=<android-all.jar> \
+  -jar graphite-sootup/build/libs/sootup-1.0.0-SNAPSHOT-jmh.jar \
+  '.*GraphBuildBenchmark.buildAndroidSdkGraph.*' -wi 0 -i 1 -f 1 -r 1s -w 1s
+```
+
+Result: `100524.865 ms/op`.
+
+**Root cause:** the `sootup` JMH Gradle harness was weaker than the already-repaired `webgraph` harness. It relied on fallback fixture discovery, did not pass exact `android-all` / Elasticsearch fixture paths into the forked JVM, did not explicitly force a consistent ASM family on all JMH configurations, and did not fail the Gradle task when JMH failed internally.
+
+**Accepted fix:** align `graphite-sootup/build.gradle.kts` with `graphite-webgraph/build.gradle.kts`:
+
+- keep large fixture jars out of the JMH fat jar
+- pass fixture paths as `-Dandroid.jar.path` / `-Delasticsearch.jar.path`
+- force `asm`, `asm-tree`, `asm-util`, `asm-commons`, and `asm-analysis` to the configured ASM version
+- set `failOnError = true` so failed JMH forks fail the Gradle task instead of creating false-success builds
+
+**Validation command:**
+
+```
+./gradlew :sootup:jmh -Pjmh.filter='GraphBuildBenchmark.buildAndroidSdkGraph' --rerun-tasks
+```
+
+**Result:**
+
+| Benchmark | Mode | Count | Score | Units |
+|-----------|------|-------|-------|-------|
+| `GraphBuildBenchmark.buildAndroidSdkGraph` | ss | 1 | `101647.075` | ms/op |
+
+**End-to-end guardrail:**
+
+```
+./gradlew :webgraph:jmh -Pjmh.filter='GraphEndToEndBenchmark.android_build_save_load_query' --rerun-tasks
+```
+
+| Benchmark | Mode | Count | Score | Units |
+|-----------|------|-------|-------|-------|
+| `GraphEndToEndBenchmark.android_build_save_load_query` | ss | 1 | `115782.725` | ms/op |
+
+This covers `build -> save -> loadMapped -> query` with `-Xmx4g`.
+
+**Conclusion:** effective as a benchmark harness repair. It proves the current Android build benchmark remains runnable after the load/query changes, and the Gradle-run result is in the same range as the direct JMH control run. The end-to-end guardrail also passes under the 4 GB heap constraint. This attempt does not change product build, save, load, or query behavior.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -401,3 +401,35 @@ Like the count fast path, it is limited to 0/1-label node patterns so multi-labe
 **Conclusion:** effective for the targeted distinct-property query. It is not a general replacement for property indexes, but it removes a common unnecessary full scan when `LIMIT` is present and no ordering constraints exist.
 
 **Root cause:** `DISTINCT` disabled early limit pushdown, so the old pipeline materialized every `CallSiteNode`, projected `callee_class`, deduplicated the full list, and then applied `LIMIT 20`. For unordered distinct queries, scanning after the first 20 distinct values is unnecessary.
+
+### 2026-07-18 — Attempt 005: Stream simple single-hop relationship `LIMIT`
+
+**Hypothesis:** `MATCH (a)-[:TYPE]->(b) RETURN ... LIMIT k` should not expand and materialize a complete relationship result list for each source node before applying `LIMIT`. On Android-scale graphs, high-fanout source nodes can make a small `LIMIT` query pay for far more edge decoding than necessary.
+
+**Change:** add a narrow `QueryPipeline` fast path for one non-optional, non-variable-length relationship pattern followed by a non-aggregate, non-`DISTINCT` `RETURN` and `LIMIT`:
+
+```
+MATCH (a:Source)-[:TYPE]->(b:Target) RETURN a.property, b.property LIMIT k
+```
+
+The fast path streams source nodes, edges, target checks, and return projection in query order, then stops as soon as `k` complete rows are produced. Queries with `WHERE`, `ORDER BY`, `SKIP`, `WITH`, variable-length relationships, path variables, aggregation, or `DISTINCT` still use the normal pipeline.
+
+**Build/save impact:** none. This is query execution control flow only; it does not add indexes, persisted fields, or build-time work.
+
+**Validation commands:**
+
+```
+./gradlew :cypher:test
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidQueryBenchmark.mapped_singleHopRelationship'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 005 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidQueryBenchmark.mapped_singleHopRelationship` | `75.802 ms/op` | `0.658 ms/op` | `-75.144 ms` / `~115.2x faster` |
+
+**Conclusion:** effective for the targeted single-hop relationship query and crosses the required order-of-magnitude threshold for this benchmark shape.
+
+**Root cause:** the generic early-limit path only checked the limit after `matchRelationship` had expanded a source node into a full intermediate list. If one source has many outgoing `DATAFLOW` edges, the engine still decodes and materializes all of those relationship matches before keeping the first 20 rows. It also risked treating `LIMIT` as a cap on source nodes rather than complete relationship matches. Streaming complete rows and stopping inside the edge loop removes both costs.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -531,3 +531,42 @@ Compared with the original Android mapped-load baseline (`2292.892 ms/op`), `176
 **Conclusion:** effective for the load-side order-of-magnitude goal when measured against the original Android-scale mapped-load baseline. It also materially reduces open-time heap for multi-graph serving because edge labels and BVGraph structures are no longer resident until an edge query needs them.
 
 **Root cause:** after lazy backward adjacency and primitive node-index loading, the dominant remaining mapped-load costs were unrelated to opening a node-readable graph: forward BVGraph, edge labels, cumulative outdegree, comparisons, metadata, and resources. Deferring those structures moves their cost to the APIs that actually need them, while node-only load/query paths avoid the work entirely.
+
+### 2026-07-18 — Current Android mapped benchmark sweep
+
+This is a verification summary of the current mapped Android-scale state after Attempts 001-008. It is not a separate optimization attempt.
+
+**Validation commands:**
+
+```
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidQueryBenchmark.mapped_.*'
+```
+
+**Current results:**
+
+| Benchmark | Current score |
+|-----------|---------------|
+| `AndroidLoadBenchmark.mapped_load` | `176.097 ms/op` |
+| `AndroidQueryBenchmark.mapped_countStar` | `0.003 ms/op` |
+| `AndroidQueryBenchmark.mapped_intConstantFilter` | `0.056 ms/op` |
+| `AndroidQueryBenchmark.mapped_returnDistinct` | `0.197 ms/op` |
+| `AndroidQueryBenchmark.mapped_simpleNodeMatch` | `0.085 ms/op` |
+| `AndroidQueryBenchmark.mapped_singleHopRelationship` | `0.701 ms/op` |
+
+**Baseline comparison:**
+
+| Benchmark | Recorded baseline | Current score | Change |
+|-----------|-------------------|---------------|--------|
+| `AndroidLoadBenchmark.mapped_load` | `2292.892 ms/op` | `176.097 ms/op` | `~13.0x faster` |
+| `AndroidQueryBenchmark.mapped_countStar` | `1816.130 ms/op` | `0.003 ms/op` | scan eliminated |
+| `AndroidQueryBenchmark.mapped_intConstantFilter` | `2.545 ms/op` | `0.056 ms/op` | `~45.4x faster` |
+| `AndroidQueryBenchmark.mapped_returnDistinct` | `2738.060 ms/op` | `0.197 ms/op` | full scan eliminated for this shape |
+| `AndroidQueryBenchmark.mapped_singleHopRelationship` | `75.802 ms/op` | `0.701 ms/op` | `~108.1x faster` |
+
+`mapped_simpleNodeMatch` was already low after existing early `LIMIT` pushdown; the current sweep records it at `0.085 ms/op`.
+
+**Build/save impact:** no optimization in Attempts 001-008 changes the graph save format or adds build-time indexes. The load-side wins come from deferring runtime structures; the query-side wins come from execution control flow and existing type indexes.
+
+**Operational note for multi-graph serving:** opening many mapped graphs now keeps edge structures, metadata, and resources unloaded until first use. The first edge or metadata query for a graph pays that lazy initialization cost once; services that need predictable first-edge latency can explicitly prewarm edge APIs for selected graphs, while node-only query workloads avoid the cost entirely.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -282,3 +282,26 @@ Archive contains more than 65535 entries.
 | `AndroidLoadBenchmark.mapped_load` | avgt | 2 | `2292.892` | ms/op |
 
 **Conclusion:** effective as a benchmark harness repair, not a load/query optimization. The Android-scale baseline path is now usable for subsequent attempts.
+
+### 2026-07-18 — Attempt 001: Skip reverse StringTable index on load
+
+**Hypothesis:** `StringTable.load` reconstructs a `HashMap<String, Int>` for every persisted graph even though eager/lazy/mapped graph loading only needs `StringTable.get(index)` while deserializing nodes and metadata. Avoiding this reverse index should reduce load time and heap without affecting build/save.
+
+**Change:** keep the reverse index for `StringTable.build` (save path) but make `StringTable.load` return a read-only table with no `indexMap`.
+
+**Validation commands:**
+
+```
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 001 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidLoadBenchmark.mapped_load` | `2292.892 ms/op` | `2341.167 ms/op` | `+48.275 ms` / `+2.1%` |
+
+**Conclusion:** not effective for load-time improvement. The result is within short JMH-run noise but does not prove a win.
+
+**Root cause:** on Android-scale mapped load, reverse string-index construction is not the dominant cost. Remaining costs such as BVGraph load, backward graph construction, node index parsing, labels, and metadata dominate the measured path. This may still reduce heap modestly, but it does not move the required load/query performance target by a meaningful amount.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -245,3 +245,40 @@ Synthetic benchmarks (IntConstant) understate steps 1/2/6 because production use
 ### Key Lesson
 
 Adding precomputed caches to reduce time tends to increase memory — violating the constraint. The path that works: **eliminate redundant work** (fewer passes, no re-scans). Both metrics improve simultaneously. Parallelism that shows gains in synthetic benchmarks can regress in production due to thread management overhead.
+
+## Ongoing Load/Query Optimization Log
+
+### 2026-07-18 — Attempt 000: Android-scale JMH harness repair
+
+**Goal:** establish a reliable Android-scale baseline before changing load/query code. The objective requires JMH results on a graph at Android jar scale; demo jars or sub-100K-node graphs are not representative.
+
+**Initial failure:** `./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'` compiled and the Gradle task reported success, but JMH produced no score because the forked JVM could not locate `android-all`.
+
+```
+java.lang.IllegalStateException: Unable to locate android fixture JAR.
+Set -Dandroid.jar.path=<path> or resolve integration fixtures first.
+```
+
+**Rejected fix:** adding `libs.android.all` and `libs.elasticsearch` to the `jmh` dependency configuration made the fixture visible, but it also placed the Android jar in the JMH fat jar. `:webgraph:jmhJar` then failed with:
+
+```
+Archive contains more than 65535 entries.
+```
+
+**Root cause:** large integration fixture jars must not be packaged into the benchmark jar. They should be resolved by Gradle and passed to the forked JMH JVM as `-Dandroid.jar.path` / `-Delasticsearch.jar.path`.
+
+**Accepted fix:** keep fixtures in `integrationFixtures`; lazily resolve that configuration only for the `jmh` task and append exact fixture paths to JMH fork JVM args. `BenchmarkCorpus` also checks `java.class.path` before falling back to the Gradle cache, which keeps explicit `-D...path` overrides, JMH classpath execution, and cache scanning all valid.
+
+**Validation command:**
+
+```
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'
+```
+
+**Result:**
+
+| Benchmark | Mode | Count | Score | Units |
+|-----------|------|-------|-------|-------|
+| `AndroidLoadBenchmark.mapped_load` | avgt | 2 | `2292.892` | ms/op |
+
+**Conclusion:** effective as a benchmark harness repair, not a load/query optimization. The Android-scale baseline path is now usable for subsequent attempts.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -465,3 +465,28 @@ The fast path scans candidate nodes, evaluates node constraints and `WHERE`, pro
 **Conclusion:** effective for the targeted filtered node query and crosses the order-of-magnitude threshold for this benchmark shape.
 
 **Root cause:** the generic pipeline executed `MATCH` first, producing bindings for all `IntConstant` nodes, then applied `WHERE`, then projected rows and finally applied `LIMIT 100`. Even when only the first 100 filtered rows are needed, the old path still deserialized and materialized every candidate node. Streaming the filter and stopping after the limit removes that intermediate list.
+
+### 2026-07-18 — Attempt 007: Single-pass primitive node-index loading
+
+**Hypothesis:** `readNodeIndex` does two full passes over `graph.nodeindex` and stores type buckets as boxed `MutableList<Int>`. On Android-scale graphs this creates unnecessary IO and heap churn during `loadMapped`. Reading the file once and storing type buckets as primitive `IntArray` should reduce mapped-load time and per-graph heap without changing build/save.
+
+**Change:** parse `graph.nodeindex` in one pass. Fill `nodeOffsets` and per-tag `IntArrayList` buckets together, then expose the loaded type index as `Map<Class<out Node>, IntArray>` to lazy/mapped graph implementations.
+
+**Build/save impact:** none. The persisted `graph.nodeindex` format and save path are unchanged; this only changes how the index is loaded.
+
+**Validation commands:**
+
+```
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 007 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidLoadBenchmark.mapped_load` | `1425.196 ms/op` | `1284.409 ms/op` | `-140.787 ms` / `-9.9%` |
+
+**Conclusion:** effective but not enough for the load-side order-of-magnitude goal. It removes measurable node-index parsing overhead and reduces boxed integer allocation, but the remaining mapped-load path is still dominated by other eager structures.
+
+**Root cause:** node-index parsing is a real cost, but not the dominant remaining load cost after lazy backward adjacency. `loadMapped` still eagerly loads forward BVGraph adjacency, edge labels, cumulative outdegree, comparison metadata, graph metadata, resources, string table, and node offsets before a graph is considered open. For node-only touch/query paths, much of that work is still paid upfront.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -334,3 +334,36 @@ Compared with Attempt 001's immediate pre-change result (`2341.167 ms/op`), this
 **Conclusion:** effective for load time. This does not yet provide a full order-of-magnitude improvement, but it removes a large eager-load cost without increasing build/save time or memory.
 
 **Root cause:** backward transpose construction is a major Android-scale mapped-load cost. Most common load and forward-query paths do not need incoming edges, so doing this work unconditionally was wasted. Queries that call `incoming()` still pay the same transpose cost once, but they pay it at first use rather than at graph open.
+
+### 2026-07-18 — Attempt 003: Fast path for simple node `count`
+
+**Hypothesis:** `MATCH (n:Label) RETURN count(*)` should not materialize every node. The graph already has type indexes for `nodes(Label)`, so Cypher can answer simple unfiltered count queries from a precomputed node count.
+
+**Change:** add optional `Graph.nodeCount(type)` with implementations in `DefaultGraph` and WebGraph-backed graphs. `QueryPipeline` now short-circuits only simple single-node count queries:
+
+```
+MATCH (n:Label) RETURN count(*)
+MATCH (n:Label) RETURN count(n)
+```
+
+Queries with relationships, `WHERE`, properties, `DISTINCT`, grouping, `WITH`, `ORDER BY`, or multiple clauses still use the normal execution path.
+
+**Build/save impact:** none. This uses existing in-memory type indexes and persisted node indexes; no new build-time or save-time structure is written.
+
+**Validation commands:**
+
+```
+./gradlew :cypher:test
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidQueryBenchmark.mapped_countStar'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 003 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidQueryBenchmark.mapped_countStar` | `1816.130 ms/op` | `0.003 ms/op` | effectively eliminates the scan |
+
+**Conclusion:** effective for the targeted count query. This is a narrow query optimization, not a general Cypher accelerator.
+
+**Root cause:** the previous pipeline executed `MATCH` before aggregation, so `count(*)` forced a full scan and deserialization of every matching node. For unfiltered single-node counts, the result is exactly the size of the node type index, so scanning was unnecessary work.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -433,3 +433,35 @@ The fast path streams source nodes, edges, target checks, and return projection 
 **Conclusion:** effective for the targeted single-hop relationship query and crosses the required order-of-magnitude threshold for this benchmark shape.
 
 **Root cause:** the generic early-limit path only checked the limit after `matchRelationship` had expanded a source node into a full intermediate list. If one source has many outgoing `DATAFLOW` edges, the engine still decodes and materializes all of those relationship matches before keeping the first 20 rows. It also risked treating `LIMIT` as a cap on source nodes rather than complete relationship matches. Streaming complete rows and stopping inside the edge loop removes both costs.
+
+### 2026-07-18 — Attempt 006: Stream filtered single-node `LIMIT`
+
+**Hypothesis:** `MATCH (n:Label) WHERE ... RETURN ... LIMIT k` should not materialize every matching node before evaluating `WHERE`. For bounded filtered scans, `LIMIT` can be applied after filtering and projection while still streaming the node scan.
+
+**Change:** add a narrow `QueryPipeline` fast path for one non-optional single-node pattern followed by `WHERE`, non-aggregate/non-`DISTINCT` `RETURN`, and `LIMIT`:
+
+```
+MATCH (n:Label) WHERE n.property = value RETURN n.id LIMIT k
+```
+
+The fast path scans candidate nodes, evaluates node constraints and `WHERE`, projects the return row, and stops when `k` filtered rows have been produced. Queries with relationships, `ORDER BY`, `SKIP`, `WITH`, aggregation, `DISTINCT`, path variables, non-literal `LIMIT`, or `RETURN *` still use the normal pipeline.
+
+**Build/save impact:** none. This is query execution control flow only; it does not add indexes, persisted fields, or build-time work.
+
+**Validation commands:**
+
+```
+./gradlew :cypher:test
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidQueryBenchmark.mapped_intConstantFilter'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 006 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidQueryBenchmark.mapped_intConstantFilter` | `2.545 ms/op` | `0.057 ms/op` | `-2.488 ms` / `~44.6x faster` |
+
+**Conclusion:** effective for the targeted filtered node query and crosses the order-of-magnitude threshold for this benchmark shape.
+
+**Root cause:** the generic pipeline executed `MATCH` first, producing bindings for all `IntConstant` nodes, then applied `WHERE`, then projected rows and finally applied `LIMIT 100`. Even when only the first 100 filtered rows are needed, the old path still deserialized and materialized every candidate node. Streaming the filter and stopping after the limit removes that intermediate list.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -347,6 +347,7 @@ MATCH (n:Label) RETURN count(n)
 ```
 
 Queries with relationships, `WHERE`, properties, `DISTINCT`, grouping, `WITH`, `ORDER BY`, or multiple clauses still use the normal execution path.
+The fast path is limited to 0/1-label node patterns; multi-label node patterns still use the normal matcher.
 
 **Build/save impact:** none. This uses existing in-memory type indexes and persisted node indexes; no new build-time or save-time structure is written.
 
@@ -367,3 +368,36 @@ Queries with relationships, `WHERE`, properties, `DISTINCT`, grouping, `WITH`, `
 **Conclusion:** effective for the targeted count query. This is a narrow query optimization, not a general Cypher accelerator.
 
 **Root cause:** the previous pipeline executed `MATCH` before aggregation, so `count(*)` forced a full scan and deserialization of every matching node. For unfiltered single-node counts, the result is exactly the size of the node type index, so scanning was unnecessary work.
+
+### 2026-07-18 — Attempt 004: Early-stop simple `DISTINCT property LIMIT`
+
+**Hypothesis:** `MATCH (n:Label) RETURN DISTINCT n.property LIMIT k` should not scan all matching nodes when there is no `WHERE`, relationship, grouping, or `ORDER BY`. The existing implementation preserves first-seen order with `List.distinct()`, so it is equivalent to stop after the first `k` distinct property values.
+
+**Change:** add a narrow `QueryPipeline` fast path for:
+
+```
+MATCH (n:Label) RETURN DISTINCT n.property LIMIT k
+```
+
+The fast path scans matching nodes only until `k` distinct values have been seen. Queries with `WHERE`, relationships, inline node properties, missing `LIMIT`, multiple return items, grouping, `WITH`, or `ORDER BY` still use the normal pipeline.
+Like the count fast path, it is limited to 0/1-label node patterns so multi-label matching semantics remain in the existing matcher.
+
+**Build/save impact:** none. This is purely query execution control flow and adds no persisted index or build-time work.
+
+**Validation commands:**
+
+```
+./gradlew :cypher:test
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidQueryBenchmark.mapped_returnDistinct'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 004 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidQueryBenchmark.mapped_returnDistinct` | `2738.060 ms/op` | `0.214 ms/op` | effectively eliminates the full scan for this shape |
+
+**Conclusion:** effective for the targeted distinct-property query. It is not a general replacement for property indexes, but it removes a common unnecessary full scan when `LIMIT` is present and no ordering constraints exist.
+
+**Root cause:** `DISTINCT` disabled early limit pushdown, so the old pipeline materialized every `CallSiteNode`, projected `callee_class`, deduplicated the full list, and then applied `LIMIT 20`. For unordered distinct queries, scanning after the first 20 distinct values is unnecessary.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -13,7 +13,9 @@ graph-dir/
 └── graph.comparisons  BranchComparison data for ControlFlowEdges
 ```
 
-Backward adjacency is rebuilt from `forward.*` at load time — not stored on disk.
+Backward adjacency is not stored on disk. It is rebuilt lazily from `forward.*`
+on the first `incoming()` query for a loaded graph, so forward-only queries do
+not pay transpose construction during load.
 
 ## Binary Format
 
@@ -46,7 +48,7 @@ SootUpAdapter                  GraphStore.save()                 GraphStore.load
   → DefaultGraph                 1. String collection              1. BVGraph.load       ┐
                                  2. Metadata + StringTable         2. StringTable.load    ├ parallel
                                  3. Forward adjacency + labels     3. Labels + comparisons┘
-                                                                   4. Build backward from forward
+                                                                   4. Prepare lazy backward builder
                                  4. BVGraph.store                  5. Read nodes + metadata
                                  5. Labels + comparisons write
                                  6. Nodedata + nodeindex write
@@ -79,15 +81,15 @@ graph TD
     B --> B2[StringTable.load]
     B --> B3[Labels + comparisons]
     B1 --> C[Build cumulative outdegree]
-    B1 --> D[Build backward from forward]
-    D --> D1[Pass 1: Count indegree]
-    D1 --> D2[Pass 2: Fill predecessor arrays + sort]
+    B1 --> D[Prepare lazy backward builder]
+    D --> D1[First incoming query: count indegree]
+    D1 --> D2[Fill predecessor arrays + sort]
     B2 --> E[Read nodes]
     E -->|Eager| E1[Deserialize all to heap]
     E -->|Mapped| E2[mmap nodedata file]
     E -->|Lazy| E3[RandomAccessFile on demand]
     B2 --> F[Read metadata]
-    C & D2 & B3 & E & F --> G[Construct Graph]
+C & D & B3 & E & F --> G[Construct Graph]
 ```
 
 ### Load Modes
@@ -305,3 +307,30 @@ Archive contains more than 65535 entries.
 **Conclusion:** not effective for load-time improvement. The result is within short JMH-run noise but does not prove a win.
 
 **Root cause:** on Android-scale mapped load, reverse string-index construction is not the dominant cost. Remaining costs such as BVGraph load, backward graph construction, node index parsing, labels, and metadata dominate the measured path. This may still reduce heap modestly, but it does not move the required load/query performance target by a meaningful amount.
+
+### 2026-07-18 — Attempt 002: Lazy backward adjacency construction
+
+**Hypothesis:** `loadEager`, `loadLazy`, and `loadMapped` all rebuild the full backward adjacency from `forward.*` during load, even when the query path only needs forward traversal or node scans. Android-scale `mapped_load` should improve if transpose construction is deferred until the first `incoming()` call.
+
+**Change:** replace eagerly constructed `ImmutableGraph backward` constructor parameters with `Lazy<ImmutableGraph>`. `GraphStore.load*` now creates a lazy handle, and each graph implementation calls `backward.value` only inside `incoming()`.
+
+**Build/save impact:** none. The persisted format and `GraphStore.save` path are unchanged.
+
+**Validation commands:**
+
+```
+./gradlew :webgraph:test
+./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'
+```
+
+**Result:**
+
+| Benchmark | Baseline | Attempt 002 | Change |
+|-----------|----------|-------------|--------|
+| `AndroidLoadBenchmark.mapped_load` | `2292.892 ms/op` | `1425.196 ms/op` | `-867.696 ms` / `-37.8%` |
+
+Compared with Attempt 001's immediate pre-change result (`2341.167 ms/op`), this is `-915.971 ms` / `-39.1%`.
+
+**Conclusion:** effective for load time. This does not yet provide a full order-of-magnitude improvement, but it removes a large eager-load cost without increasing build/save time or memory.
+
+**Root cause:** backward transpose construction is a major Android-scale mapped-load cost. Most common load and forward-query paths do not need incoming edges, so doing this work unconditionally was wasted. Queries that call `incoming()` still pay the same transpose cost once, but they pay it at first use rather than at graph open.

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/DefaultGraph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/DefaultGraph.kt
@@ -86,6 +86,12 @@ class DefaultGraph private constructor(
             .flatMap { it.value.asSequence() } as Sequence<T>
     }
 
+    override fun nodeCount(type: Class<out Node>): Long =
+        nodesByType[type]?.size?.toLong()
+            ?: nodesByType.entries.asSequence()
+                .filter { type.isAssignableFrom(it.key) }
+                .sumOf { it.value.size.toLong() }
+
     override fun outgoing(id: NodeId): Sequence<Edge> =
         outgoingEdges.get(id.value)?.asSequence() ?: emptySequence()
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -30,6 +30,13 @@ interface Graph {
     fun <T : Node> nodes(type: Class<T>): Sequence<T>
 
     /**
+     * Return a precomputed node count for [type] when the graph can answer
+     * without scanning/deserializing nodes. Implementations may return null
+     * to indicate callers should fall back to [nodes].
+     */
+    fun nodeCount(type: Class<out Node>): Long? = null
+
+    /**
      * Get all outgoing edges from a node
      */
     fun outgoing(id: NodeId): Sequence<Edge>

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
@@ -75,6 +75,18 @@ class DefaultGraphTest {
         assertEquals(1, stringConstants.size)
     }
 
+    @Test
+    fun `nodeCount returns exact and assignable type counts`() {
+        val graph = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId.next(), 1))
+            .addNode(StringConstant(NodeId.next(), "hello"))
+            .addNode(IntConstant(NodeId.next(), 2))
+            .build()
+
+        assertEquals(2L, graph.nodeCount(IntConstant::class.java))
+        assertEquals(3L, graph.nodeCount(Node::class.java))
+    }
+
     // ========================================================================
     // Edge operations
     // ========================================================================
@@ -304,6 +316,7 @@ class DefaultGraphTest {
         }
 
         assertTrue(graph.typeHierarchyTypes().isEmpty())
+        assertNull(graph.nodeCount(Node::class.java))
         assertNull(graph.classOrigin("com.example.App"))
         assertTrue(graph.classOrigins().isEmpty())
         assertTrue(graph.artifactDependencies().isEmpty())

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -33,6 +33,8 @@ class QueryPipeline(private val graph: Graph) {
      * Execute a list of clauses and return the final result.
      */
     fun execute(clauses: List<CypherClause>): CypherResult {
+        tryFastNodeCount(clauses)?.let { return it }
+
         var rows: List<Map<String, Any?>> = listOf(emptyMap())
         var columns: List<String> = emptyList()
 
@@ -90,6 +92,54 @@ class QueryPipeline(private val graph: Graph) {
         }
 
         return CypherResult(columns, rows)
+    }
+
+    /**
+     * Fast path for simple count queries:
+     *
+     *   MATCH (n:Label) RETURN count(*)
+     *   MATCH (n:Label) RETURN count(n)
+     *
+     * This avoids scanning and materializing every node when the graph backend
+     * already has a type index count.
+     */
+    private fun tryFastNodeCount(clauses: List<CypherClause>): CypherResult? {
+        if (clauses.size != 2) return null
+        val match = clauses[0] as? CypherClause.Match ?: return null
+        val ret = clauses[1] as? CypherClause.Return ?: return null
+        if (match.optional || ret.distinct || match.patterns.size != 1 || ret.items.size != 1) return null
+
+        val pattern = match.patterns.single()
+        if (pattern.pathVariable != null || pattern.elements.size != 1) return null
+
+        val nodePattern = pattern.elements.single() as? PatternElement.NodePattern ?: return null
+        if (nodePattern.properties.isNotEmpty()) return null
+
+        val returnItem = ret.items.single()
+        val countedVariable = countedVariable(returnItem.expression) ?: return null
+        if (countedVariable != "*" && countedVariable != nodePattern.variable) return null
+
+        val nodeClass = nodePattern.labels.firstOrNull()
+            ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
+            ?: Node::class.java
+        val count = graph.nodeCount(nodeClass) ?: return null
+        val column = returnItem.alias ?: returnItem.expression.toCypherString()
+        return CypherResult(
+            columns = listOf(column),
+            rows = listOf(mapOf(column to count))
+        )
+    }
+
+    private fun countedVariable(expr: CypherExpr): String? = when (expr) {
+        is CypherExpr.CountStar -> "*"
+        is CypherExpr.FunctionCall -> {
+            if (!expr.name.equals("count", ignoreCase = true) || expr.distinct || expr.args.size != 1) {
+                null
+            } else {
+                (expr.args.single() as? CypherExpr.Variable)?.name
+            }
+        }
+        else -> null
     }
 
     // ========================================================================

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -10,6 +10,12 @@ import io.johnsonlee.graphite.core.ResourceEdge
 import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.graph.Graph
 
+private const val COUNT_QUERY_CLAUSES = 2
+private const val DISTINCT_LIMIT_QUERY_CLAUSES = 3
+private const val FILTERED_LIMIT_QUERY_CLAUSES = 4
+private const val SINGLE_HOP_LIMIT_QUERY_CLAUSES = 3
+private const val SINGLE_HOP_PATTERN_ELEMENTS = 3
+
 /**
  * Executes a sequence of [CypherClause] elements against a [Graph],
  * maintaining a result set (list of binding maps) that flows through each clause.
@@ -25,6 +31,7 @@ import io.johnsonlee.graphite.graph.Graph
  * Write clauses (`CREATE`, `DELETE`, `SET`, `REMOVE`) are not executed
  * because Graphite graphs are immutable; they are silently ignored.
  */
+@Suppress("LargeClass")
 class QueryPipeline(private val graph: Graph) {
 
     private val evaluator = ExpressionEvaluator()
@@ -33,10 +40,11 @@ class QueryPipeline(private val graph: Graph) {
      * Execute a list of clauses and return the final result.
      */
     fun execute(clauses: List<CypherClause>): CypherResult {
-        tryFastNodeCount(clauses)?.let { return it }
-        tryFastDistinctPropertyLimit(clauses)?.let { return it }
-        tryFastFilteredNodeLimit(clauses)?.let { return it }
-        tryFastSingleHopRelationshipLimit(clauses)?.let { return it }
+        val fastResult = tryFastNodeCount(clauses)
+            ?: tryFastDistinctPropertyLimit(clauses)
+            ?: tryFastFilteredNodeLimit(clauses)
+            ?: tryFastSingleHopRelationshipLimit(clauses)
+        if (fastResult != null) return fastResult
 
         var rows: List<Map<String, Any?>> = listOf(emptyMap())
         var columns: List<String> = emptyList()
@@ -106,8 +114,9 @@ class QueryPipeline(private val graph: Graph) {
      * This avoids scanning and materializing every node when the graph backend
      * already has a type index count.
      */
+    @Suppress("CyclomaticComplexMethod", "ComplexCondition", "ReturnCount")
     private fun tryFastNodeCount(clauses: List<CypherClause>): CypherResult? {
-        if (clauses.size != 2) return null
+        if (clauses.size != COUNT_QUERY_CLAUSES) return null
         val match = clauses[0] as? CypherClause.Match ?: return null
         val ret = clauses[1] as? CypherClause.Return ?: return null
         if (match.optional || ret.distinct || match.patterns.size != 1 || ret.items.size != 1) return null
@@ -155,8 +164,9 @@ class QueryPipeline(private val graph: Graph) {
      * so we can stop after the first k distinct property values instead of
      * materializing every matching node first.
      */
+    @Suppress("CyclomaticComplexMethod", "ComplexCondition", "ReturnCount")
     private fun tryFastDistinctPropertyLimit(clauses: List<CypherClause>): CypherResult? {
-        if (clauses.size != 3) return null
+        if (clauses.size != DISTINCT_LIMIT_QUERY_CLAUSES) return null
         val match = clauses[0] as? CypherClause.Match ?: return null
         val ret = clauses[1] as? CypherClause.Return ?: return null
         val limit = clauses[2] as? CypherClause.Limit ?: return null
@@ -192,9 +202,9 @@ class QueryPipeline(private val graph: Graph) {
     }
 
     private fun propertyProjection(expr: CypherExpr, variable: String): String? {
-        val property = expr as? CypherExpr.Property ?: return null
-        val owner = property.expression as? CypherExpr.Variable ?: return null
-        return if (owner.name == variable) property.propertyName else null
+        val property = expr as? CypherExpr.Property
+        val owner = property?.expression as? CypherExpr.Variable
+        return property?.propertyName?.takeIf { owner?.name == variable }
     }
 
     /**
@@ -205,8 +215,9 @@ class QueryPipeline(private val graph: Graph) {
      * This keeps LIMIT semantics on filtered/projected rows while avoiding
      * materializing every node match before WHERE is evaluated.
      */
+    @Suppress("CyclomaticComplexMethod", "ComplexCondition", "MagicNumber", "ReturnCount")
     private fun tryFastFilteredNodeLimit(clauses: List<CypherClause>): CypherResult? {
-        if (clauses.size != 4) return null
+        if (clauses.size != FILTERED_LIMIT_QUERY_CLAUSES) return null
         val match = clauses[0] as? CypherClause.Match ?: return null
         val where = clauses[1] as? CypherClause.Where ?: return null
         val ret = clauses[2] as? CypherClause.Return ?: return null
@@ -252,8 +263,9 @@ class QueryPipeline(private val graph: Graph) {
      * we can stream complete relationship matches and stop once LIMIT rows have
      * been projected.
      */
+    @Suppress("CyclomaticComplexMethod", "ComplexCondition", "ReturnCount")
     private fun tryFastSingleHopRelationshipLimit(clauses: List<CypherClause>): CypherResult? {
-        if (clauses.size != 3) return null
+        if (clauses.size != SINGLE_HOP_LIMIT_QUERY_CLAUSES) return null
         val match = clauses[0] as? CypherClause.Match ?: return null
         val ret = clauses[1] as? CypherClause.Return ?: return null
         val limit = clauses[2] as? CypherClause.Limit ?: return null
@@ -263,7 +275,7 @@ class QueryPipeline(private val graph: Graph) {
         if (ret.items.any { (it.expression as? CypherExpr.Variable)?.name == "*" }) return null
 
         val pattern = match.patterns.single()
-        if (pattern.pathVariable != null || pattern.elements.size != 3) return null
+        if (pattern.pathVariable != null || pattern.elements.size != SINGLE_HOP_PATTERN_ELEMENTS) return null
 
         val sourcePattern = pattern.elements[0] as? PatternElement.NodePattern ?: return null
         val rel = pattern.elements[1] as? PatternElement.RelationshipPattern ?: return null

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -35,6 +35,7 @@ class QueryPipeline(private val graph: Graph) {
     fun execute(clauses: List<CypherClause>): CypherResult {
         tryFastNodeCount(clauses)?.let { return it }
         tryFastDistinctPropertyLimit(clauses)?.let { return it }
+        tryFastSingleHopRelationshipLimit(clauses)?.let { return it }
 
         var rows: List<Map<String, Any?>> = listOf(emptyMap())
         var columns: List<String> = emptyList()
@@ -193,6 +194,77 @@ class QueryPipeline(private val graph: Graph) {
         val property = expr as? CypherExpr.Property ?: return null
         val owner = property.expression as? CypherExpr.Variable ?: return null
         return if (owner.name == variable) property.propertyName else null
+    }
+
+    /**
+     * Fast path for:
+     *
+     *   MATCH (a:Source)-[:TYPE]->(b:Target) RETURN ... LIMIT k
+     *
+     * The generic pipeline materializes node and relationship intermediates.
+     * For a single non-variable-length hop without filtering/reordering clauses,
+     * we can stream complete relationship matches and stop once LIMIT rows have
+     * been projected.
+     */
+    private fun tryFastSingleHopRelationshipLimit(clauses: List<CypherClause>): CypherResult? {
+        if (clauses.size != 3) return null
+        val match = clauses[0] as? CypherClause.Match ?: return null
+        val ret = clauses[1] as? CypherClause.Return ?: return null
+        val limit = clauses[2] as? CypherClause.Limit ?: return null
+        if (match.optional || ret.distinct || match.patterns.size != 1 || ret.items.any { containsAggregation(it.expression) }) {
+            return null
+        }
+        if (ret.items.any { (it.expression as? CypherExpr.Variable)?.name == "*" }) return null
+
+        val pattern = match.patterns.single()
+        if (pattern.pathVariable != null || pattern.elements.size != 3) return null
+
+        val sourcePattern = pattern.elements[0] as? PatternElement.NodePattern ?: return null
+        val rel = pattern.elements[1] as? PatternElement.RelationshipPattern ?: return null
+        val targetPattern = pattern.elements[2] as? PatternElement.NodePattern ?: return null
+        if (sourcePattern.variable == null || rel.variableLength) return null
+
+        val limitCount = evaluateToInt(limit.count, emptyMap())
+        val columns = ret.items.map { it.alias ?: it.expression.toCypherString() }
+        if (limitCount <= 0) return CypherResult(columns, emptyList())
+
+        val sourceClass = sourcePattern.labels.firstOrNull()
+            ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
+            ?: Node::class.java
+        val edgeClass = rel.types.singleOrNull()?.let { NodePropertyAccessor.resolveEdgeType(it) }
+
+        val rows = mutableListOf<Map<String, Any?>>()
+        for (source in graph.nodes(sourceClass)) {
+            if (!matchesNodeConstraints(source, sourcePattern, emptyMap())) continue
+
+            val sourceBindings = mutableMapOf<String, Any?>(sourcePattern.variable to source)
+            for (edge in edgesForDirection(source.id, rel.direction, edgeClass)) {
+                if (!matchesRelConstraints(edge, rel, sourceBindings)) continue
+
+                val targetId = resolveTargetId(edge, source.id, rel.direction)
+                val target = graph.node(targetId) ?: continue
+                val targetBindings = matchTargetNode(targetPattern, target, sourceBindings) ?: continue
+
+                val bindings = targetBindings.toMutableMap()
+                if (rel.variable != null) bindings[rel.variable] = edge
+                rows.add(projectRow(ret.items, columns, bindings))
+                if (rows.size >= limitCount) return CypherResult(columns, rows)
+            }
+        }
+
+        return CypherResult(columns, rows)
+    }
+
+    private fun projectRow(
+        items: List<ReturnItem>,
+        columns: List<String>,
+        bindings: Map<String, Any?>
+    ): Map<String, Any?> {
+        val projected = mutableMapOf<String, Any?>()
+        for (i in items.indices) {
+            projected[columns[i]] = evaluator.evaluate(items[i].expression, bindings)
+        }
+        return projected
     }
 
     // ========================================================================

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -35,6 +35,7 @@ class QueryPipeline(private val graph: Graph) {
     fun execute(clauses: List<CypherClause>): CypherResult {
         tryFastNodeCount(clauses)?.let { return it }
         tryFastDistinctPropertyLimit(clauses)?.let { return it }
+        tryFastFilteredNodeLimit(clauses)?.let { return it }
         tryFastSingleHopRelationshipLimit(clauses)?.let { return it }
 
         var rows: List<Map<String, Any?>> = listOf(emptyMap())
@@ -169,7 +170,7 @@ class QueryPipeline(private val graph: Graph) {
 
         val returnItem = ret.items.single()
         val propertyName = propertyProjection(returnItem.expression, nodePattern.variable) ?: return null
-        val limitCount = evaluateToInt(limit.count, emptyMap())
+        val limitCount = literalLimitCount(limit.count) ?: return null
         if (limitCount <= 0) {
             val column = returnItem.alias ?: returnItem.expression.toCypherString()
             return CypherResult(listOf(column), emptyList())
@@ -194,6 +195,51 @@ class QueryPipeline(private val graph: Graph) {
         val property = expr as? CypherExpr.Property ?: return null
         val owner = property.expression as? CypherExpr.Variable ?: return null
         return if (owner.name == variable) property.propertyName else null
+    }
+
+    /**
+     * Fast path for:
+     *
+     *   MATCH (n:Label) WHERE ... RETURN ... LIMIT k
+     *
+     * This keeps LIMIT semantics on filtered/projected rows while avoiding
+     * materializing every node match before WHERE is evaluated.
+     */
+    private fun tryFastFilteredNodeLimit(clauses: List<CypherClause>): CypherResult? {
+        if (clauses.size != 4) return null
+        val match = clauses[0] as? CypherClause.Match ?: return null
+        val where = clauses[1] as? CypherClause.Where ?: return null
+        val ret = clauses[2] as? CypherClause.Return ?: return null
+        val limit = clauses[3] as? CypherClause.Limit ?: return null
+        if (match.optional || ret.distinct || match.patterns.size != 1 || ret.items.any { containsAggregation(it.expression) }) {
+            return null
+        }
+        if (ret.items.any { (it.expression as? CypherExpr.Variable)?.name == "*" }) return null
+
+        val pattern = match.patterns.single()
+        if (pattern.pathVariable != null || pattern.elements.size != 1) return null
+
+        val nodePattern = pattern.elements.single() as? PatternElement.NodePattern ?: return null
+        val variable = nodePattern.variable ?: return null
+        val limitCount = literalLimitCount(limit.count) ?: return null
+        val columns = ret.items.map { it.alias ?: it.expression.toCypherString() }
+        if (limitCount <= 0) return CypherResult(columns, emptyList())
+
+        val nodeClass = nodePattern.labels.firstOrNull()
+            ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
+            ?: Node::class.java
+        val rows = mutableListOf<Map<String, Any?>>()
+        for (node in graph.nodes(nodeClass)) {
+            if (!matchesNodeConstraints(node, nodePattern, emptyMap())) continue
+
+            val bindings = mapOf<String, Any?>(variable to node)
+            if (evaluator.evaluate(where.condition, bindings) != true) continue
+
+            rows.add(projectRow(ret.items, columns, bindings))
+            if (rows.size >= limitCount) return CypherResult(columns, rows)
+        }
+
+        return CypherResult(columns, rows)
     }
 
     /**
@@ -224,7 +270,7 @@ class QueryPipeline(private val graph: Graph) {
         val targetPattern = pattern.elements[2] as? PatternElement.NodePattern ?: return null
         if (sourcePattern.variable == null || rel.variableLength) return null
 
-        val limitCount = evaluateToInt(limit.count, emptyMap())
+        val limitCount = literalLimitCount(limit.count) ?: return null
         val columns = ret.items.map { it.alias ?: it.expression.toCypherString() }
         if (limitCount <= 0) return CypherResult(columns, emptyList())
 
@@ -265,6 +311,11 @@ class QueryPipeline(private val graph: Graph) {
             projected[columns[i]] = evaluator.evaluate(items[i].expression, bindings)
         }
         return projected
+    }
+
+    private fun literalLimitCount(expr: CypherExpr): Int? {
+        if (expr !is CypherExpr.Literal) return null
+        return evaluateToInt(expr, emptyMap())
     }
 
     // ========================================================================

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -34,6 +34,7 @@ class QueryPipeline(private val graph: Graph) {
      */
     fun execute(clauses: List<CypherClause>): CypherResult {
         tryFastNodeCount(clauses)?.let { return it }
+        tryFastDistinctPropertyLimit(clauses)?.let { return it }
 
         var rows: List<Map<String, Any?>> = listOf(emptyMap())
         var columns: List<String> = emptyList()
@@ -113,7 +114,7 @@ class QueryPipeline(private val graph: Graph) {
         if (pattern.pathVariable != null || pattern.elements.size != 1) return null
 
         val nodePattern = pattern.elements.single() as? PatternElement.NodePattern ?: return null
-        if (nodePattern.properties.isNotEmpty()) return null
+        if (nodePattern.labels.size > 1 || nodePattern.properties.isNotEmpty()) return null
 
         val returnItem = ret.items.single()
         val countedVariable = countedVariable(returnItem.expression) ?: return null
@@ -140,6 +141,58 @@ class QueryPipeline(private val graph: Graph) {
             }
         }
         else -> null
+    }
+
+    /**
+     * Fast path for:
+     *
+     *   MATCH (n:Label) RETURN DISTINCT n.property LIMIT k
+     *
+     * Without ORDER BY, Cypher does not require a globally sorted result. The
+     * existing implementation preserves first-seen order via List.distinct(),
+     * so we can stop after the first k distinct property values instead of
+     * materializing every matching node first.
+     */
+    private fun tryFastDistinctPropertyLimit(clauses: List<CypherClause>): CypherResult? {
+        if (clauses.size != 3) return null
+        val match = clauses[0] as? CypherClause.Match ?: return null
+        val ret = clauses[1] as? CypherClause.Return ?: return null
+        val limit = clauses[2] as? CypherClause.Limit ?: return null
+        if (match.optional || !ret.distinct || match.patterns.size != 1 || ret.items.size != 1) return null
+
+        val pattern = match.patterns.single()
+        if (pattern.pathVariable != null || pattern.elements.size != 1) return null
+
+        val nodePattern = pattern.elements.single() as? PatternElement.NodePattern ?: return null
+        if (nodePattern.variable == null || nodePattern.labels.size > 1 || nodePattern.properties.isNotEmpty()) return null
+
+        val returnItem = ret.items.single()
+        val propertyName = propertyProjection(returnItem.expression, nodePattern.variable) ?: return null
+        val limitCount = evaluateToInt(limit.count, emptyMap())
+        if (limitCount <= 0) {
+            val column = returnItem.alias ?: returnItem.expression.toCypherString()
+            return CypherResult(listOf(column), emptyList())
+        }
+
+        val nodeClass = nodePattern.labels.firstOrNull()
+            ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
+            ?: Node::class.java
+        val column = returnItem.alias ?: returnItem.expression.toCypherString()
+        val seen = LinkedHashSet<Any?>()
+        for (node in graph.nodes(nodeClass)) {
+            seen.add(NodePropertyAccessor.getProperty(node, propertyName))
+            if (seen.size >= limitCount) break
+        }
+        return CypherResult(
+            columns = listOf(column),
+            rows = seen.map { value -> mapOf(column to value) }
+        )
+    }
+
+    private fun propertyProjection(expr: CypherExpr, variable: String): String? {
+        val property = expr as? CypherExpr.Property ?: return null
+        val owner = property.expression as? CypherExpr.Variable ?: return null
+        return if (owner.name == variable) property.propertyName else null
     }
 
     // ========================================================================

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -211,6 +211,37 @@ class QueryPipelineTest {
         assertEquals(0, result.rows[0]["pidx"])
     }
 
+    @Test
+    fun `single hop relationship limit counts complete matches`() {
+        NodeId.reset()
+        val builder = DefaultGraph.Builder()
+        val method = MethodDescriptor(type, "limited", emptyList(), TypeDescriptor("void"))
+
+        val first = NodeId.next()
+        builder.addNode(IntConstant(first, 7))
+
+        val second = NodeId.next()
+        builder.addNode(IntConstant(second, 42))
+
+        val param = NodeId.next()
+        builder.addNode(ParameterNode(param, 0, intType, method))
+        builder.addEdge(DataFlowEdge(second, param, DataFlowKind.PARAMETER_PASS))
+
+        val localPipeline = QueryPipeline(builder.build())
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(
+                nodePattern("c", "IntConstant"),
+                relPattern(type = "DATAFLOW"),
+                nodePattern("p", "ParameterNode")
+            ))),
+            CypherClause.Return(listOf(returnItem(prop(variable("c"), "value"), "value"))),
+            CypherClause.Limit(lit(1))
+        )
+        val result = localPipeline.execute(clauses)
+        assertEquals(1, result.rows.size)
+        assertEquals(42, result.rows[0]["value"])
+    }
+
     // ========================================================================
     // MATCH - 5. Variable-length path
     // ========================================================================

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -426,6 +426,22 @@ class QueryPipelineTest {
         assertEquals(1, result.rows.size)
     }
 
+    @Test
+    fun `return distinct property with limit`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(nodePattern("n", "CallSiteNode")))),
+            CypherClause.Return(
+                listOf(returnItem(prop(variable("n"), "callee_class"), "cls")),
+                distinct = true
+            ),
+            CypherClause.Limit(lit(1))
+        )
+        val result = pipeline.execute(clauses)
+        assertEquals(listOf("cls"), result.columns)
+        assertEquals(1, result.rows.size)
+        assertEquals("com.example.Repository", result.rows[0]["cls"])
+    }
+
     // ========================================================================
     // RETURN - 16. Aggregation count(*)
     // ========================================================================

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -242,6 +242,56 @@ class QueryPipelineTest {
         assertEquals(42, result.rows[0]["value"])
     }
 
+    @Test
+    fun `single hop relationship limit supports unlabeled source scans`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(
+                nodePattern("a"),
+                relPattern(type = "DATAFLOW"),
+                nodePattern("b")
+            ))),
+            CypherClause.Return(listOf(returnItem(prop(variable("a"), "id"), "id"))),
+            CypherClause.Limit(lit(1))
+        )
+        val result = pipeline.execute(clauses)
+        assertEquals(1, result.rows.size)
+        assertEquals(intConst42.value, result.rows[0]["id"])
+    }
+
+    @Test
+    fun `single hop relationship zero limit returns no rows`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(
+                nodePattern("a", "IntConstant"),
+                relPattern(type = "DATAFLOW"),
+                nodePattern("b", "ParameterNode")
+            ))),
+            CypherClause.Return(listOf(returnItem(prop(variable("a"), "value"), "value"))),
+            CypherClause.Limit(lit(0))
+        )
+        val result = pipeline.execute(clauses)
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `single hop relationship distinct return falls back to generic pipeline`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(
+                nodePattern("a", "StringConstant"),
+                relPattern(type = "DATAFLOW"),
+                nodePattern("b", "CallSiteNode")
+            ))),
+            CypherClause.Return(
+                listOf(returnItem(prop(variable("a"), "value"), "value")),
+                distinct = true
+            ),
+            CypherClause.Limit(lit(1))
+        )
+        val result = pipeline.execute(clauses)
+        assertEquals(1, result.rows.size)
+        assertEquals("hello", result.rows[0]["value"])
+    }
+
     // ========================================================================
     // MATCH - 5. Variable-length path
     // ========================================================================
@@ -430,6 +480,31 @@ class QueryPipelineTest {
         assertEquals(42, result.rows[0]["value"])
     }
 
+    @Test
+    fun `filtered node zero limit returns no rows`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(nodePattern("n", "IntConstant")))),
+            CypherClause.Where(CypherExpr.Comparison(">", prop(variable("n"), "value"), lit(0))),
+            CypherClause.Return(listOf(returnItem(prop(variable("n"), "value"), "value"))),
+            CypherClause.Limit(lit(0))
+        )
+        val result = pipeline.execute(clauses)
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `filtered node limit supports unlabeled node scans`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(nodePattern("n")))),
+            CypherClause.Where(CypherExpr.Comparison("=", prop(variable("n"), "id"), lit(strConstHello.value))),
+            CypherClause.Return(listOf(returnItem(prop(variable("n"), "id"), "id"))),
+            CypherClause.Limit(lit(1))
+        )
+        val result = pipeline.execute(clauses)
+        assertEquals(1, result.rows.size)
+        assertEquals(strConstHello.value, result.rows[0]["id"])
+    }
+
     // ========================================================================
     // RETURN - 13. Property projection
     // ========================================================================
@@ -494,6 +569,37 @@ class QueryPipelineTest {
         assertEquals(listOf("cls"), result.columns)
         assertEquals(1, result.rows.size)
         assertEquals("com.example.Repository", result.rows[0]["cls"])
+    }
+
+    @Test
+    fun `return distinct property zero limit returns no rows`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(nodePattern("n", "CallSiteNode")))),
+            CypherClause.Return(
+                listOf(returnItem(prop(variable("n"), "callee_class"), "cls")),
+                distinct = true
+            ),
+            CypherClause.Limit(lit(0))
+        )
+        val result = pipeline.execute(clauses)
+        assertEquals(listOf("cls"), result.columns)
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `return distinct property with limit supports unlabeled node scans`() {
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(nodePattern("n")))),
+            CypherClause.Return(
+                listOf(returnItem(prop(variable("n"), "id"), "id")),
+                distinct = true
+            ),
+            CypherClause.Limit(lit(1))
+        )
+        val result = pipeline.execute(clauses)
+        assertEquals(listOf("id"), result.columns)
+        assertEquals(1, result.rows.size)
+        assertEquals(intConst42.value, result.rows[0]["id"])
     }
 
     // ========================================================================

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -407,6 +407,29 @@ class QueryPipelineTest {
         assertEquals(7, result.rows[0]["value"])
     }
 
+    @Test
+    fun `filtered node limit counts rows after where`() {
+        NodeId.reset()
+        val builder = DefaultGraph.Builder()
+
+        val first = NodeId.next()
+        builder.addNode(IntConstant(first, 7))
+
+        val second = NodeId.next()
+        builder.addNode(IntConstant(second, 42))
+
+        val localPipeline = QueryPipeline(builder.build())
+        val clauses = listOf(
+            CypherClause.Match(listOf(pattern(nodePattern("n", "IntConstant")))),
+            CypherClause.Where(CypherExpr.Comparison("=", prop(variable("n"), "value"), lit(42))),
+            CypherClause.Return(listOf(returnItem(prop(variable("n"), "value"), "value"))),
+            CypherClause.Limit(lit(1))
+        )
+        val result = localPipeline.execute(clauses)
+        assertEquals(1, result.rows.size)
+        assertEquals(42, result.rows[0]["value"])
+    }
+
     // ========================================================================
     // RETURN - 13. Property projection
     // ========================================================================

--- a/graphite-sootup/build.gradle.kts
+++ b/graphite-sootup/build.gradle.kts
@@ -17,6 +17,7 @@ kover {
 }
 
 val integrationFixtures: Configuration by configurations.creating
+val asmVersion = libs.versions.asm.get()
 
 dependencies {
     api(project(":core"))
@@ -42,8 +43,34 @@ dependencies {
     // JMH benchmark dependencies
     jmh(libs.jmh.core)
     jmhAnnotationProcessor(libs.jmh.generator)
+    jmh("org.ow2.asm:asm:$asmVersion")
+    jmh("org.ow2.asm:asm-tree:$asmVersion")
+    jmh("org.ow2.asm:asm-util:$asmVersion")
+    jmh("org.ow2.asm:asm-commons:$asmVersion")
+    jmh("org.ow2.asm:asm-analysis:$asmVersion")
     add(integrationFixtures.name, libs.elasticsearch)
     add(integrationFixtures.name, libs.android.all)
+}
+
+configurations.matching { it.name.startsWith("jmh", ignoreCase = true) }.configureEach {
+    resolutionStrategy.force(
+        "org.ow2.asm:asm:$asmVersion",
+        "org.ow2.asm:asm-tree:$asmVersion",
+        "org.ow2.asm:asm-util:$asmVersion",
+        "org.ow2.asm:asm-commons:$asmVersion",
+        "org.ow2.asm:asm-analysis:$asmVersion"
+    )
+}
+
+val integrationFixtureJvmArgs = providers.provider {
+    val elasticsearchJar = Regex("""elasticsearch-\d+\.\d+\.\d+\.jar""")
+    integrationFixtures.resolve().mapNotNull { jar ->
+        when {
+            elasticsearchJar.matches(jar.name) -> "-Delasticsearch.jar.path=${jar.absolutePath}"
+            jar.name.startsWith("android-all-") && jar.name.endsWith(".jar") -> "-Dandroid.jar.path=${jar.absolutePath}"
+            else -> null
+        }
+    }
 }
 
 jmh {
@@ -51,4 +78,6 @@ jmh {
     if (filter != null) {
         includes.set(listOf(filter))
     }
+    failOnError.set(true)
+    jvmArgsAppend.addAll(integrationFixtureJvmArgs)
 }

--- a/graphite-webgraph/build.gradle.kts
+++ b/graphite-webgraph/build.gradle.kts
@@ -48,11 +48,24 @@ configurations.matching { it.name.startsWith("jmh", ignoreCase = true) }.configu
     )
 }
 
+val integrationFixtureJvmArgs = providers.provider {
+    val elasticsearchJar = Regex("""elasticsearch-\d+\.\d+\.\d+\.jar""")
+    integrationFixtures.resolve().mapNotNull { jar ->
+        when {
+            elasticsearchJar.matches(jar.name) -> "-Delasticsearch.jar.path=${jar.absolutePath}"
+            jar.name.startsWith("android-all-") && jar.name.endsWith(".jar") -> "-Dandroid.jar.path=${jar.absolutePath}"
+            else -> null
+        }
+    }
+}
+
 jmh {
     val filter = project.findProperty("jmh.filter") as String?
     if (filter != null) {
         includes.set(listOf(filter))
     }
+    failOnError.set(true)
+    jvmArgsAppend.addAll(integrationFixtureJvmArgs)
 }
 
 tasks.test {

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BenchmarkCorpus.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BenchmarkCorpus.kt
@@ -102,9 +102,9 @@ internal object BenchmarkCorpus {
         }
     }
 
-    private fun findJarOnClasspath(kind: CorpusKind): Path? {
+    private fun findJarOnClasspath(kind: BenchmarkCorpusKind): Path? {
         return System.getProperty("java.class.path")
-            .split(System.getProperty("path.separator"))
+            .split(System.getProperty("path.separator").toRegex())
             .asSequence()
             .mapNotNull { entry -> entry.takeIf { it.isNotBlank() }?.let(Path::of) }
             .filter { it.isRegularFile() && kind.matches(it.fileName.toString()) }

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BenchmarkCorpus.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BenchmarkCorpus.kt
@@ -83,6 +83,8 @@ internal object BenchmarkCorpus {
             return jarPath
         }
 
+        findJarOnClasspath(kind)?.let { return it }
+
         val cacheDir = Path.of(System.getProperty("user.home"), ".gradle", "caches")
         require(cacheDir.isDirectory()) { "Gradle cache not found at $cacheDir" }
 
@@ -98,6 +100,15 @@ internal object BenchmarkCorpus {
                     )
                 }
         }
+    }
+
+    private fun findJarOnClasspath(kind: CorpusKind): Path? {
+        return System.getProperty("java.class.path")
+            .split(System.getProperty("path.separator"))
+            .asSequence()
+            .mapNotNull { entry -> entry.takeIf { it.isNotBlank() }?.let(Path::of) }
+            .filter { it.isRegularFile() && kind.matches(it.fileName.toString()) }
+            .firstOrNull()
     }
 
     private fun hasPersistedGraph(dir: Path): Boolean {

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -252,8 +252,8 @@ object GraphStore {
     }
 
     /**
-     * Load a graph lazily -- BVGraph adjacency and edge labels are loaded into
-     * memory, but node data stays on disk and is read on demand.
+     * Load a graph lazily -- node data stays on disk and is read on demand.
+     * Edge structures, metadata, and resources are also loaded on first use.
      *
      * Memory savings for Android SDK (5.9M nodes): ~500 MB vs ~4 GB eager.
      * Query speed for LIMIT queries is similar; full-scan queries pay ~5-10x
@@ -264,24 +264,20 @@ object GraphStore {
 
         val (nodeDataVersion, _) = readNodeDataHeader(dir)
         val nodeIndex = readNodeIndex(dir)
-
-        val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
-        val stringTableFuture = CompletableFuture.supplyAsync { StringTable.load(dir) }
-        val labelsFuture = CompletableFuture.supplyAsync { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
-
-        val forward = forwardFuture.join()
-        val stringTable = stringTableFuture.join()
-        val labelBytes = labelsFuture.join()
-
-        val cumulativeOutdeg = buildCumulativeOutdeg(forward)
-        val backward = lazy { loadBackward(forward) }
-
-        val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
-            NodeSerializer.readComparisons(dis)
+        val stringTable = StringTable.load(dir)
+        val forward = lazy { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
+        val backward = lazy { loadBackward(forward.value) }
+        val labelBytes = lazy { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
+        val cumulativeOutdeg = lazy { buildCumulativeOutdeg(forward.value) }
+        val comparisonMap = lazy {
+            DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
+                NodeSerializer.readComparisons(dis)
+            }
         }
-
-        val metadata = DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
-            NodeSerializer.loadMetadata(dis, stringTable)
+        val metadata = lazy {
+            DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
+                NodeSerializer.loadMetadata(dis, stringTable)
+            }
         }
 
         return LazyWebGraphBackedGraph(
@@ -296,13 +292,13 @@ object GraphStore {
             cumulativeOutdeg = cumulativeOutdeg,
             comparisonMap = comparisonMap,
             metadata = metadata,
-            resources = PersistedResourceStore.load(dir)
+            resourceAccessor = lazy { PersistedResourceStore.load(dir) }
         )
     }
 
     /**
-     * Load a graph with memory-mapped node data — BVGraph adjacency and edge
-     * labels are loaded into JVM heap, but node data is memory-mapped (mmap).
+     * Load a graph with memory-mapped node data. Edge structures, metadata,
+     * and resources are loaded on first use, while node data is memory-mapped.
      *
      * The OS page cache manages which node pages are in physical RAM.
      * No JVM heap allocation for node data, and no system calls per node access
@@ -314,28 +310,25 @@ object GraphStore {
         val (nodeDataVersion, _) = readNodeDataHeader(dir)
         val nodeIndex = readNodeIndex(dir)
 
-        val forwardFuture = CompletableFuture.supplyAsync { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
-        val stringTableFuture = CompletableFuture.supplyAsync { StringTable.load(dir) }
-        val labelsFuture = CompletableFuture.supplyAsync { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
-
-        val forward = forwardFuture.join()
-        val stringTable = stringTableFuture.join()
-        val labelBytes = labelsFuture.join()
-
-        val cumulativeOutdeg = buildCumulativeOutdeg(forward)
-        val backward = lazy { loadBackward(forward) }
-
-        val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
-            NodeSerializer.readComparisons(dis)
-        }
-
         val nodeDataPath = dir.resolve(NODE_DATA_FILE)
         val channel = FileChannel.open(nodeDataPath, StandardOpenOption.READ)
         val mappedBuffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size())
         channel.close()
 
-        val metadata = DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
-            NodeSerializer.loadMetadata(dis, stringTable)
+        val stringTable = StringTable.load(dir)
+        val forward = lazy { BVGraph.load(dir.resolve(FORWARD_GRAPH).toString()) }
+        val backward = lazy { loadBackward(forward.value) }
+        val labelBytes = lazy { BinIO.loadBytes(dir.resolve(LABELS_FILE).toString()) }
+        val cumulativeOutdeg = lazy { buildCumulativeOutdeg(forward.value) }
+        val comparisonMap = lazy {
+            DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
+                NodeSerializer.readComparisons(dis)
+            }
+        }
+        val metadata = lazy {
+            DataInputStream(BufferedInputStream(dir.resolve(METADATA_FILE).toFile().inputStream())).use { dis ->
+                NodeSerializer.loadMetadata(dis, stringTable)
+            }
         }
 
         return MappedWebGraphBackedGraph(
@@ -350,7 +343,7 @@ object GraphStore {
             cumulativeOutdeg = cumulativeOutdeg,
             comparisonMap = comparisonMap,
             metadata = metadata,
-            resources = PersistedResourceStore.load(dir)
+            resourceAccessor = lazy { PersistedResourceStore.load(dir) }
         )
     }
 

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -69,7 +69,7 @@ private class CountingOutputStream(private val delegate: OutputStream) : OutputS
  * ecosystem tools (dsiutils + sux4j + fastutil).
  *
  * Storage layout:
- * - `forward.*`                -- BVGraph adjacency (forward only; backward is rebuilt at load time)
+ * - `forward.*`                -- BVGraph adjacency (forward only; backward is rebuilt lazily on incoming queries)
  * - `graph.strings`            -- [StringTable] (FrontCodedStringList via BinIO)
  * - `graph.labels`             -- byte[] via [BinIO.storeBytes], 1 byte per arc in BVGraph successor order
  * - `graph.comparisons`        -- [BranchComparison] data for [ControlFlowEdge]s that carry one
@@ -217,7 +217,7 @@ object GraphStore {
         val labelBytes = labelsFuture.join()
 
         val cumulativeOutdeg = buildCumulativeOutdeg(forward)
-        val backward = loadBackward(forward)
+        val backward = lazy { loadBackward(forward) }
 
         val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.readComparisons(dis)
@@ -273,7 +273,7 @@ object GraphStore {
         val labelBytes = labelsFuture.join()
 
         val cumulativeOutdeg = buildCumulativeOutdeg(forward)
-        val backward = loadBackward(forward)
+        val backward = lazy { loadBackward(forward) }
 
         val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.readComparisons(dis)
@@ -322,7 +322,7 @@ object GraphStore {
         val labelBytes = labelsFuture.join()
 
         val cumulativeOutdeg = buildCumulativeOutdeg(forward)
-        val backward = loadBackward(forward)
+        val backward = lazy { loadBackward(forward) }
 
         val comparisonMap = DataInputStream(BufferedInputStream(dir.resolve(COMPARISONS_FILE).toFile().inputStream())).use { dis ->
             NodeSerializer.readComparisons(dis)

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -27,6 +27,7 @@ import io.johnsonlee.graphite.core.ValueNode
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
 import it.unimi.dsi.fastutil.io.BinIO
+import it.unimi.dsi.fastutil.ints.IntArrayList
 import it.unimi.dsi.webgraph.BVGraph
 import it.unimi.dsi.webgraph.ImmutableGraph
 import it.unimi.dsi.webgraph.LazyIntIterator
@@ -514,7 +515,7 @@ object GraphStore {
      */
     private class NodeIndexData(
         val nodeOffsets: LongArray,
-        val nodeTypeIndex: HashMap<Class<out Node>, List<Int>>
+        val nodeTypeIndex: HashMap<Class<out Node>, IntArray>
     )
 
     /**
@@ -526,37 +527,28 @@ object GraphStore {
             "Node index file not found: $nodeIndexFile. Re-save the graph to generate it."
         }
 
-        // Pass 1: find maxNodeId and collect type info
-        var maxNodeId = 0
-        val nodeTypeByTag = HashMap<Int, MutableList<Int>>()
-        var nodeCount = 0
+        val nodeTypeByTag = HashMap<Int, IntArrayList>()
+        lateinit var nodeOffsets: LongArray
         DataInputStream(BufferedInputStream(nodeIndexFile.inputStream())).use { dis ->
             NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEINDEX)
-            nodeCount = dis.readInt()
+            val nodeCount = dis.readInt()
+            nodeOffsets = LongArray(nodeCount) { -1L }
             repeat(nodeCount) {
                 val nodeId = dis.readInt()
                 val tag = dis.readByte().toInt()
-                dis.readLong() // skip offset
-                if (nodeId > maxNodeId) maxNodeId = nodeId
-                nodeTypeByTag.getOrPut(tag) { mutableListOf() }.add(nodeId)
-            }
-        }
-
-        // Pass 2: fill nodeOffsets directly
-        val nodeOffsets = LongArray(maxNodeId + 1) { -1L }
-        DataInputStream(BufferedInputStream(nodeIndexFile.inputStream())).use { dis ->
-            NodeSerializer.readHeader(dis, NodeSerializer.MAGIC_NODEINDEX)
-            dis.readInt() // skip count
-            repeat(nodeCount) {
-                val nodeId = dis.readInt()
-                dis.readByte() // skip tag
                 val offset = dis.readLong()
+                if (nodeId >= nodeOffsets.size) {
+                    val oldSize = nodeOffsets.size
+                    nodeOffsets = nodeOffsets.copyOf(nodeId + 1)
+                    java.util.Arrays.fill(nodeOffsets, oldSize, nodeOffsets.size, -1L)
+                }
                 nodeOffsets[nodeId] = offset
+                nodeTypeByTag.getOrPut(tag) { IntArrayList() }.add(nodeId)
             }
         }
 
         // Map tags to concrete Node classes
-        val nodeTypeIndex = HashMap<Class<out Node>, List<Int>>()
+        val nodeTypeIndex = HashMap<Class<out Node>, IntArray>()
         val tagToClass = mapOf(
             NodeSerializer.TAG_INT_CONSTANT to IntConstant::class.java,
             NodeSerializer.TAG_STRING_CONSTANT to StringConstant::class.java,
@@ -577,7 +569,7 @@ object GraphStore {
         )
         for ((tag, ids) in nodeTypeByTag) {
             val cls = tagToClass[tag] ?: continue
-            nodeTypeIndex[cls] = ids
+            nodeTypeIndex[cls] = ids.toIntArray()
         }
 
         return NodeIndexData(nodeOffsets, nodeTypeIndex)

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -45,7 +45,7 @@ internal class LazyWebGraphBackedGraph(
     private val nodeDataVersion: Int,
     private val stringTable: StringTable,
     private val nodeOffsets: LongArray,
-    private val nodeTypeIndex: Map<Class<out Node>, List<Int>>,
+    private val nodeTypeIndex: Map<Class<out Node>, IntArray>,
     private val forwardLabels: ByteArray,
     private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -22,36 +22,39 @@ import java.io.RandomAccessFile
 /**
  * A [Graph] backed by WebGraph compression for edges and lazy disk reads for nodes.
  *
- * BVGraph adjacency (compressed, ~30 MB for 5.9M nodes) and edge label maps
- * stay in memory for fast edge traversal.  Node data is read on demand from
- * `graph.nodedata` via [RandomAccessFile.seek], using a pre-built index
- * (nodeId -> file offset).
+ * Node data is read on demand from `graph.nodedata` via [RandomAccessFile.seek],
+ * using a pre-built index (nodeId -> file offset). Edge structures, metadata,
+ * and resources are loaded on first use.
  *
  * **Memory profile (5.9M nodes, 6.5M edges):**
- * - BVGraph forward: loaded at graph open
+ * - BVGraph forward: loaded lazily on first edge traversal
  * - BVGraph backward: built lazily on first incoming query
- * - Edge label map: ~364 MB
+ * - Edge label map: loaded lazily on first edge traversal
  * - Node index: ~47 MB (nodeId -> offset)
  * - Node type index: ~24 MB (type -> nodeId list)
  * - StringTable: ~21 MB
- * - **Total: ~486 MB** vs ~4 GB for eager [WebGraphBackedGraph]
+ * - **Open heap before edge traversal: ~92 MB plus object overhead** vs ~4 GB
+ *   for eager [WebGraphBackedGraph]
  *
  * Created by [GraphStore.loadLazy].
  */
 internal class LazyWebGraphBackedGraph(
-    private val forward: ImmutableGraph,
+    private val forward: Lazy<ImmutableGraph>,
     private val backward: Lazy<ImmutableGraph>,
     private val nodeDataFile: File,
     private val nodeDataVersion: Int,
     private val stringTable: StringTable,
     private val nodeOffsets: LongArray,
     private val nodeTypeIndex: Map<Class<out Node>, IntArray>,
-    private val forwardLabels: ByteArray,
-    private val cumulativeOutdeg: LongArray,
-    private val comparisonMap: Map<Long, BranchComparison>,
-    private val metadata: GraphMetadata,
-    override val resources: ResourceAccessor
+    private val forwardLabels: Lazy<ByteArray>,
+    private val cumulativeOutdeg: Lazy<LongArray>,
+    private val comparisonMap: Lazy<Map<Long, BranchComparison>>,
+    private val metadata: Lazy<GraphMetadata>,
+    private val resourceAccessor: Lazy<ResourceAccessor>
 ) : Graph, Closeable {
+
+    override val resources: ResourceAccessor
+        get() = resourceAccessor.value
 
     private val openRafs = java.util.Collections.synchronizedList(mutableListOf<RandomAccessFile>())
 
@@ -60,7 +63,7 @@ internal class LazyWebGraphBackedGraph(
     }
 
     private val branchScopeIndex: Map<Int, List<BranchScope>> by lazy {
-        metadata.branchScopes.map { raw ->
+        metadata.value.branchScopes.map { raw ->
             BranchScope(
                 conditionNodeId = NodeId(raw.conditionNodeId),
                 method = raw.method,
@@ -100,15 +103,17 @@ internal class LazyWebGraphBackedGraph(
 
     override fun outgoing(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
-        if (nodeIdx >= forward.numNodes()) return emptySequence()
-        val succs = forward.successorArray(nodeIdx)
-        val outdeg = forward.outdegree(nodeIdx)
-        val labelStart = cumulativeOutdeg[nodeIdx]
+        val forwardGraph = forward.value
+        if (nodeIdx >= forwardGraph.numNodes()) return emptySequence()
+        val succs = forwardGraph.successorArray(nodeIdx)
+        val outdeg = forwardGraph.outdegree(nodeIdx)
+        val labels = forwardLabels.value
+        val labelStart = cumulativeOutdeg.value[nodeIdx]
         return (0 until outdeg).asSequence().map { i ->
             val to = succs[i]
-            val label = forwardLabels[(labelStart + i).toInt()].toInt() and BYTE_MASK
+            val label = labels[(labelStart + i).toInt()].toInt() and BYTE_MASK
             val key = nodeIdx.toLong() shl INT_BITS or (to.toLong() and UNSIGNED_INT_MASK)
-            val comparison = comparisonMap[key]
+            val comparison = comparisonMap.value[key]
             NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison, nodeDataVersion)
         }
     }
@@ -123,16 +128,21 @@ internal class LazyWebGraphBackedGraph(
             val from = preds[i]
             val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl INT_BITS or (nodeIdx.toLong() and UNSIGNED_INT_MASK)
-            val comparison = comparisonMap[key]
+            val comparison = comparisonMap.value[key]
             NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison, nodeDataVersion)
         }
     }
 
     private fun lookupForwardLabel(from: Int, to: Int): Int {
-        val succs = forward.successorArray(from)
-        val outdeg = forward.outdegree(from)
+        val forwardGraph = forward.value
+        val succs = forwardGraph.successorArray(from)
+        val outdeg = forwardGraph.outdegree(from)
         val pos = java.util.Arrays.binarySearch(succs, 0, outdeg, to)
-        return if (pos >= 0) forwardLabels[(cumulativeOutdeg[from] + pos).toInt()].toInt() and BYTE_MASK else 0
+        return if (pos >= 0) {
+            forwardLabels.value[(cumulativeOutdeg.value[from] + pos).toInt()].toInt() and BYTE_MASK
+        } else {
+            0
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -147,25 +157,25 @@ internal class LazyWebGraphBackedGraph(
         nodes(CallSiteNode::class.java).filter { methodPattern.matches(it.callee) }
 
     override fun supertypes(type: TypeDescriptor): Sequence<TypeDescriptor> =
-        metadata.supertypes[type.className]?.asSequence() ?: emptySequence()
+        metadata.value.supertypes[type.className]?.asSequence() ?: emptySequence()
 
     override fun subtypes(type: TypeDescriptor): Sequence<TypeDescriptor> =
-        metadata.subtypes[type.className]?.asSequence() ?: emptySequence()
+        metadata.value.subtypes[type.className]?.asSequence() ?: emptySequence()
 
     override fun methods(pattern: MethodPattern): Sequence<MethodDescriptor> =
-        metadata.methods.values.asSequence().filter { pattern.matches(it) }
+        metadata.value.methods.values.asSequence().filter { pattern.matches(it) }
 
     override fun enumValues(enumClass: String, enumName: String): List<Any?>? =
-        metadata.enumValues["$enumClass#$enumName"]
+        metadata.value.enumValues["$enumClass#$enumName"]
 
     override fun memberAnnotations(className: String, memberName: String): Map<String, Map<String, Any?>> =
-        metadata.memberAnnotations["$className#$memberName"] ?: emptyMap()
+        metadata.value.memberAnnotations["$className#$memberName"] ?: emptyMap()
 
-    override fun classOrigin(className: String): String? = metadata.classOrigins[className]
+    override fun classOrigin(className: String): String? = metadata.value.classOrigins[className]
 
-    override fun classOrigins(): Map<String, String> = metadata.classOrigins
+    override fun classOrigins(): Map<String, String> = metadata.value.classOrigins
 
-    override fun artifactDependencies(): Map<String, Map<String, Int>> = metadata.artifactDependencies
+    override fun artifactDependencies(): Map<String, Map<String, Int>> = metadata.value.artifactDependencies
 
     override fun branchScopes(): Sequence<BranchScope> =
         branchScopeIndex.values.asSequence().flatMap { it.asSequence() }
@@ -174,7 +184,7 @@ internal class LazyWebGraphBackedGraph(
         branchScopeIndex[conditionNodeId.value]?.asSequence() ?: emptySequence()
 
     override fun typeHierarchyTypes(): Set<String> =
-        metadata.supertypes.keys + metadata.subtypes.keys
+        metadata.value.supertypes.keys + metadata.value.subtypes.keys
 
     override fun close() {
         openRafs.forEach { runCatching { it.close() } }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -92,6 +92,12 @@ internal class LazyWebGraphBackedGraph(
             .mapNotNull { node(NodeId(it)) as? T }
     }
 
+    override fun nodeCount(type: Class<out Node>): Long =
+        nodeTypeIndex[type]?.size?.toLong()
+            ?: nodeTypeIndex.entries.asSequence()
+                .filter { type.isAssignableFrom(it.key) }
+                .sumOf { it.value.size.toLong() }
+
     override fun outgoing(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
         if (nodeIdx >= forward.numNodes()) return emptySequence()

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -28,7 +28,8 @@ import java.io.RandomAccessFile
  * (nodeId -> file offset).
  *
  * **Memory profile (5.9M nodes, 6.5M edges):**
- * - BVGraph forward + backward: ~30 MB
+ * - BVGraph forward: loaded at graph open
+ * - BVGraph backward: built lazily on first incoming query
  * - Edge label map: ~364 MB
  * - Node index: ~47 MB (nodeId -> offset)
  * - Node type index: ~24 MB (type -> nodeId list)
@@ -39,7 +40,7 @@ import java.io.RandomAccessFile
  */
 internal class LazyWebGraphBackedGraph(
     private val forward: ImmutableGraph,
-    private val backward: ImmutableGraph,
+    private val backward: Lazy<ImmutableGraph>,
     private val nodeDataFile: File,
     private val nodeDataVersion: Int,
     private val stringTable: StringTable,
@@ -108,9 +109,10 @@ internal class LazyWebGraphBackedGraph(
 
     override fun incoming(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
-        if (nodeIdx >= backward.numNodes()) return emptySequence()
-        val preds = backward.successorArray(nodeIdx)
-        val indeg = backward.outdegree(nodeIdx)
+        val backwardGraph = backward.value
+        if (nodeIdx >= backwardGraph.numNodes()) return emptySequence()
+        val preds = backwardGraph.successorArray(nodeIdx)
+        val indeg = backwardGraph.outdegree(nodeIdx)
         return (0 until indeg).asSequence().map { i ->
             val from = preds[i]
             val label = lookupForwardLabel(from, nodeIdx)

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/LazyWebGraphBackedGraph.kt
@@ -38,6 +38,7 @@ import java.io.RandomAccessFile
  *
  * Created by [GraphStore.loadLazy].
  */
+@Suppress("LongParameterList")
 internal class LazyWebGraphBackedGraph(
     private val forward: Lazy<ImmutableGraph>,
     private val backward: Lazy<ImmutableGraph>,

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -33,7 +33,8 @@ import java.nio.MappedByteBuffer
  * to direct memory reads — no system calls after the initial page fault.
  *
  * **Memory profile (5.9M nodes, 6.5M edges):**
- * - BVGraph forward + backward: ~30 MB (heap)
+ * - BVGraph forward: loaded at graph open
+ * - BVGraph backward: built lazily on first incoming query
  * - Edge label map: ~364 MB (heap)
  * - Node index: ~47 MB (heap, nodeId → offset)
  * - Node type index: ~24 MB (heap, type → nodeId list)
@@ -45,7 +46,7 @@ import java.nio.MappedByteBuffer
  */
 internal class MappedWebGraphBackedGraph(
     private val forward: ImmutableGraph,
-    private val backward: ImmutableGraph,
+    private val backward: Lazy<ImmutableGraph>,
     private val mappedNodeData: MappedByteBuffer,
     private val nodeDataVersion: Int,
     private val stringTable: StringTable,
@@ -108,9 +109,10 @@ internal class MappedWebGraphBackedGraph(
 
     override fun incoming(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
-        if (nodeIdx >= backward.numNodes()) return emptySequence()
-        val preds = backward.successorArray(nodeIdx)
-        val indeg = backward.outdegree(nodeIdx)
+        val backwardGraph = backward.value
+        if (nodeIdx >= backwardGraph.numNodes()) return emptySequence()
+        val preds = backwardGraph.successorArray(nodeIdx)
+        val indeg = backwardGraph.outdegree(nodeIdx)
         return (0 until indeg).asSequence().map { i ->
             val from = preds[i]
             val label = lookupForwardLabel(from, nodeIdx)

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -45,6 +45,7 @@ import java.nio.MappedByteBuffer
  *
  * Created by [GraphStore.loadMapped].
  */
+@Suppress("LongParameterList")
 internal class MappedWebGraphBackedGraph(
     private val forward: Lazy<ImmutableGraph>,
     private val backward: Lazy<ImmutableGraph>,

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -92,6 +92,12 @@ internal class MappedWebGraphBackedGraph(
             .mapNotNull { node(NodeId(it)) as? T }
     }
 
+    override fun nodeCount(type: Class<out Node>): Long =
+        nodeTypeIndex[type]?.size?.toLong()
+            ?: nodeTypeIndex.entries.asSequence()
+                .filter { type.isAssignableFrom(it.key) }
+                .sumOf { it.value.size.toLong() }
+
     override fun outgoing(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
         if (nodeIdx >= forward.numNodes()) return emptySequence()

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -51,7 +51,7 @@ internal class MappedWebGraphBackedGraph(
     private val nodeDataVersion: Int,
     private val stringTable: StringTable,
     private val nodeOffsets: LongArray,
-    private val nodeTypeIndex: Map<Class<out Node>, List<Int>>,
+    private val nodeTypeIndex: Map<Class<out Node>, IntArray>,
     private val forwardLabels: ByteArray,
     private val cumulativeOutdeg: LongArray,
     private val comparisonMap: Map<Long, BranchComparison>,

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -33,34 +33,38 @@ import java.nio.MappedByteBuffer
  * to direct memory reads — no system calls after the initial page fault.
  *
  * **Memory profile (5.9M nodes, 6.5M edges):**
- * - BVGraph forward: loaded at graph open
+ * - BVGraph forward: loaded lazily on first edge traversal
  * - BVGraph backward: built lazily on first incoming query
- * - Edge label map: ~364 MB (heap)
+ * - Edge label map: loaded lazily on first edge traversal
  * - Node index: ~47 MB (heap, nodeId → offset)
  * - Node type index: ~24 MB (heap, type → nodeId list)
  * - StringTable: ~21 MB (heap)
  * - Node data: ~252 MB (mmap, NOT heap — managed by OS page cache)
- * - **JVM Heap total: ~486 MB** vs ~4 GB for eager [WebGraphBackedGraph]
+ * - **Open heap before edge traversal: ~92 MB plus object overhead** vs ~4 GB
+ *   for eager [WebGraphBackedGraph]
  *
  * Created by [GraphStore.loadMapped].
  */
 internal class MappedWebGraphBackedGraph(
-    private val forward: ImmutableGraph,
+    private val forward: Lazy<ImmutableGraph>,
     private val backward: Lazy<ImmutableGraph>,
     private val mappedNodeData: MappedByteBuffer,
     private val nodeDataVersion: Int,
     private val stringTable: StringTable,
     private val nodeOffsets: LongArray,
     private val nodeTypeIndex: Map<Class<out Node>, IntArray>,
-    private val forwardLabels: ByteArray,
-    private val cumulativeOutdeg: LongArray,
-    private val comparisonMap: Map<Long, BranchComparison>,
-    private val metadata: GraphMetadata,
-    override val resources: ResourceAccessor
+    private val forwardLabels: Lazy<ByteArray>,
+    private val cumulativeOutdeg: Lazy<LongArray>,
+    private val comparisonMap: Lazy<Map<Long, BranchComparison>>,
+    private val metadata: Lazy<GraphMetadata>,
+    private val resourceAccessor: Lazy<ResourceAccessor>
 ) : Graph, Closeable {
 
+    override val resources: ResourceAccessor
+        get() = resourceAccessor.value
+
     private val branchScopeIndex: Map<Int, List<BranchScope>> by lazy {
-        metadata.branchScopes.map { raw ->
+        metadata.value.branchScopes.map { raw ->
             BranchScope(
                 conditionNodeId = NodeId(raw.conditionNodeId),
                 method = raw.method,
@@ -100,15 +104,17 @@ internal class MappedWebGraphBackedGraph(
 
     override fun outgoing(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
-        if (nodeIdx >= forward.numNodes()) return emptySequence()
-        val succs = forward.successorArray(nodeIdx)
-        val outdeg = forward.outdegree(nodeIdx)
-        val labelStart = cumulativeOutdeg[nodeIdx]
+        val forwardGraph = forward.value
+        if (nodeIdx >= forwardGraph.numNodes()) return emptySequence()
+        val succs = forwardGraph.successorArray(nodeIdx)
+        val outdeg = forwardGraph.outdegree(nodeIdx)
+        val labels = forwardLabels.value
+        val labelStart = cumulativeOutdeg.value[nodeIdx]
         return (0 until outdeg).asSequence().map { i ->
             val to = succs[i]
-            val label = forwardLabels[(labelStart + i).toInt()].toInt() and BYTE_MASK
+            val label = labels[(labelStart + i).toInt()].toInt() and BYTE_MASK
             val key = nodeIdx.toLong() shl INT_BITS or (to.toLong() and UNSIGNED_INT_MASK)
-            val comparison = comparisonMap[key]
+            val comparison = comparisonMap.value[key]
             NodeSerializer.decodeEdge(label, NodeId(nodeIdx), NodeId(to), comparison, nodeDataVersion)
         }
     }
@@ -123,16 +129,21 @@ internal class MappedWebGraphBackedGraph(
             val from = preds[i]
             val label = lookupForwardLabel(from, nodeIdx)
             val key = from.toLong() shl INT_BITS or (nodeIdx.toLong() and UNSIGNED_INT_MASK)
-            val comparison = comparisonMap[key]
+            val comparison = comparisonMap.value[key]
             NodeSerializer.decodeEdge(label, NodeId(from), NodeId(nodeIdx), comparison, nodeDataVersion)
         }
     }
 
     private fun lookupForwardLabel(from: Int, to: Int): Int {
-        val succs = forward.successorArray(from)
-        val outdeg = forward.outdegree(from)
+        val forwardGraph = forward.value
+        val succs = forwardGraph.successorArray(from)
+        val outdeg = forwardGraph.outdegree(from)
         val pos = java.util.Arrays.binarySearch(succs, 0, outdeg, to)
-        return if (pos >= 0) forwardLabels[(cumulativeOutdeg[from] + pos).toInt()].toInt() and BYTE_MASK else 0
+        return if (pos >= 0) {
+            forwardLabels.value[(cumulativeOutdeg.value[from] + pos).toInt()].toInt() and BYTE_MASK
+        } else {
+            0
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -147,25 +158,25 @@ internal class MappedWebGraphBackedGraph(
         nodes(CallSiteNode::class.java).filter { methodPattern.matches(it.callee) }
 
     override fun supertypes(type: TypeDescriptor): Sequence<TypeDescriptor> =
-        metadata.supertypes[type.className]?.asSequence() ?: emptySequence()
+        metadata.value.supertypes[type.className]?.asSequence() ?: emptySequence()
 
     override fun subtypes(type: TypeDescriptor): Sequence<TypeDescriptor> =
-        metadata.subtypes[type.className]?.asSequence() ?: emptySequence()
+        metadata.value.subtypes[type.className]?.asSequence() ?: emptySequence()
 
     override fun methods(pattern: MethodPattern): Sequence<MethodDescriptor> =
-        metadata.methods.values.asSequence().filter { pattern.matches(it) }
+        metadata.value.methods.values.asSequence().filter { pattern.matches(it) }
 
     override fun enumValues(enumClass: String, enumName: String): List<Any?>? =
-        metadata.enumValues["$enumClass#$enumName"]
+        metadata.value.enumValues["$enumClass#$enumName"]
 
     override fun memberAnnotations(className: String, memberName: String): Map<String, Map<String, Any?>> =
-        metadata.memberAnnotations["$className#$memberName"] ?: emptyMap()
+        metadata.value.memberAnnotations["$className#$memberName"] ?: emptyMap()
 
-    override fun classOrigin(className: String): String? = metadata.classOrigins[className]
+    override fun classOrigin(className: String): String? = metadata.value.classOrigins[className]
 
-    override fun classOrigins(): Map<String, String> = metadata.classOrigins
+    override fun classOrigins(): Map<String, String> = metadata.value.classOrigins
 
-    override fun artifactDependencies(): Map<String, Map<String, Int>> = metadata.artifactDependencies
+    override fun artifactDependencies(): Map<String, Map<String, Int>> = metadata.value.artifactDependencies
 
     override fun branchScopes(): Sequence<BranchScope> =
         branchScopeIndex.values.asSequence().flatMap { it.asSequence() }
@@ -174,7 +185,7 @@ internal class MappedWebGraphBackedGraph(
         branchScopeIndex[conditionNodeId.value]?.asSequence() ?: emptySequence()
 
     override fun typeHierarchyTypes(): Set<String> =
-        metadata.supertypes.keys + metadata.subtypes.keys
+        metadata.value.supertypes.keys + metadata.value.subtypes.keys
 
     override fun close() {
         // MappedByteBuffer is unmapped by GC; no explicit unmap in standard API

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/StringTable.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/StringTable.kt
@@ -17,13 +17,13 @@ import java.nio.file.Path
  */
 internal class StringTable private constructor(
     private val list: FrontCodedStringList,
-    private val indexMap: Map<String, Int>
+    private val indexMap: Map<String, Int>?
 ) {
 
     /**
      * Returns the index of [s] in the string table, or -1 if not found.
      */
-    fun indexOf(s: String): Int = indexMap[s] ?: -1
+    fun indexOf(s: String): Int = indexMap?.get(s) ?: -1
 
     /**
      * Returns the string at the given [index].
@@ -63,12 +63,7 @@ internal class StringTable private constructor(
         fun load(dir: Path): StringTable {
             @Suppress("UNCHECKED_CAST")
             val fcl = BinIO.loadObject(dir.resolve(FILE_NAME).toString()) as FrontCodedStringList
-            val sz = fcl.size
-            val indexMap = HashMap<String, Int>(sz)
-            for (i in 0 until sz) {
-                indexMap[fcl.get(i).toString()] = i
-            }
-            return StringTable(fcl, indexMap)
+            return StringTable(fcl, null)
         }
     }
 }

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
@@ -23,6 +23,7 @@ import it.unimi.dsi.webgraph.ImmutableGraph
  * [ControlFlowEdge.comparison] data is stored in a separate map keyed by
  * `(from << 32 | to)`.
  */
+@Suppress("TooManyFunctions")
 internal class WebGraphBackedGraph(
     private val forward: ImmutableGraph,
     private val backward: Lazy<ImmutableGraph>,

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
@@ -63,6 +63,12 @@ internal class WebGraphBackedGraph(
             .flatMap { it.value.asSequence() } as Sequence<T>
     }
 
+    override fun nodeCount(type: Class<out Node>): Long =
+        nodesByType[type]?.size?.toLong()
+            ?: nodesByType.entries.asSequence()
+                .filter { type.isAssignableFrom(it.key) }
+                .sumOf { it.value.size.toLong() }
+
     override fun outgoing(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
         if (nodeIdx >= forward.numNodes()) return emptySequence()

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
@@ -25,7 +25,7 @@ import it.unimi.dsi.webgraph.ImmutableGraph
  */
 internal class WebGraphBackedGraph(
     private val forward: ImmutableGraph,
-    private val backward: ImmutableGraph,
+    private val backward: Lazy<ImmutableGraph>,
     private val nodesById: Map<Int, Node>,
     private val nodeDataVersion: Int,
     private val forwardLabels: ByteArray,
@@ -80,9 +80,10 @@ internal class WebGraphBackedGraph(
 
     override fun incoming(id: NodeId): Sequence<Edge> {
         val nodeIdx = id.value
-        if (nodeIdx >= backward.numNodes()) return emptySequence()
-        val preds = backward.successorArray(nodeIdx)
-        val indeg = backward.outdegree(nodeIdx)
+        val backwardGraph = backward.value
+        if (nodeIdx >= backwardGraph.numNodes()) return emptySequence()
+        val preds = backwardGraph.successorArray(nodeIdx)
+        val indeg = backwardGraph.outdegree(nodeIdx)
         return (0 until indeg).asSequence().map { i ->
             val from = preds[i]
             val label = lookupForwardLabel(from, nodeIdx)

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.input.LoaderConfig
 import io.johnsonlee.graphite.sootup.JavaProjectLoader
 import org.junit.Assume.assumeTrue
+import java.io.Closeable
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -29,20 +30,34 @@ class AndroidSdkIntegrationTest {
         assumeTrue("Android JAR not available", androidJar != null && Files.exists(androidJar!!))
     }
 
+    @org.junit.After
+    fun releaseLargeGraphMemory() {
+        System.gc()
+        System.runFinalization()
+    }
+
     @Test
     fun `load Android SDK and verify millions of nodes`() {
         val graph = loadGraph()
-        val nodeCount = graph.nodes(Node::class.java).count()
-        assertTrue(nodeCount > 1000000, "Android graph should have >1M nodes, got $nodeCount")
+        try {
+            val nodeCount = graph.nodes(Node::class.java).count()
+            assertTrue(nodeCount > 1000000, "Android graph should have >1M nodes, got $nodeCount")
+        } finally {
+            closeQuietly(graph)
+        }
     }
 
     @Test
     fun `Cypher query works on Android graph`() {
         val graph = loadGraph()
-        val result = graph.query("MATCH (n:CallSiteNode) RETURN count(*)")
-        assertTrue(result.rows.isNotEmpty())
-        val count = result.rows[0].values.first()
-        assertTrue((count as Number).toLong() > 10000, "Should have >10K call sites")
+        try {
+            val result = graph.query("MATCH (n:CallSiteNode) RETURN count(*)")
+            assertTrue(result.rows.isNotEmpty())
+            val count = result.rows[0].values.first()
+            assertTrue((count as Number).toLong() > 10000, "Should have >10K call sites")
+        } finally {
+            closeQuietly(graph)
+        }
     }
 
     @Test
@@ -52,10 +67,15 @@ class AndroidSdkIntegrationTest {
         try {
             GraphStore.save(original, dir)
             val loaded = GraphStore.load(dir)
-            val originalCount = original.nodes(Node::class.java).count()
-            val loadedCount = loaded.nodes(Node::class.java).count()
-            assertTrue(loadedCount == originalCount, "Node count should match: $originalCount vs $loadedCount")
+            try {
+                val originalCount = original.nodes(Node::class.java).count()
+                val loadedCount = loaded.nodes(Node::class.java).count()
+                assertTrue(loadedCount == originalCount, "Node count should match: $originalCount vs $loadedCount")
+            } finally {
+                closeQuietly(loaded)
+            }
         } finally {
+            closeQuietly(original)
             dir.toFile().deleteRecursively()
         }
     }
@@ -68,5 +88,9 @@ class AndroidSdkIntegrationTest {
                 trackCrossMethodFunctionalDispatch = false
             )
         ).load(androidJar!!)
+    }
+
+    private fun closeQuietly(graph: Graph) {
+        runCatching { (graph as? Closeable)?.close() }
     }
 }

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
@@ -31,6 +31,7 @@ class AndroidSdkIntegrationTest {
     }
 
     @org.junit.After
+    @Suppress("ExplicitGarbageCollectionCall")
     fun releaseLargeGraphMemory() {
         System.gc()
         System.runFinalization()


### PR DESCRIPTION
## What changed

- Repaired Android-scale JMH fixture handling so large fixture jars are passed to forked JVMs instead of being packed into benchmark jars.
- Deferred mapped/lazy graph edge structures, metadata, and resources until first use, reducing multi-graph open-time heap and load cost.
- Added narrow Cypher fast paths for simple counts, bounded filtered node scans, bounded distinct property queries, and bounded single-hop relationship queries.
- Loaded the persisted node index in one primitive pass.
- Repaired the SootUp Android build benchmark harness and documented every attempt/result/root cause under `docs/webgraph-storage.md`.
- Stabilized Android integration tests by closing large graphs and forcing cleanup between class methods.

## Why

Serving multiple microservice graphs on one machine is constrained by open-time heap and unnecessary full scans. A single persisted graph can be around 500 MB, so opening many graphs must avoid eagerly loading edge/metadata structures unless a query actually needs them.

## Validation

- `./gradlew :cypher:test :webgraph:test :sootup:test`
- `./gradlew :webgraph:jmh -Pjmh.filter='AndroidLoadBenchmark.mapped_load'`
- `./gradlew :webgraph:jmh -Pjmh.filter='AndroidQueryBenchmark.mapped_.*'`
- `./gradlew :sootup:jmh -Pjmh.filter='GraphBuildBenchmark.buildAndroidSdkGraph' --rerun-tasks`
- `./gradlew :webgraph:jmh -Pjmh.filter='GraphEndToEndBenchmark.android_build_save_load_query' --rerun-tasks`

Key Android-scale results are recorded in `docs/webgraph-storage.md`: mapped load improved from `2292.892 ms/op` to `176.097 ms/op`; bounded query shapes improved by one or more orders of magnitude.