### PR TITLE
Publish only the unified Graphite CLI artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,17 +107,16 @@ jobs:
         cd tap
         mkdir -p Formula
 
-        cat > Formula/graphite@2.0.rb <<RUBY
-        class GraphiteAT20 < Formula
+        cat > Formula/graphite.rb <<RUBY
+        class Graphite < Formula
           desc "Build, query, and serve Graphite static analysis graphs"
           homepage "https://github.com/johnsonlee/graphite"
+          url "https://github.com/johnsonlee/graphite/releases/download/v${RELEASE_VERSION}/graphite.jar"
           version "${RELEASE_VERSION}"
-          url "https://github.com/johnsonlee/graphite/releases/download/v#{version}/graphite.jar"
           sha256 "${QUERY_SHA}"
           license "Apache-2.0"
 
           depends_on "openjdk@17"
-          conflicts_with "graphite", because: "both install the graphite executable"
 
           def install
             libexec.install "graphite.jar"
@@ -147,7 +146,7 @@ jobs:
                   PASSTHROUGH_ARGS+=("\$arg")
                 fi
               done
-              exec "#{Formula["openjdk@17"].opt_bin}/java" \$AGENT_ARGS -jar "#{libexec}/graphite.jar" "\${PASSTHROUGH_ARGS[@]}"
+              exec "#{formula_opt_bin("openjdk@17")}/java" \$AGENT_ARGS -jar "#{libexec}/graphite.jar" "\${PASSTHROUGH_ARGS[@]}"
             EOS
           end
 
@@ -157,17 +156,16 @@ jobs:
         end
         RUBY
 
-        cat > Formula/graphite-explore@2.0.rb <<RUBY
-        class GraphiteExploreAT20 < Formula
+        cat > Formula/graphite-explore.rb <<RUBY
+        class GraphiteExplore < Formula
           desc "Interactive web visualization for Graphite static analysis graphs"
           homepage "https://github.com/johnsonlee/graphite"
+          url "https://github.com/johnsonlee/graphite/releases/download/v${RELEASE_VERSION}/graphite-explore.jar"
           version "${RELEASE_VERSION}"
-          url "https://github.com/johnsonlee/graphite/releases/download/v#{version}/graphite-explore.jar"
           sha256 "${EXPLORE_SHA}"
           license "Apache-2.0"
 
           depends_on "openjdk@17"
-          conflicts_with "graphite-explore", because: "both install the graphite-explore executable"
 
           def install
             libexec.install "graphite-explore.jar"
@@ -197,7 +195,7 @@ jobs:
                   PASSTHROUGH_ARGS+=("\$arg")
                 fi
               done
-              exec "#{Formula["openjdk@17"].opt_bin}/java" \$AGENT_ARGS -jar "#{libexec}/graphite-explore.jar" "\${PASSTHROUGH_ARGS[@]}"
+              exec "#{formula_opt_bin("openjdk@17")}/java" \$AGENT_ARGS -jar "#{libexec}/graphite-explore.jar" "\${PASSTHROUGH_ARGS[@]}"
             EOS
           end
 
@@ -209,8 +207,10 @@ jobs:
 
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        # Keep existing 1.0/unversioned formulae in the tap untouched.
-        git add Formula/graphite@2.0.rb Formula/graphite-explore@2.0.rb
+        # The unversioned formulae track the current release. Version-pinned
+        # formulae are maintained directly in the tap without cutting duplicate
+        # Graphite releases.
+        git add Formula/graphite.rb Formula/graphite-explore.rb
         if ! git diff --cached --quiet; then
           git commit -m "graphite ${RELEASE_VERSION}"
           git push origin main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,10 +78,9 @@ jobs:
         echo "RELEASE_VERSION=${RELEASE_TAG#v}" >> "${GITHUB_ENV}"
     - name: Build CLI shadow JARs
       run: |
-        ./gradlew :query:shadowJar :explore:shadowJar --no-daemon -Pversion=${RELEASE_VERSION}
+        ./gradlew :query:shadowJar --no-daemon -Pversion=${RELEASE_VERSION}
         mkdir -p release-assets
         cp graphite-query/build/libs/graphite.jar release-assets/graphite.jar
-        cp graphite-explore/build/libs/graphite-explore.jar release-assets/graphite-explore.jar
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
@@ -101,7 +100,6 @@ jobs:
         fi
 
         QUERY_SHA=$(sha256sum release-assets/graphite.jar | awk '{print $1}')
-        EXPLORE_SHA=$(sha256sum release-assets/graphite-explore.jar | awk '{print $1}')
 
         git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/johnsonlee/homebrew-tap.git" tap
         cd tap
@@ -156,61 +154,12 @@ jobs:
         end
         RUBY
 
-        cat > Formula/graphite-explore.rb <<RUBY
-        class GraphiteExplore < Formula
-          desc "Interactive web visualization for Graphite static analysis graphs"
-          homepage "https://github.com/johnsonlee/graphite"
-          url "https://github.com/johnsonlee/graphite/releases/download/v${RELEASE_VERSION}/graphite-explore.jar"
-          version "${RELEASE_VERSION}"
-          sha256 "${EXPLORE_SHA}"
-          license "Apache-2.0"
-
-          depends_on "openjdk@17"
-
-          def install
-            libexec.install "graphite-explore.jar"
-            (bin/"graphite-explore").write <<~EOS
-              #!/bin/bash
-              export JAVA_TOOL_OPTIONS="\${JAVA_TOOL_OPTIONS:-\${JAVA_OPTS:--Xmx8g}}"
-              AGENT_ARGS=""
-              PASSTHROUGH_ARGS=()
-              for arg in "\$@"; do
-                if [ "\$arg" = "--profile" ]; then
-                  PROFILE_OUT="\${GRAPHITE_PROFILE:-profile.html}"
-                  AP_LIB=""
-                  ASPROF="\$(which asprof 2>/dev/null)"
-                  if [ -n "\$ASPROF" ]; then
-                    AP_DIR="\$(dirname "\$ASPROF")/../lib"
-                    for ext in dylib so; do
-                      [ -f "\$AP_DIR/libasyncProfiler.\$ext" ] && AP_LIB="\$AP_DIR/libasyncProfiler.\$ext" && break
-                    done
-                  fi
-                  if [ -n "\$AP_LIB" ]; then
-                    AGENT_ARGS="-agentpath:\$AP_LIB=start,event=cpu,file=\$PROFILE_OUT"
-                  else
-                    echo "async-profiler not found. Install: brew install async-profiler" >&2
-                    exit 1
-                  fi
-                else
-                  PASSTHROUGH_ARGS+=("\$arg")
-                fi
-              done
-              exec "#{formula_opt_bin("openjdk@17")}/java" \$AGENT_ARGS -jar "#{libexec}/graphite-explore.jar" "\${PASSTHROUGH_ARGS[@]}"
-            EOS
-          end
-
-          test do
-            assert_match "Usage", shell_output("#{bin}/graphite-explore --help")
-          end
-        end
-        RUBY
-
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         # The unversioned formulae track the current release. Version-pinned
         # formulae are maintained directly in the tap without cutting duplicate
         # Graphite releases.
-        git add Formula/graphite.rb Formula/graphite-explore.rb
+        git add Formula/graphite.rb
         if ! git diff --cached --quiet; then
           git commit -m "graphite ${RELEASE_VERSION}"
           git push origin main
@@ -235,9 +184,9 @@ jobs:
           exit 1
         fi
         echo "RELEASE_VERSION=${RELEASE_TAG#v}" >> "${GITHUB_ENV}"
-    - name: Download explore jar from GitHub Release
+    - name: Download graphite jar from GitHub Release
       run: |
-        gh release download "${RELEASE_TAG}" -p "graphite-explore.jar" -D .
+        gh release download "${RELEASE_TAG}" -p "graphite.jar" -D .
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: docker/setup-qemu-action@v3

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For LLMs, this difference is critical. A syntax tree tells you what code *looks 
 ```bash
 # Install via Homebrew
 brew tap johnsonlee/tap
-brew install graphite@2.0
+brew install graphite
 
 # Build a graph from your JAR
 graphite build app.jar -o /data/app-graph --include com.example

--- a/graphite-explore/Dockerfile
+++ b/graphite-explore/Dockerfile
@@ -1,11 +1,12 @@
 # syntax=docker/dockerfile:1.7
 #
 # Runtime-only image — no build stage needed.
-# The shadow jar is pre-built by CI and passed via build arg.
+# The unified Graphite CLI shadow jar is pre-built by CI and downloaded from
+# the GitHub Release before building this runtime image.
 #
 # Usage:
 #   docker build -f graphite-explore/Dockerfile \
-#     --build-arg JAR=graphite-explore.jar -t graphite-explore .
+#     -t graphite-explore .
 #
 #   docker run --rm -p 8080:8080 -v /path/to/graph:/data graphite-explore /data
 
@@ -24,7 +25,7 @@ RUN groupadd --system --gid 1000 graphite \
  && useradd  --system --uid 1000 --gid graphite --home /home/graphite --create-home graphite
 
 WORKDIR /app
-COPY graphite-explore.jar /app/graphite-explore.jar
+COPY graphite.jar /app/graphite.jar
 
 USER graphite:graphite
 
@@ -33,5 +34,5 @@ ENV JAVA_TOOL_OPTIONS="-Xmx4g"
 EXPOSE 8080
 VOLUME ["/data"]
 
-ENTRYPOINT ["java", "-jar", "/app/graphite-explore.jar"]
+ENTRYPOINT ["java", "-jar", "/app/graphite.jar", "serve"]
 CMD ["/data"]


### PR DESCRIPTION
## Summary

- Updates the publish workflow so future Graphite releases update the unversioned `graphite` Homebrew formula.
- Stops generating `graphite@2.0` / `graphite-explore@2.0` formulas from the release workflow.
- Stops building and uploading the standalone `graphite-explore.jar` release asset; v2 ships the unified `graphite.jar` CLI with `graphite serve`.
- Updates the Docker image build to download `graphite.jar` and run `java -jar /app/graphite.jar serve`.
- Keeps version-pinned formulas as tap-maintained files, so Homebrew-only formula corrections do not require cutting duplicate Graphite releases.
- Updates the README Homebrew install command to `brew install graphite`.

## Validation

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml")'
rg -n "graphite-explore\.jar|Formula/graphite-explore\.rb|EXPLORE_SHA|:explore:shadowJar|graphite-explore@2\.0|brew install graphite@2\.0|Formula\[\"openjdk@17\"\]" .github/workflows/publish.yml README.md graphite-explore/Dockerfile || true
git diff --check
./gradlew :query:shadowJar --no-daemon -Pversion=2.0.1-test
java -jar graphite-query/build/libs/graphite.jar --help
java -jar graphite-query/build/libs/graphite.jar serve --help
```

Results: all commands passed. Docker cannot be built locally here because Docker is not installed, but the Dockerfile now copies the same `graphite.jar` artifact that the workflow downloads from the release.