### PR TITLE
Support building graphs directly from Android APKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ curl -X PUT http://localhost:8080/api/graphs/orders \
 ```
 
 For APK inputs, Graphite uses Android platform jars to resolve the APK's target
-API level. Pass `--android-sdk` with either the SDK `platforms` directory
-or the Android SDK root. If omitted, Graphite searches in this order:
+API level. Pass `--android-sdk` with the Android SDK root. If omitted,
+Graphite searches in this order:
 
-1. `ANDROID_PLATFORMS`, `ANDROID_HOME`, then `ANDROID_SDK_ROOT`.
+1. `ANDROID_HOME`, then `ANDROID_SDK_ROOT`.
 2. Default SDK roots for the current OS:
    - macOS: `~/Library/Android/sdk`,
      `/opt/homebrew/share/android-commandlinetools`,

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ curl -X PUT http://localhost:8080/api/graphs/orders \
 ```
 
 For APK inputs, Graphite uses Android platform jars to resolve the APK's target
-API level. Pass `--android-platforms` with either the SDK `platforms` directory
+API level. Pass `--android-sdk` with either the SDK `platforms` directory
 or the Android SDK root. If omitted, Graphite first checks `ANDROID_PLATFORMS`,
 `ANDROID_HOME`, and `ANDROID_SDK_ROOT`, then checks common platform SDK install
 locations, then infers SDK roots from `adb`, `emulator`, or `sdkmanager` on

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ brew install graphite
 # Build a graph from your JAR
 graphite build app.jar -o /data/app-graph --include com.example
 
+# Build a graph from an Android APK
+graphite build app.apk \
+  -o /data/apk-graph \
+  --include com.example
+
 # Query with Cypher
 graphite query /data/app-graph \
   "MATCH (c:IntConstant)-[:DATAFLOW*]->(cs:CallSiteNode)
@@ -91,6 +96,13 @@ curl -X PUT http://localhost:8080/api/graphs/orders \
   -H 'Content-Type: application/json' \
   -d '{"path":"/data/graphs/orders-graph-v2"}'
 ```
+
+For APK inputs, Graphite uses Android platform jars to resolve the APK's target
+API level. Pass `--android-platforms` with either the SDK `platforms` directory
+or the Android SDK root. If omitted, Graphite first checks `ANDROID_PLATFORMS`,
+`ANDROID_HOME`, and `ANDROID_SDK_ROOT`, then checks common platform SDK install
+locations, then infers SDK roots from `adb`, `emulator`, or `sdkmanager` on
+`PATH`.
 
 ## Kotlin API
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,17 @@ curl -X PUT http://localhost:8080/api/graphs/orders \
 
 For APK inputs, Graphite uses Android platform jars to resolve the APK's target
 API level. Pass `--android-sdk` with either the SDK `platforms` directory
-or the Android SDK root. If omitted, Graphite first checks `ANDROID_PLATFORMS`,
-`ANDROID_HOME`, and `ANDROID_SDK_ROOT`, then checks common platform SDK install
-locations, then infers SDK roots from `adb`, `emulator`, or `sdkmanager` on
-`PATH`.
+or the Android SDK root. If omitted, Graphite searches in this order:
+
+1. `ANDROID_PLATFORMS`, `ANDROID_HOME`, then `ANDROID_SDK_ROOT`.
+2. Default SDK roots for the current OS:
+   - macOS: `~/Library/Android/sdk`,
+     `/opt/homebrew/share/android-commandlinetools`,
+     `/usr/local/share/android-commandlinetools`
+   - Linux: `~/Android/Sdk`, `~/android-sdk`, `/opt/android-sdk`,
+     `/usr/local/android-sdk`, `/usr/lib/android-sdk`
+   - Windows: `%USERPROFILE%\AppData\Local\Android\Sdk`
+3. SDK roots inferred from `adb`, `emulator`, or `sdkmanager` on `PATH`.
 
 ## Kotlin API
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraph.kt
@@ -27,6 +27,7 @@ import java.io.EOFException
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 
@@ -54,7 +55,6 @@ class MmapGraph internal constructor(
     private val nodeIndex: LongArray,
     private val nodeTypeIndex: Map<Class<out Node>, IntArray>,
     private val outgoingIndex: EdgeOffsetIndex,
-    private val incomingIndex: EdgeOffsetIndex,
     private val nodeMethods: List<MethodDescriptor>,
     private val nodeTypes: List<TypeDescriptor>,
     private val methodIndex: Map<String, MethodDescriptor>,
@@ -64,6 +64,7 @@ class MmapGraph internal constructor(
     private val artifactDependenciesMap: Map<String, Map<String, Int>>,
     private val memberAnnotationsMap: Map<String, Map<String, Map<String, Any?>>>,
     private val branchScopeData: List<DefaultGraph.RawBranchScope>,
+    incomingIndex: EdgeOffsetIndex?,
     override val resources: ResourceAccessor
 ) : Graph, Closeable {
 
@@ -72,6 +73,9 @@ class MmapGraph internal constructor(
     }
     private val edgeMmap: ByteBuffer = FileChannel.open(dataDir.resolve("edges.dat"), StandardOpenOption.READ).use {
         it.map(FileChannel.MapMode.READ_ONLY, 0, it.size())
+    }
+    private val incomingIndex: EdgeOffsetIndex by lazy {
+        incomingIndex ?: buildIncomingEdgeOffsetIndex()
     }
 
     private val branchScopeIndex: Map<Int, List<BranchScope>> by lazy {
@@ -88,8 +92,24 @@ class MmapGraph internal constructor(
 
     internal data class EdgeOffsetIndex(
         val starts: IntArray,
-        val offsets: LongArray
+        val offsets: LongOffsetIndex
     )
+
+    internal interface LongOffsetIndex {
+        operator fun get(position: Int): Long
+    }
+
+    internal class HeapLongOffsetIndex(private val offsets: LongArray) : LongOffsetIndex {
+        override fun get(position: Int): Long = offsets[position]
+    }
+
+    internal class MappedLongOffsetIndex(path: Path) : LongOffsetIndex {
+        private val offsets: ByteBuffer = FileChannel.open(path, StandardOpenOption.READ).use {
+            it.map(FileChannel.MapMode.READ_ONLY, 0, it.size())
+        }
+
+        override fun get(position: Int): Long = offsets.getLong(position * Long.SIZE_BYTES)
+    }
 
     override fun node(id: NodeId): Node? {
         val nodeId = id.value
@@ -251,6 +271,100 @@ class MmapGraph internal constructor(
         val end = index.starts[nodeId + 1]
         if (start == end) return emptySequence()
         return (start until end).asSequence().map { position -> index.offsets[position] }
+    }
+
+    private fun buildIncomingEdgeOffsetIndex(): EdgeOffsetIndex {
+        val counts = IntArray(nodeIndex.size)
+        var totalEdges = 0
+        val countBuf = edgeMmap.duplicate()
+        while (countBuf.hasRemaining()) {
+            countBuf.int
+            val to = countBuf.int
+            counts[to]++
+            skipEdgePayload(countBuf)
+            totalEdges++
+        }
+
+        val starts = buildPrefixStarts(counts)
+        if (totalEdges == 0) {
+            return EdgeOffsetIndex(starts, HeapLongOffsetIndex(LongArray(0)))
+        }
+        val offsetsFile = Files.createTempFile(dataDir, "incoming-offsets", ".dat")
+        val offsets = createMappedLongOffsetIndex(offsetsFile, totalEdges)
+        System.arraycopy(starts, 0, counts, 0, counts.size)
+
+        val fillBuf = edgeMmap.duplicate()
+        while (fillBuf.hasRemaining()) {
+            val recordOffset = fillBuf.position().toLong()
+            fillBuf.int
+            val to = fillBuf.int
+            skipEdgePayload(fillBuf)
+            offsets.putLong(counts[to]++, recordOffset)
+        }
+
+        return EdgeOffsetIndex(starts, MappedLongOffsetIndex(offsetsFile))
+    }
+
+    internal class WritableLongOffsetIndex private constructor(
+        private val channel: FileChannel,
+        private val buffer: ByteBuffer
+    ) : Closeable {
+        fun putLong(position: Int, value: Long) {
+            buffer.putLong(position * Long.SIZE_BYTES, value)
+        }
+
+        override fun close() {
+            channel.close()
+        }
+
+        companion object {
+            fun create(path: Path, entries: Int): WritableLongOffsetIndex {
+                val bytes = entries.toLong() * Long.SIZE_BYTES
+                require(bytes <= Int.MAX_VALUE) {
+                    "Memory-mapped edge offset indexes support at most ${Int.MAX_VALUE / Long.SIZE_BYTES} edges"
+                }
+                val channel = FileChannel.open(
+                    path,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.READ,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING
+                )
+                channel.truncate(bytes)
+                val buffer = channel.map(FileChannel.MapMode.READ_WRITE, 0, bytes)
+                return WritableLongOffsetIndex(channel, buffer)
+            }
+        }
+    }
+
+    internal companion object {
+        fun createMappedLongOffsetIndex(path: Path, entries: Int): WritableLongOffsetIndex =
+            WritableLongOffsetIndex.create(path, entries)
+    }
+
+    private fun skipEdgePayload(buf: ByteBuffer) {
+        when (buf.get().toInt()) {
+            MmapGraphBuilder.TAG_EDGE_DATAFLOW,
+            MmapGraphBuilder.TAG_EDGE_CALL,
+            MmapGraphBuilder.TAG_EDGE_TYPE,
+            MmapGraphBuilder.TAG_EDGE_RESOURCE -> buf.get()
+            MmapGraphBuilder.TAG_EDGE_CONTROL_FLOW -> {
+                buf.get()
+                if (buf.get().toInt() == 1) {
+                    buf.get()
+                    buf.int
+                }
+            }
+            else -> error("Unknown edge type tag")
+        }
+    }
+
+    private fun buildPrefixStarts(counts: IntArray): IntArray {
+        val starts = IntArray(counts.size + 1)
+        for (i in counts.indices) {
+            starts[i + 1] = starts[i] + counts[i]
+        }
+        return starts
     }
 
     internal class ByteBufferInputStream(private val buf: ByteBuffer) : InputStream() {

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraphBuilder.kt
@@ -183,40 +183,35 @@ class MmapGraphBuilder(
         nodeStream.close()
         edgeStream.close()
 
-        // Build indexes by scanning compact record headers sequentially.
-        // Node payloads stay on disk; deserializing every node here was pure
-        // build-time overhead because MmapGraph will decode nodes on demand.
-        var nodeOffsets = LongArray(INITIAL_NODE_INDEX_CAPACITY) { -1L }
-        var maxNodeId = -1
-        val nodeTypeIndexBuilder = HashMap<Class<out Node>, IntArrayBuilder>()
+        val nodeFile = workDir.resolve(NODES_FILE).toFile()
+        val nodeFileLen = nodeFile.length()
+        val (maxNodeId, nodeTypeCounts) = scanNodeIndexShape(nodeFile, nodeFileLen)
+        val nodeIndex = if (maxNodeId >= 0) LongArray(maxNodeId + 1) { -1L } else LongArray(0)
+        val nodeTypeArrays = nodeTypeCounts.mapValues { (_, count) -> IntArray(count) }
+        val nodeTypeCursors = HashMap<Class<out Node>, Int>(nodeTypeArrays.size)
 
         var offset = 0L
-        DataInputStream(workDir.resolve(NODES_FILE).toFile().inputStream().buffered()).use { dis ->
-            val fileLen = workDir.resolve(NODES_FILE).toFile().length()
-            while (offset < fileLen) {
+        DataInputStream(nodeFile.inputStream().buffered()).use { dis ->
+            while (offset < nodeFileLen) {
                 val len = dis.readInt()
                 val nodeId = dis.readInt()
                 val tag = dis.readByte().toInt()
                 skipFully(dis, len - NODE_ID_BYTES - NODE_TAG_BYTES)
-                if (nodeId >= nodeOffsets.size) {
-                    nodeOffsets = growLongArray(nodeOffsets, nodeId + 1)
-                }
-                nodeOffsets[nodeId] = offset
-                maxNodeId = maxOf(maxNodeId, nodeId)
-                nodeTypeIndexBuilder.getOrPut(nodeClassForTag(tag)) { IntArrayBuilder() }.add(nodeId)
+                nodeIndex[nodeId] = offset
+                val nodeClass = nodeClassForTag(tag)
+                val cursor = nodeTypeCursors[nodeClass] ?: 0
+                nodeTypeArrays.getValue(nodeClass)[cursor] = nodeId
+                nodeTypeCursors[nodeClass] = cursor + 1
                 offset += LENGTH_PREFIX_BYTES + len
             }
         }
-
-        val nodeIndex = if (maxNodeId >= 0) nodeOffsets.copyOf(maxNodeId + 1) else LongArray(0)
-        val nodeTypeIndex = nodeTypeIndexBuilder.mapValues { (_, ids) -> ids.toIntArray() }
+        val nodeTypeIndex = nodeTypeArrays
         val nodeCapacity = nodeIndex.size
         require(edgeCount <= Int.MAX_VALUE.toLong()) {
             "MmapGraphBuilder supports at most ${Int.MAX_VALUE} edges in memory-mapped indexes, got $edgeCount"
         }
         val totalEdges = edgeCount.toInt()
         val outgoingCounts = IntArray(nodeCapacity)
-        val incomingCounts = IntArray(nodeCapacity)
 
         offset = 0L
         val edgeFile = workDir.resolve(EDGES_FILE).toFile()
@@ -224,31 +219,14 @@ class MmapGraphBuilder(
         DataInputStream(edgeFile.inputStream().buffered()).use { edgeDis ->
             while (offset < edgeFileLen) {
                 val from = edgeDis.readInt()
-                val to = edgeDis.readInt()
+                edgeDis.readInt()
                 outgoingCounts[from]++
-                incomingCounts[to]++
                 offset += EDGE_ENDPOINT_BYTES + skipEdgePayload(edgeDis)
             }
         }
 
         val outgoingStarts = buildPrefixStarts(outgoingCounts)
-        val incomingStarts = buildPrefixStarts(incomingCounts)
-        val outgoingOffsets = LongArray(totalEdges)
-        val incomingOffsets = LongArray(totalEdges)
-        val outgoingCursor = outgoingStarts.copyOf(outgoingStarts.size - 1)
-        val incomingCursor = incomingStarts.copyOf(incomingStarts.size - 1)
-
-        offset = 0L
-        DataInputStream(edgeFile.inputStream().buffered()).use { edgeDis ->
-            while (offset < edgeFileLen) {
-                val recordOffset = offset
-                val from = edgeDis.readInt()
-                val to = edgeDis.readInt()
-                offset += EDGE_ENDPOINT_BYTES + skipEdgePayload(edgeDis)
-                outgoingOffsets[outgoingCursor[from]++] = recordOffset
-                incomingOffsets[incomingCursor[to]++] = recordOffset
-            }
-        }
+        val outgoingOffsetIndex = buildOutgoingEdgeOffsetIndex(edgeFile, edgeFileLen, totalEdges, outgoingStarts, outgoingCounts)
 
         val methodIndex = LinkedHashMap<String, MethodDescriptor>(methods.size)
         methods.forEach { methodIndex[it.signature] = it }
@@ -257,8 +235,7 @@ class MmapGraphBuilder(
             dataDir = workDir,
             nodeIndex = nodeIndex,
             nodeTypeIndex = nodeTypeIndex,
-            outgoingIndex = MmapGraph.EdgeOffsetIndex(outgoingStarts, outgoingOffsets),
-            incomingIndex = MmapGraph.EdgeOffsetIndex(incomingStarts, incomingOffsets),
+            outgoingIndex = MmapGraph.EdgeOffsetIndex(outgoingStarts, outgoingOffsetIndex),
             nodeMethods = nodeMethods.toList(),
             nodeTypes = nodeTypes.toList(),
             methodIndex = methodIndex,
@@ -268,14 +245,43 @@ class MmapGraphBuilder(
             artifactDependenciesMap = artifactDependencies.mapValues { (_, deps) -> deps.toMap() },
             memberAnnotationsMap = memberAnnotations.mapValues { it.value.toMap() },
             branchScopeData = branchScopes.toList(),
+            incomingIndex = null,
             resources = resourceAccessor
         )
+    }
+
+    private fun buildOutgoingEdgeOffsetIndex(
+        edgeFile: File,
+        edgeFileLen: Long,
+        totalEdges: Int,
+        outgoingStarts: IntArray,
+        outgoingCounts: IntArray
+    ): MmapGraph.LongOffsetIndex {
+        if (totalEdges == 0) {
+            return MmapGraph.HeapLongOffsetIndex(LongArray(0))
+        }
+
+        val outgoingOffsetsFile = workDir.resolve(OUTGOING_OFFSETS_FILE)
+        System.arraycopy(outgoingStarts, 0, outgoingCounts, 0, outgoingCounts.size)
+        MmapGraph.createMappedLongOffsetIndex(outgoingOffsetsFile, totalEdges).use { outgoingOffsets ->
+            var offset = 0L
+            DataInputStream(edgeFile.inputStream().buffered()).use { edgeDis ->
+                while (offset < edgeFileLen) {
+                    val recordOffset = offset
+                    val from = edgeDis.readInt()
+                    edgeDis.readInt()
+                    offset += EDGE_ENDPOINT_BYTES + skipEdgePayload(edgeDis)
+                    outgoingOffsets.putLong(outgoingCounts[from]++, recordOffset)
+                }
+            }
+        }
+        return MmapGraph.MappedLongOffsetIndex(outgoingOffsetsFile)
     }
 
     companion object {
         private const val NODES_FILE = "nodes.dat"
         private const val EDGES_FILE = "edges.dat"
-        private const val INITIAL_NODE_INDEX_CAPACITY = 16
+        private const val OUTGOING_OFFSETS_FILE = "outgoing-offsets.dat"
         private const val LENGTH_PREFIX_BYTES = 4
         private const val NODE_ID_BYTES = 4
         private const val NODE_TAG_BYTES = 1
@@ -559,12 +565,22 @@ class MmapGraphBuilder(
             return String(bytes, Charsets.UTF_8)
         }
 
-        private fun growLongArray(current: LongArray, minSize: Int): LongArray {
-            var newSize = current.size
-            while (newSize < minSize) {
-                newSize = maxOf(newSize * 2, 1)
+        private fun scanNodeIndexShape(nodeFile: File, fileLen: Long): Pair<Int, Map<Class<out Node>, Int>> {
+            var maxNodeId = -1
+            val nodeTypeCounts = HashMap<Class<out Node>, Int>()
+            var offset = 0L
+            DataInputStream(nodeFile.inputStream().buffered()).use { dis ->
+                while (offset < fileLen) {
+                    val len = dis.readInt()
+                    val nodeId = dis.readInt()
+                    val tag = dis.readByte().toInt()
+                    skipFully(dis, len - NODE_ID_BYTES - NODE_TAG_BYTES)
+                    maxNodeId = maxOf(maxNodeId, nodeId)
+                    nodeTypeCounts.merge(nodeClassForTag(tag), 1, Int::plus)
+                    offset += LENGTH_PREFIX_BYTES + len
+                }
             }
-            return LongArray(newSize) { index -> if (index < current.size) current[index] else -1L }
+            return maxNodeId to nodeTypeCounts
         }
 
         private fun buildPrefixStarts(counts: IntArray): IntArray {
@@ -759,19 +775,5 @@ class MmapGraphBuilder(
     private class ReusableByteArrayOutputStream(initialSize: Int) : ByteArrayOutputStream(initialSize) {
         val capacity: Int
             get() = buf.size
-    }
-
-    private class IntArrayBuilder(initialSize: Int = INITIAL_NODE_INDEX_CAPACITY) {
-        private var values = IntArray(initialSize)
-        private var size = 0
-
-        fun add(value: Int) {
-            if (size == values.size) {
-                values = values.copyOf(values.size * 2)
-            }
-            values[size++] = value
-        }
-
-        fun toIntArray(): IntArray = values.copyOf(size)
     }
 }

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
@@ -68,12 +68,12 @@ data class LoaderConfig(
     val callGraphAlgorithm: CallGraphAlgorithm = CallGraphAlgorithm.CHA,
 
     /**
-     * Android platform directory used when loading APK inputs.
+     * Android SDK location used when loading APK inputs.
      *
      * Accepts either a platforms directory containing android-<api>/android.jar
      * entries, or an Android SDK root containing a platforms directory.
      */
-    val androidPlatforms: Path? = null,
+    val androidSdk: Path? = null,
 
     /**
      * Verbose logging callback

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
@@ -70,8 +70,7 @@ data class LoaderConfig(
     /**
      * Android SDK location used when loading APK inputs.
      *
-     * Accepts either a platforms directory containing android-<api>/android.jar
-     * entries, or an Android SDK root containing a platforms directory.
+     * Must be an Android SDK root containing a platforms directory.
      */
     val androidSdk: Path? = null,
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ProjectLoader.kt
@@ -68,6 +68,14 @@ data class LoaderConfig(
     val callGraphAlgorithm: CallGraphAlgorithm = CallGraphAlgorithm.CHA,
 
     /**
+     * Android platform directory used when loading APK inputs.
+     *
+     * Accepts either a platforms directory containing android-<api>/android.jar
+     * entries, or an Android SDK root containing a platforms directory.
+     */
+    val androidPlatforms: Path? = null,
+
+    /**
      * Verbose logging callback
      */
     val verbose: ((String) -> Unit)? = null

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphOffsetIndexTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/MmapGraphOffsetIndexTest.kt
@@ -1,0 +1,99 @@
+package io.johnsonlee.graphite.graph
+
+import io.johnsonlee.graphite.core.BranchComparison
+import io.johnsonlee.graphite.core.CallEdge
+import io.johnsonlee.graphite.core.ComparisonOp
+import io.johnsonlee.graphite.core.ControlFlowEdge
+import io.johnsonlee.graphite.core.ControlFlowKind
+import io.johnsonlee.graphite.core.DataFlowEdge
+import io.johnsonlee.graphite.core.DataFlowKind
+import io.johnsonlee.graphite.core.IntConstant
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.ResourceEdge
+import io.johnsonlee.graphite.core.ResourceRelation
+import io.johnsonlee.graphite.core.TypeEdge
+import io.johnsonlee.graphite.core.TypeRelation
+import java.nio.file.Files
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MmapGraphOffsetIndexTest {
+
+    @BeforeTest
+    fun resetNodeId() {
+        NodeId.reset()
+    }
+
+    @Test
+    fun `lazy incoming index scans every edge payload variant`() {
+        val source = NodeId(0)
+        val dataTarget = NodeId(1)
+        val callTarget = NodeId(2)
+        val typeTarget = NodeId(3)
+        val controlTarget = NodeId(4)
+        val comparedControlTarget = NodeId(5)
+        val resourceTarget = NodeId(6)
+        val comparisonValue = NodeId(7)
+        val dataEdge = DataFlowEdge(source, dataTarget, DataFlowKind.ASSIGN)
+        val callEdge = CallEdge(source, callTarget, isVirtual = true, isDynamic = true)
+        val typeEdge = TypeEdge(source, typeTarget, TypeRelation.IMPLEMENTS)
+        val controlEdge = ControlFlowEdge(source, controlTarget, ControlFlowKind.SEQUENTIAL)
+        val comparedControlEdge = ControlFlowEdge(
+            source,
+            comparedControlTarget,
+            ControlFlowKind.BRANCH_TRUE,
+            BranchComparison(ComparisonOp.GT, comparisonValue)
+        )
+        val resourceEdge = ResourceEdge(source, resourceTarget, ResourceRelation.LOADS)
+        val graph = MmapGraphBuilder()
+            .addNode(IntConstant(source, 0))
+            .addNode(IntConstant(dataTarget, 1))
+            .addNode(IntConstant(callTarget, 2))
+            .addNode(IntConstant(typeTarget, 3))
+            .addNode(IntConstant(controlTarget, 4))
+            .addNode(IntConstant(comparedControlTarget, 5))
+            .addNode(IntConstant(resourceTarget, 6))
+            .addNode(IntConstant(comparisonValue, 7))
+            .addEdge(dataEdge)
+            .addEdge(callEdge)
+            .addEdge(typeEdge)
+            .addEdge(controlEdge)
+            .addEdge(comparedControlEdge)
+            .addEdge(resourceEdge)
+            .build()
+
+        assertEquals(listOf(dataEdge), graph.incoming(dataTarget).toList())
+        assertEquals(listOf(callEdge), graph.incoming(callTarget).toList())
+        assertEquals(listOf(typeEdge), graph.incoming(typeTarget).toList())
+        assertEquals(listOf(controlEdge), graph.incoming(controlTarget).toList())
+        assertEquals(listOf(comparedControlEdge), graph.incoming(comparedControlTarget).toList())
+        assertEquals(listOf(resourceEdge), graph.incoming(resourceTarget).toList())
+    }
+
+    @Test
+    fun `long offset indexes read heap and mapped offsets`() {
+        val heapIndex = MmapGraph.HeapLongOffsetIndex(longArrayOf(17L, 23L))
+        assertEquals(17L, heapIndex[0])
+        assertEquals(23L, heapIndex[1])
+
+        val offsetsFile = Files.createTempFile("graphite-offset-index", ".dat")
+        try {
+            MmapGraph.createMappedLongOffsetIndex(offsetsFile, 2).use { offsets ->
+                offsets.putLong(0, 123L)
+                offsets.putLong(1, 456L)
+            }
+
+            val index = MmapGraph.MappedLongOffsetIndex(offsetsFile)
+            assertEquals(123L, index[0])
+            assertEquals(456L, index[1])
+
+            assertFailsWith<IllegalArgumentException> {
+                MmapGraph.createMappedLongOffsetIndex(offsetsFile, Int.MAX_VALUE / Long.SIZE_BYTES + 1)
+            }
+        } finally {
+            Files.deleteIfExists(offsetsFile)
+        }
+    }
+}

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
@@ -50,7 +50,7 @@ class LoaderConfigTest {
             extractAnnotations = false,
             trackCrossMethodFunctionalDispatch = false,
             callGraphAlgorithm = CallGraphAlgorithm.RTA,
-            androidSdk = Path.of("/opt/android-sdk/platforms"),
+            androidSdk = Path.of("/opt/android-sdk"),
             verbose = { verboseCalled = true }
         )
 
@@ -62,7 +62,7 @@ class LoaderConfigTest {
         assertFalse(config.extractAnnotations)
         assertFalse(config.trackCrossMethodFunctionalDispatch)
         assertEquals(CallGraphAlgorithm.RTA, config.callGraphAlgorithm)
-        assertEquals(Path.of("/opt/android-sdk/platforms"), config.androidSdk)
+        assertEquals(Path.of("/opt/android-sdk"), config.androidSdk)
 
         config.verbose?.invoke("test")
         assertTrue(verboseCalled)

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
@@ -1,5 +1,6 @@
 package io.johnsonlee.graphite.input
 
+import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,6 +20,7 @@ class LoaderConfigTest {
         assertTrue(config.extractAnnotations)
         assertTrue(config.trackCrossMethodFunctionalDispatch)
         assertEquals(CallGraphAlgorithm.CHA, config.callGraphAlgorithm)
+        assertNull(config.androidPlatforms)
         assertNull(config.verbose)
     }
 
@@ -48,6 +50,7 @@ class LoaderConfigTest {
             extractAnnotations = false,
             trackCrossMethodFunctionalDispatch = false,
             callGraphAlgorithm = CallGraphAlgorithm.RTA,
+            androidPlatforms = Path.of("/opt/android-sdk/platforms"),
             verbose = { verboseCalled = true }
         )
 
@@ -59,6 +62,7 @@ class LoaderConfigTest {
         assertFalse(config.extractAnnotations)
         assertFalse(config.trackCrossMethodFunctionalDispatch)
         assertEquals(CallGraphAlgorithm.RTA, config.callGraphAlgorithm)
+        assertEquals(Path.of("/opt/android-sdk/platforms"), config.androidPlatforms)
 
         config.verbose?.invoke("test")
         assertTrue(verboseCalled)

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/LoaderConfigTest.kt
@@ -20,7 +20,7 @@ class LoaderConfigTest {
         assertTrue(config.extractAnnotations)
         assertTrue(config.trackCrossMethodFunctionalDispatch)
         assertEquals(CallGraphAlgorithm.CHA, config.callGraphAlgorithm)
-        assertNull(config.androidPlatforms)
+        assertNull(config.androidSdk)
         assertNull(config.verbose)
     }
 
@@ -50,7 +50,7 @@ class LoaderConfigTest {
             extractAnnotations = false,
             trackCrossMethodFunctionalDispatch = false,
             callGraphAlgorithm = CallGraphAlgorithm.RTA,
-            androidPlatforms = Path.of("/opt/android-sdk/platforms"),
+            androidSdk = Path.of("/opt/android-sdk/platforms"),
             verbose = { verboseCalled = true }
         )
 
@@ -62,7 +62,7 @@ class LoaderConfigTest {
         assertFalse(config.extractAnnotations)
         assertFalse(config.trackCrossMethodFunctionalDispatch)
         assertEquals(CallGraphAlgorithm.RTA, config.callGraphAlgorithm)
-        assertEquals(Path.of("/opt/android-sdk/platforms"), config.androidPlatforms)
+        assertEquals(Path.of("/opt/android-sdk/platforms"), config.androidSdk)
 
         config.verbose?.invoke("test")
         assertTrue(verboseCalled)

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/query/QueryDslTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/query/QueryDslTest.kt
@@ -22,6 +22,7 @@ import io.johnsonlee.graphite.core.MethodDescriptor
 import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.core.NullConstant
+import io.johnsonlee.graphite.core.ResourceValueNode
 import io.johnsonlee.graphite.core.ReturnNode
 import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeDescriptor
@@ -573,6 +574,14 @@ class QueryDslTest {
         val enumConst = EnumConstant(enumId, TypeDescriptor("com.example.Status"), "ACTIVE")
         val nullId = NodeId.next()
         val nullConst = NullConstant(nullId)
+        val resourceIds = listOf(
+            ResourceValueNode(NodeId.next(), "app.yml", "int", 7, "yaml"),
+            ResourceValueNode(NodeId.next(), "app.yml", "long", 8L, "yaml"),
+            ResourceValueNode(NodeId.next(), "app.yml", "float", 1.25f, "yaml"),
+            ResourceValueNode(NodeId.next(), "app.yml", "double", 2.5, "yaml"),
+            ResourceValueNode(NodeId.next(), "app.yml", "boolean", true, "yaml"),
+            ResourceValueNode(NodeId.next(), "app.yml", "string", "enabled", "yaml")
+        )
 
         val returnId = NodeId.next()
         val returnNode = ReturnNode(returnId, method)
@@ -587,6 +596,7 @@ class QueryDslTest {
         builder.addNode(strConst)
         builder.addNode(enumConst)
         builder.addNode(nullConst)
+        resourceIds.forEach(builder::addNode)
         builder.addNode(returnNode)
         builder.addEdge(DataFlowEdge(intId, returnId, DataFlowKind.ASSIGN))
         builder.addEdge(DataFlowEdge(longId, returnId, DataFlowKind.ASSIGN))
@@ -596,6 +606,7 @@ class QueryDslTest {
         builder.addEdge(DataFlowEdge(strId, returnId, DataFlowKind.ASSIGN))
         builder.addEdge(DataFlowEdge(enumId, returnId, DataFlowKind.ASSIGN))
         builder.addEdge(DataFlowEdge(nullId, returnId, DataFlowKind.ASSIGN))
+        resourceIds.forEach { builder.addEdge(DataFlowEdge(it.id, returnId, DataFlowKind.ASSIGN)) }
         val graph = builder.build()
 
         val query = GraphiteQuery(graph)

--- a/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
+++ b/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
@@ -11,10 +11,10 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.Callable
 
-@Command(name = "build", description = ["Build graph from JAR/WAR/directory and save to disk"])
+@Command(name = "build", description = ["Build graph from JAR/WAR/APK/directory and save to disk"])
 class BuildCommand : Callable<Int> {
 
-    @Parameters(index = "0", description = ["Input JAR, WAR, or class directory"])
+    @Parameters(index = "0", description = ["Input JAR, WAR, APK, or class directory"])
     lateinit var input: Path
 
     @Option(names = ["-o", "--output"], description = ["Output directory for saved graph"], required = true)
@@ -26,8 +26,19 @@ class BuildCommand : Callable<Int> {
     @Option(names = ["--exclude"], description = ["Package prefixes to exclude (comma-separated)"], split = ",")
     var excludePackages: List<String> = emptyList()
 
-    @Option(names = ["--include-libs"], description = ["Include library JARs from WEB-INF/lib or BOOT-INF/lib"])
+    @Option(
+        names = ["--include-libs"],
+        description = ["Include library JARs from WEB-INF/lib or BOOT-INF/lib, or Android platform classes for APK inputs"]
+    )
     var includeLibs: Boolean = false
+
+    @Option(
+        names = ["--android-platforms"],
+        description = [
+            "Android platforms directory or SDK root for APK inputs; defaults to env, standard SDK paths, or Android tools on PATH"
+        ]
+    )
+    var androidPlatforms: Path? = null
 
     @Option(names = ["--lib-filter"], description = ["Only load JARs matching these patterns (comma-separated)"], split = ",")
     var libFilters: List<String> = emptyList()
@@ -48,6 +59,7 @@ class BuildCommand : Callable<Int> {
                 includeLibraries = includeLibs,
                 libraryFilters = libFilters,
                 buildCallGraph = true,
+                androidPlatforms = androidPlatforms,
                 verbose = if (verbose) { msg -> System.err.println(msg) } else null
             )
 

--- a/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
+++ b/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
@@ -35,7 +35,16 @@ class BuildCommand : Callable<Int> {
     @Option(
         names = ["--android-sdk"],
         description = [
-            "Android SDK root (or platforms directory) for APK inputs; defaults to env, standard SDK paths, or Android tools on PATH"
+            "Android SDK root (or platforms directory) for APK inputs.",
+            "When omitted, search order is:",
+            "1) ANDROID_PLATFORMS, 2) ANDROID_HOME, 3) ANDROID_SDK_ROOT.",
+            "4) Default roots for the current OS:",
+            "   macOS: ~/Library/Android/sdk, /opt/homebrew/share/android-commandlinetools, " +
+                "/usr/local/share/android-commandlinetools.",
+            "   Linux: ~/Android/Sdk, ~/android-sdk, /opt/android-sdk, " +
+                "/usr/local/android-sdk, /usr/lib/android-sdk.",
+            "   Windows: %USERPROFILE%\\AppData\\Local\\Android\\Sdk.",
+            "5) SDK roots inferred from adb, emulator, or sdkmanager on PATH."
         ]
     )
     var androidSdk: Path? = null

--- a/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
+++ b/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
@@ -33,12 +33,12 @@ class BuildCommand : Callable<Int> {
     var includeLibs: Boolean = false
 
     @Option(
-        names = ["--android-platforms"],
+        names = ["--android-sdk"],
         description = [
-            "Android platforms directory or SDK root for APK inputs; defaults to env, standard SDK paths, or Android tools on PATH"
+            "Android SDK root (or platforms directory) for APK inputs; defaults to env, standard SDK paths, or Android tools on PATH"
         ]
     )
-    var androidPlatforms: Path? = null
+    var androidSdk: Path? = null
 
     @Option(names = ["--lib-filter"], description = ["Only load JARs matching these patterns (comma-separated)"], split = ",")
     var libFilters: List<String> = emptyList()
@@ -59,7 +59,7 @@ class BuildCommand : Callable<Int> {
                 includeLibraries = includeLibs,
                 libraryFilters = libFilters,
                 buildCallGraph = true,
-                androidPlatforms = androidPlatforms,
+                androidSdk = androidSdk,
                 verbose = if (verbose) { msg -> System.err.println(msg) } else null
             )
 

--- a/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
+++ b/graphite-query/src/main/kotlin/io/johnsonlee/graphite/cli/BuildCommand.kt
@@ -35,16 +35,16 @@ class BuildCommand : Callable<Int> {
     @Option(
         names = ["--android-sdk"],
         description = [
-            "Android SDK root (or platforms directory) for APK inputs.",
+            "Android SDK root for APK inputs.",
             "When omitted, search order is:",
-            "1) ANDROID_PLATFORMS, 2) ANDROID_HOME, 3) ANDROID_SDK_ROOT.",
-            "4) Default roots for the current OS:",
+            "1) ANDROID_HOME, 2) ANDROID_SDK_ROOT.",
+            "3) Default roots for the current OS:",
             "   macOS: ~/Library/Android/sdk, /opt/homebrew/share/android-commandlinetools, " +
                 "/usr/local/share/android-commandlinetools.",
             "   Linux: ~/Android/Sdk, ~/android-sdk, /opt/android-sdk, " +
                 "/usr/local/android-sdk, /usr/lib/android-sdk.",
-            "   Windows: %USERPROFILE%\\AppData\\Local\\Android\\Sdk.",
-            "5) SDK roots inferred from adb, emulator, or sdkmanager on PATH."
+            "   Windows: %%USERPROFILE%%\\AppData\\Local\\Android\\Sdk.",
+            "4) SDK roots inferred from adb, emulator, or sdkmanager on PATH."
         ]
     )
     var androidSdk: Path? = null

--- a/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
+++ b/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
@@ -56,7 +56,6 @@ class GraphiteCommandTest {
         val normalizedHelp = help.replace(Regex("\\s+"), " ")
 
         assertTrue(help.contains("--android-sdk"), "Help should contain Android SDK option, got: $help")
-        assertTrue(help.contains("ANDROID_PLATFORMS"), "Help should contain env priority, got: $help")
         assertTrue(help.contains("ANDROID_HOME"), "Help should contain env priority, got: $help")
         assertTrue(help.contains("ANDROID_SDK_ROOT"), "Help should contain env priority, got: $help")
         assertTrue(help.contains("~/Library/Android/sdk"), "Help should contain macOS default path, got: $help")

--- a/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
+++ b/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
@@ -2,8 +2,10 @@ package io.johnsonlee.graphite.cli
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
+import java.io.PrintWriter
 import java.nio.file.Files
 import java.nio.file.Path
+import picocli.CommandLine
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -45,6 +47,29 @@ class GraphiteCommandTest {
     // ========================================================================
     // BuildCommand
     // ========================================================================
+
+    @Test
+    fun `build help describes android sdk discovery order`() {
+        val outBaos = ByteArrayOutputStream()
+        CommandLine(BuildCommand()).usage(PrintWriter(outBaos, true))
+        val help = outBaos.toString()
+        val normalizedHelp = help.replace(Regex("\\s+"), " ")
+
+        assertTrue(help.contains("--android-sdk"), "Help should contain Android SDK option, got: $help")
+        assertTrue(help.contains("ANDROID_PLATFORMS"), "Help should contain env priority, got: $help")
+        assertTrue(help.contains("ANDROID_HOME"), "Help should contain env priority, got: $help")
+        assertTrue(help.contains("ANDROID_SDK_ROOT"), "Help should contain env priority, got: $help")
+        assertTrue(help.contains("~/Library/Android/sdk"), "Help should contain macOS default path, got: $help")
+        assertTrue(help.contains("~/Android/Sdk"), "Help should contain Linux default path, got: $help")
+        assertTrue(
+            help.contains("%USERPROFILE%\\AppData\\Local\\Android\\Sdk"),
+            "Help should contain Windows default path, got: $help"
+        )
+        assertTrue(
+            normalizedHelp.contains("adb, emulator, or sdkmanager"),
+            "Help should contain PATH tool fallback, got: $help"
+        )
+    }
 
     @Test
     fun `build from nonexistent path returns error`() {

--- a/graphite-sootup/build.gradle.kts
+++ b/graphite-sootup/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(libs.sootup.core)
     implementation(libs.sootup.java.core)
     implementation(libs.sootup.java.bytecode.frontend)
+    implementation(libs.sootup.apk.frontend)
     implementation(libs.sootup.callgraph)
     implementation(libs.asm)  // For parsing generic signatures from bytecode
     implementation(libs.gson)

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/ArchiveResourceAccessor.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/ArchiveResourceAccessor.kt
@@ -17,7 +17,7 @@ private const val GLOBSTAR_SLASH_LENGTH = 3
 private const val GLOBSTAR_LENGTH = 2
 
 /**
- * [ResourceAccessor] that supports directories, JARs, Spring Boot fat JARs, and WAR files.
+ * [ResourceAccessor] that supports directories, JARs, Spring Boot fat JARs, WAR files, and APK files.
  *
  * For fat JARs / WARs, resources inside nested JARs are also accessible.
  * are also accessible.
@@ -82,7 +82,7 @@ class ArchiveResourceAccessor private constructor(
                     sources.add(DirectorySource(path))
                     collectDirectoryJars(path).appendTo(sources, closers)
                 }
-                path.extension.lowercase() == "jar" -> {
+                path.extension.lowercase() in listOf("jar", "apk") -> {
                     val zip = ZipFile(path.toFile())
                     val hasBootInf = zip.getEntry(JavaArchiveLayout.BOOT_INF_CLASSES) != null
                     if (hasBootInf) {
@@ -143,7 +143,7 @@ class ArchiveResourceAccessor private constructor(
                 stream.filter { Files.isRegularFile(it) }
                     .filter {
                         when (it.fileName.toString().substringAfterLast('.', "").lowercase()) {
-                            "jar", "war", "zip" -> true
+                            "jar", "war", "zip", "apk" -> true
                             else -> false
                         }
                     }
@@ -226,7 +226,7 @@ private class DirectorySource(private val root: Path) : ResourceSource {
 
     private fun isArchive(path: Path): Boolean =
         when (path.fileName.toString().substringAfterLast('.', "").lowercase()) {
-            "jar", "war", "zip" -> true
+            "jar", "war", "zip", "apk" -> true
             else -> false
         }
 }

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
@@ -7,10 +7,15 @@ import io.johnsonlee.graphite.graph.MmapGraphBuilder
 import io.johnsonlee.graphite.input.LoaderConfig
 import io.johnsonlee.graphite.input.JavaArchiveLayout
 import io.johnsonlee.graphite.input.ProjectLoader
+import sootup.apk.frontend.ApkAnalysisInputLocation
+import sootup.apk.frontend.DexBodyInterceptors
+import sootup.apk.frontend.main.AndroidVersionInfo
 import sootup.core.inputlocation.AnalysisInputLocation
 import sootup.core.model.SourceType
+import sootup.java.bytecode.frontend.inputlocation.JavaClassPathAnalysisInputLocation
 import sootup.java.bytecode.frontend.inputlocation.PathBasedAnalysisInputLocation
 import sootup.java.core.views.JavaView
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.zip.ZipEntry
@@ -21,6 +26,198 @@ import kotlin.io.path.isDirectory
 private const val JAR_EXTENSION_NAME = "jar"
 private const val WAR_EXTENSION_NAME = "war"
 private const val ZIP_EXTENSION_NAME = "zip"
+private const val APK_EXTENSION_NAME = "apk"
+private const val ANDROID_JAR_NAME = "android.jar"
+private const val ANDROID_PLATFORM_PREFIX = "android-"
+private const val ANDROID_PLATFORMS_DIR = "platforms"
+private const val ANDROID_PLATFORMS_ENV = "ANDROID_PLATFORMS"
+private const val ANDROID_HOME_ENV = "ANDROID_HOME"
+private const val ANDROID_SDK_ROOT_ENV = "ANDROID_SDK_ROOT"
+private const val PATH_ENV = "PATH"
+private const val MAC_OS_NAME = "mac"
+private const val DARWIN_OS_NAME = "darwin"
+private const val WINDOWS_OS_NAME = "win"
+private const val ANDROID_DIR_NAME = "Android"
+private const val ANDROID_SDK_DIR_NAME = "Sdk"
+private val ANDROID_TOOL_NAMES = listOf("adb", "emulator", "sdkmanager")
+
+private data class InputLocations(
+    val locations: List<AnalysisInputLocation>,
+    val sources: Map<AnalysisInputLocation, String>
+)
+
+private fun createApkInputLocations(
+    path: Path,
+    config: LoaderConfig,
+    log: (String) -> Unit
+): InputLocations {
+    val platforms = resolveAndroidPlatformsPath(config)
+    val apkLocation = ApkAnalysisInputLocation(
+        path,
+        platforms.toString(),
+        DexBodyInterceptors.Default.bodyInterceptors()
+    )
+    val locations = mutableListOf<AnalysisInputLocation>(apkLocation)
+    val sources = mutableMapOf<AnalysisInputLocation, String>(apkLocation to path.fileName.toString())
+
+    if (config.includeLibraries) {
+        val androidJar = resolveAndroidJar(path, platforms)
+        val sourceName = platforms.relativize(androidJar).toString().replace('\\', '/')
+        val androidJarLocation = JavaClassPathAnalysisInputLocation(androidJar.toString(), SourceType.Library)
+        locations.add(androidJarLocation)
+        sources[androidJarLocation] = sourceName
+        log("  + Loading Android platform: $sourceName")
+    }
+
+    return InputLocations(locations, sources)
+}
+
+private fun resolveAndroidPlatformsPath(config: LoaderConfig): Path {
+    val configured = config.androidPlatforms ?: findAndroidPlatformsFromEnvironment()
+    if (configured != null) {
+        return validateAndroidPlatformsPath(configured)
+    }
+    return discoverAndroidPlatformsPath()
+        ?: throw IllegalArgumentException(
+            "APK input requires Android platforms. Pass --android-platforms <dir>, set " +
+                "$ANDROID_PLATFORMS_ENV, $ANDROID_HOME_ENV, or $ANDROID_SDK_ROOT_ENV, " +
+                "install the Android SDK in a default location, or put adb, emulator, " +
+                "or sdkmanager on PATH."
+        )
+}
+
+private fun validateAndroidPlatformsPath(path: Path): Path {
+    val normalized = normalizeAndroidPlatformsPath(path.toAbsolutePath().normalize())
+    require(Files.isDirectory(normalized)) {
+        "Android platforms path does not exist: $normalized"
+    }
+    require(containsAndroidPlatformJar(normalized)) {
+        "Android platforms path must contain android-<api>/android.jar entries: $normalized"
+    }
+    return normalized
+}
+
+private fun findAndroidPlatformsFromEnvironment(environment: Map<String, String> = System.getenv()): Path? =
+    environmentPath(environment, ANDROID_PLATFORMS_ENV)
+        ?: environmentPath(environment, ANDROID_HOME_ENV)
+        ?: environmentPath(environment, ANDROID_SDK_ROOT_ENV)
+
+private fun environmentPath(environment: Map<String, String>, name: String): Path? =
+    environment[name]?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
+
+private fun discoverAndroidPlatformsPath(
+    defaultRoots: List<Path> = defaultAndroidSdkRoots(),
+    pathValue: String? = System.getenv(PATH_ENV)
+): Path? =
+    findValidAndroidPlatformsPath(defaultRoots)
+        ?: findValidAndroidPlatformsPath(androidSdkRootsFromTools(pathValue))
+
+private fun defaultAndroidSdkRoots(
+    osName: String = System.getProperty("os.name").orEmpty(),
+    userHome: Path? = System.getProperty("user.home")?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
+): List<Path> {
+    val roots = linkedSetOf<Path>()
+    val lowerOsName = osName.lowercase()
+
+    when {
+        MAC_OS_NAME in lowerOsName || DARWIN_OS_NAME in lowerOsName -> {
+            userHome?.let { roots.add(it.resolve("Library").resolve(ANDROID_DIR_NAME).resolve("sdk")) }
+            roots.add(Path.of("/opt/homebrew/share/android-commandlinetools"))
+            roots.add(Path.of("/usr/local/share/android-commandlinetools"))
+        }
+        WINDOWS_OS_NAME in lowerOsName -> {
+            userHome?.let {
+                roots.add(it.resolve("AppData").resolve("Local").resolve(ANDROID_DIR_NAME).resolve(ANDROID_SDK_DIR_NAME))
+            }
+        }
+        else -> {
+            userHome?.let {
+                roots.add(it.resolve(ANDROID_DIR_NAME).resolve(ANDROID_SDK_DIR_NAME))
+                roots.add(it.resolve("android-sdk"))
+            }
+            roots.add(Path.of("/opt/android-sdk"))
+            roots.add(Path.of("/usr/local/android-sdk"))
+            roots.add(Path.of("/usr/lib/android-sdk"))
+        }
+    }
+
+    return roots.toList()
+}
+
+private fun androidSdkRootsFromTools(pathValue: String?): List<Path> =
+    executablePathsFromPath(pathValue)
+        .flatMap(::candidateAndroidSdkRootsForTool)
+        .distinct()
+
+private fun executablePathsFromPath(pathValue: String?): List<Path> {
+    if (pathValue.isNullOrBlank()) {
+        return emptyList()
+    }
+    return pathValue.split(File.pathSeparator)
+        .asSequence()
+        .filter { it.isNotBlank() }
+        .map { Path.of(it) }
+        .flatMap { dir ->
+            ANDROID_TOOL_NAMES.asSequence()
+                .flatMap(::androidToolExecutableNames)
+                .map { dir.resolve(it) }
+        }
+        .filter { Files.isRegularFile(it) }
+        .toList()
+}
+
+private fun androidToolExecutableNames(toolName: String): Sequence<String> =
+    sequenceOf(toolName, "$toolName.exe", "$toolName.bat", "$toolName.cmd")
+        .distinct()
+
+private fun candidateAndroidSdkRootsForTool(toolPath: Path): List<Path> =
+    sequenceOf(toolPath.toAbsolutePath().normalize(), realPathOrNull(toolPath))
+        .filterNotNull()
+        .flatMap { path -> path.ancestors() }
+        .distinct()
+        .toList()
+
+private fun realPathOrNull(path: Path): Path? =
+    runCatching { path.toRealPath().normalize() }.getOrNull()
+
+private fun Path.ancestors(): Sequence<Path> =
+    generateSequence(parent) { it.parent }
+
+private fun findValidAndroidPlatformsPath(candidates: Iterable<Path>): Path? =
+    candidates.asSequence()
+        .map { normalizeAndroidPlatformsPath(it.toAbsolutePath().normalize()) }
+        .distinct()
+        .firstOrNull(::containsAndroidPlatformJar)
+
+private fun normalizeAndroidPlatformsPath(path: Path): Path =
+    when {
+        containsAndroidPlatformJar(path) -> path
+        containsAndroidPlatformJar(path.resolve(ANDROID_PLATFORMS_DIR)) -> path.resolve(ANDROID_PLATFORMS_DIR)
+        else -> path
+    }
+
+private fun containsAndroidPlatformJar(path: Path): Boolean {
+    if (!Files.isDirectory(path)) {
+        return false
+    }
+    return Files.list(path).use { stream ->
+        stream.anyMatch { child ->
+            Files.isDirectory(child) &&
+                child.fileName.toString().startsWith(ANDROID_PLATFORM_PREFIX) &&
+                Files.isRegularFile(child.resolve(ANDROID_JAR_NAME))
+        }
+    }
+}
+
+private fun resolveAndroidJar(apkPath: Path, platforms: Path): Path {
+    val versionInfo = AndroidVersionInfo(apkPath, platforms.toString())
+    val api = versionInfo.getApi_version()
+    val androidJar = platforms.resolve("$ANDROID_PLATFORM_PREFIX$api").resolve(ANDROID_JAR_NAME)
+    require(Files.isRegularFile(androidJar)) {
+        "Android platform android.jar not found for API $api: $androidJar"
+    }
+    return androidJar
+}
 
 /**
  * SootUp-based loader for Java projects.
@@ -28,6 +225,7 @@ private const val ZIP_EXTENSION_NAME = "zip"
  * Supports loading from various sources:
  * - JAR files
  * - WAR files
+ * - APK files
  * - Directories containing .class files
  * - Spring Boot fat JARs (BOOT-INF layout)
  */
@@ -77,17 +275,13 @@ class JavaProjectLoader(
             return true
         }
         val ext = path.extension.lowercase()
-        return ext in listOf(JAR_EXTENSION_NAME, WAR_EXTENSION_NAME, ZIP_EXTENSION_NAME)
+        return ext in listOf(JAR_EXTENSION_NAME, WAR_EXTENSION_NAME, ZIP_EXTENSION_NAME, APK_EXTENSION_NAME)
     }
-
-    private data class InputLocations(
-        val locations: List<AnalysisInputLocation>,
-        val sources: Map<AnalysisInputLocation, String>
-    )
 
     private fun createInputLocations(path: Path): InputLocations {
         return when {
             path.isDirectory() -> createDirectoryInputLocations(path)
+            path.extension.lowercase() == APK_EXTENSION_NAME -> createApkInputLocations(path, config, ::log)
             isSpringBootJar(path) -> createSpringBootInputLocations(path)
             isWarFile(path) -> createWarInputLocations(path)
             else -> {

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
@@ -73,13 +73,13 @@ private fun createApkInputLocations(
 }
 
 private fun resolveAndroidPlatformsPath(config: LoaderConfig): Path {
-    val configured = config.androidPlatforms ?: findAndroidPlatformsFromEnvironment()
+    val configured = config.androidSdk ?: findAndroidPlatformsFromEnvironment()
     if (configured != null) {
         return validateAndroidPlatformsPath(configured)
     }
     return discoverAndroidPlatformsPath()
         ?: throw IllegalArgumentException(
-            "APK input requires Android platforms. Pass --android-platforms <dir>, set " +
+            "APK input requires an Android SDK. Pass --android-sdk <dir>, set " +
                 "$ANDROID_PLATFORMS_ENV, $ANDROID_HOME_ENV, or $ANDROID_SDK_ROOT_ENV, " +
                 "install the Android SDK in a default location, or put adb, emulator, " +
                 "or sdkmanager on PATH."
@@ -87,12 +87,14 @@ private fun resolveAndroidPlatformsPath(config: LoaderConfig): Path {
 }
 
 private fun validateAndroidPlatformsPath(path: Path): Path {
-    val normalized = normalizeAndroidPlatformsPath(path.toAbsolutePath().normalize())
+    val requested = path.toAbsolutePath().normalize()
+    val normalized = normalizeAndroidPlatformsPath(requested)
     require(Files.isDirectory(normalized)) {
-        "Android platforms path does not exist: $normalized"
+        "Android SDK path does not exist: $requested"
     }
     require(containsAndroidPlatformJar(normalized)) {
-        "Android platforms path must contain android-<api>/android.jar entries: $normalized"
+        "Android SDK path must be an SDK root or platforms directory containing " +
+            "android-<api>/android.jar entries: $requested"
     }
     return normalized
 }

--- a/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
+++ b/graphite-sootup/src/main/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoader.kt
@@ -30,7 +30,6 @@ private const val APK_EXTENSION_NAME = "apk"
 private const val ANDROID_JAR_NAME = "android.jar"
 private const val ANDROID_PLATFORM_PREFIX = "android-"
 private const val ANDROID_PLATFORMS_DIR = "platforms"
-private const val ANDROID_PLATFORMS_ENV = "ANDROID_PLATFORMS"
 private const val ANDROID_HOME_ENV = "ANDROID_HOME"
 private const val ANDROID_SDK_ROOT_ENV = "ANDROID_SDK_ROOT"
 private const val PATH_ENV = "PATH"
@@ -73,35 +72,33 @@ private fun createApkInputLocations(
 }
 
 private fun resolveAndroidPlatformsPath(config: LoaderConfig): Path {
-    val configured = config.androidSdk ?: findAndroidPlatformsFromEnvironment()
+    val configured = config.androidSdk ?: findAndroidSdkRootFromEnvironment()
     if (configured != null) {
-        return validateAndroidPlatformsPath(configured)
+        return validateAndroidSdkRoot(configured)
     }
     return discoverAndroidPlatformsPath()
         ?: throw IllegalArgumentException(
-            "APK input requires an Android SDK. Pass --android-sdk <dir>, set " +
-                "$ANDROID_PLATFORMS_ENV, $ANDROID_HOME_ENV, or $ANDROID_SDK_ROOT_ENV, " +
+            "APK input requires an Android SDK. Pass --android-sdk <sdk-root>, set " +
+                "$ANDROID_HOME_ENV or $ANDROID_SDK_ROOT_ENV, " +
                 "install the Android SDK in a default location, or put adb, emulator, " +
                 "or sdkmanager on PATH."
         )
 }
 
-private fun validateAndroidPlatformsPath(path: Path): Path {
+private fun validateAndroidSdkRoot(path: Path): Path {
     val requested = path.toAbsolutePath().normalize()
-    val normalized = normalizeAndroidPlatformsPath(requested)
-    require(Files.isDirectory(normalized)) {
-        "Android SDK path does not exist: $requested"
+    val platforms = requested.resolve(ANDROID_PLATFORMS_DIR)
+    require(Files.isDirectory(requested)) {
+        "Android SDK root does not exist: $requested"
     }
-    require(containsAndroidPlatformJar(normalized)) {
-        "Android SDK path must be an SDK root or platforms directory containing " +
-            "android-<api>/android.jar entries: $requested"
+    require(containsAndroidPlatformJar(platforms)) {
+        "Android SDK root must contain platforms/android-<api>/android.jar entries: $requested"
     }
-    return normalized
+    return platforms
 }
 
-private fun findAndroidPlatformsFromEnvironment(environment: Map<String, String> = System.getenv()): Path? =
-    environmentPath(environment, ANDROID_PLATFORMS_ENV)
-        ?: environmentPath(environment, ANDROID_HOME_ENV)
+private fun findAndroidSdkRootFromEnvironment(environment: Map<String, String> = System.getenv()): Path? =
+    environmentPath(environment, ANDROID_HOME_ENV)
         ?: environmentPath(environment, ANDROID_SDK_ROOT_ENV)
 
 private fun environmentPath(environment: Map<String, String>, name: String): Path? =
@@ -187,16 +184,9 @@ private fun Path.ancestors(): Sequence<Path> =
 
 private fun findValidAndroidPlatformsPath(candidates: Iterable<Path>): Path? =
     candidates.asSequence()
-        .map { normalizeAndroidPlatformsPath(it.toAbsolutePath().normalize()) }
+        .map { it.toAbsolutePath().normalize().resolve(ANDROID_PLATFORMS_DIR) }
         .distinct()
         .firstOrNull(::containsAndroidPlatformJar)
-
-private fun normalizeAndroidPlatformsPath(path: Path): Path =
-    when {
-        containsAndroidPlatformJar(path) -> path
-        containsAndroidPlatformJar(path.resolve(ANDROID_PLATFORMS_DIR)) -> path.resolve(ANDROID_PLATFORMS_DIR)
-        else -> path
-    }
 
 private fun containsAndroidPlatformJar(path: Path): Boolean {
     if (!Files.isDirectory(path)) {

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ArchiveResourceAccessorTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/ArchiveResourceAccessorTest.kt
@@ -7,6 +7,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -229,6 +231,27 @@ class ArchiveResourceAccessorTest {
         }
     }
 
+    @Test
+    fun `create from APK lists Android resources`() {
+        val apkFile = createTempZip(
+            extension = ".apk",
+            entries = mapOf(
+                "AndroidManifest.xml" to "manifest",
+                "assets/config.json" to "{\"enabled\":true}",
+                "res/raw/settings.json" to "{}"
+            )
+        )
+        try {
+            val accessor = ArchiveResourceAccessor.create(apkFile.toPath())
+            val entries = accessor.list("**").toList()
+            assertTrue(entries.any { it.path == "AndroidManifest.xml" })
+            assertTrue(entries.any { it.path == "assets/config.json" })
+            assertEquals("{\"enabled\":true}", accessor.open("assets/config.json").bufferedReader().readText())
+        } finally {
+            apkFile.delete()
+        }
+    }
+
     // ========================================================================
     // Spring Boot fat JAR (NestedJarSource)
     // ========================================================================
@@ -340,6 +363,18 @@ class ArchiveResourceAccessorTest {
                 jos.putNextEntry(JarEntry(name))
                 jos.write(content)
                 jos.closeEntry()
+            }
+        }
+        return file
+    }
+
+    private fun createTempZip(extension: String, entries: Map<String, String>): File {
+        val file = File.createTempFile("test", extension)
+        ZipOutputStream(file.outputStream()).use { zos ->
+            entries.forEach { (name, content) ->
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(content.toByteArray())
+                zos.closeEntry()
             }
         }
         return file

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
@@ -89,7 +89,7 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android platforms resolution accepts sdk root and platforms directory`() {
+    fun `android SDK resolution accepts sdk root and platforms directory`() {
         val sdkRoot = Files.createTempDirectory("graphite-android-sdk-root")
         val platformsFromRoot = Files.createDirectories(sdkRoot.resolve("platforms"))
         val directPlatforms = Files.createTempDirectory("graphite-android-platforms")
@@ -102,7 +102,7 @@ class JavaProjectLoaderTest {
                 invokeLoaderFilePrivate<Path>(
                     "resolveAndroidPlatformsPath",
                     arrayOf(LoaderConfig::class.java),
-                    LoaderConfig(androidPlatforms = sdkRoot)
+                    LoaderConfig(androidSdk = sdkRoot)
                 )
             )
             assertEquals(
@@ -110,7 +110,7 @@ class JavaProjectLoaderTest {
                 invokeLoaderFilePrivate<Path>(
                     "resolveAndroidPlatformsPath",
                     arrayOf(LoaderConfig::class.java),
-                    LoaderConfig(androidPlatforms = directPlatforms)
+                    LoaderConfig(androidSdk = directPlatforms)
                 )
             )
             assertTrue(
@@ -134,18 +134,18 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android platforms environment lookup keeps configured priority`() {
-        val androidPlatforms = Path.of("/env/platforms")
+    fun `android SDK environment lookup keeps configured priority`() {
+        val androidSdk = Path.of("/env/platforms")
         val androidHome = Path.of("/env/home")
         val androidSdkRoot = Path.of("/env/sdk-root")
 
         assertEquals(
-            androidPlatforms,
+            androidSdk,
             invokeLoaderFilePrivate<Path>(
                 "findAndroidPlatformsFromEnvironment",
                 arrayOf(Map::class.java),
                 mapOf(
-                    "ANDROID_PLATFORMS" to androidPlatforms.toString(),
+                    "ANDROID_PLATFORMS" to androidSdk.toString(),
                     "ANDROID_HOME" to androidHome.toString(),
                     "ANDROID_SDK_ROOT" to androidSdkRoot.toString()
                 )
@@ -180,7 +180,7 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android platforms discovery includes platform default install roots`() {
+    fun `android SDK discovery includes platform default install roots`() {
         val home = Path.of("/home/tester")
 
         val macRoots = invokeLoaderFilePrivate<List<Path>>(
@@ -214,7 +214,7 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android platforms discovery tries default roots before tool paths`() {
+    fun `android SDK discovery tries default roots before tool paths`() {
         val defaultSdkRoot = Files.createTempDirectory("graphite-default-android-sdk")
         val toolSdkRoot = Files.createTempDirectory("graphite-tool-android-sdk")
         val defaultPlatforms = Files.createDirectories(defaultSdkRoot.resolve("platforms"))
@@ -241,7 +241,7 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android platforms discovery infers sdk roots from android tools on path`() {
+    fun `android SDK discovery infers sdk roots from android tools on path`() {
         val sdkRoot = Files.createTempDirectory("graphite-tool-path-android-sdk")
         val platforms = Files.createDirectories(sdkRoot.resolve("platforms"))
         val platformToolsDir = Files.createDirectories(sdkRoot.resolve("platform-tools"))
@@ -270,7 +270,7 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android platforms discovery returns null when no fallback candidates are valid`() {
+    fun `android SDK discovery returns null when no fallback candidates are valid`() {
         assertNull(
             invokeLoaderFilePrivate<Path?>(
                 "discoverAndroidPlatformsPath",
@@ -282,7 +282,7 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android platforms resolution reports missing and invalid directories`() {
+    fun `android SDK resolution reports missing and invalid directories`() {
         val missingPlatforms = Files.createTempDirectory("graphite-missing-android-platforms")
             .resolve("missing")
         val invalidPlatforms = Files.createTempDirectory("graphite-invalid-android-platforms")
@@ -291,19 +291,19 @@ class JavaProjectLoaderTest {
                 invokeLoaderFilePrivate<Path>(
                     "resolveAndroidPlatformsPath",
                     arrayOf(LoaderConfig::class.java),
-                    LoaderConfig(androidPlatforms = missingPlatforms)
+                    LoaderConfig(androidSdk = missingPlatforms)
                 )
             }
             val invalid = assertFailsWith<IllegalArgumentException> {
                 invokeLoaderFilePrivate<Path>(
                     "resolveAndroidPlatformsPath",
                     arrayOf(LoaderConfig::class.java),
-                    LoaderConfig(androidPlatforms = invalidPlatforms)
+                    LoaderConfig(androidSdk = invalidPlatforms)
                 )
             }
 
             assertTrue(missing.message.orEmpty().contains("does not exist"))
-            assertTrue(invalid.message.orEmpty().contains("must contain android-<api>/android.jar"))
+            assertTrue(invalid.message.orEmpty().contains("SDK root or platforms directory"))
         } finally {
             missingPlatforms.parent.toFile().deleteRecursively()
             invalidPlatforms.toFile().deleteRecursively()

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
@@ -89,7 +89,7 @@ class JavaProjectLoaderTest {
     }
 
     @Test
-    fun `android SDK resolution accepts sdk root and platforms directory`() {
+    fun `android SDK resolution accepts sdk root only`() {
         val sdkRoot = Files.createTempDirectory("graphite-android-sdk-root")
         val platformsFromRoot = Files.createDirectories(sdkRoot.resolve("platforms"))
         val directPlatforms = Files.createTempDirectory("graphite-android-platforms")
@@ -105,14 +105,14 @@ class JavaProjectLoaderTest {
                     LoaderConfig(androidSdk = sdkRoot)
                 )
             )
-            assertEquals(
-                directPlatforms,
+            val directPlatformsError = assertFailsWith<IllegalArgumentException> {
                 invokeLoaderFilePrivate<Path>(
                     "resolveAndroidPlatformsPath",
                     arrayOf(LoaderConfig::class.java),
                     LoaderConfig(androidSdk = directPlatforms)
                 )
-            )
+            }
+            assertTrue(directPlatformsError.message.orEmpty().contains("Android SDK root must contain"))
             assertTrue(
                 invokeLoaderFilePrivate<Boolean>(
                     "containsAndroidPlatformJar",
@@ -135,26 +135,13 @@ class JavaProjectLoaderTest {
 
     @Test
     fun `android SDK environment lookup keeps configured priority`() {
-        val androidSdk = Path.of("/env/platforms")
         val androidHome = Path.of("/env/home")
         val androidSdkRoot = Path.of("/env/sdk-root")
 
         assertEquals(
-            androidSdk,
-            invokeLoaderFilePrivate<Path>(
-                "findAndroidPlatformsFromEnvironment",
-                arrayOf(Map::class.java),
-                mapOf(
-                    "ANDROID_PLATFORMS" to androidSdk.toString(),
-                    "ANDROID_HOME" to androidHome.toString(),
-                    "ANDROID_SDK_ROOT" to androidSdkRoot.toString()
-                )
-            )
-        )
-        assertEquals(
             androidHome,
             invokeLoaderFilePrivate<Path>(
-                "findAndroidPlatformsFromEnvironment",
+                "findAndroidSdkRootFromEnvironment",
                 arrayOf(Map::class.java),
                 mapOf(
                     "ANDROID_HOME" to androidHome.toString(),
@@ -165,14 +152,14 @@ class JavaProjectLoaderTest {
         assertEquals(
             androidSdkRoot,
             invokeLoaderFilePrivate<Path>(
-                "findAndroidPlatformsFromEnvironment",
+                "findAndroidSdkRootFromEnvironment",
                 arrayOf(Map::class.java),
                 mapOf("ANDROID_SDK_ROOT" to androidSdkRoot.toString())
             )
         )
         assertNull(
             invokeLoaderFilePrivate<Path?>(
-                "findAndroidPlatformsFromEnvironment",
+                "findAndroidSdkRootFromEnvironment",
                 arrayOf(Map::class.java),
                 mapOf("ANDROID_HOME" to "")
             )
@@ -283,30 +270,30 @@ class JavaProjectLoaderTest {
 
     @Test
     fun `android SDK resolution reports missing and invalid directories`() {
-        val missingPlatforms = Files.createTempDirectory("graphite-missing-android-platforms")
+        val missingSdkRoot = Files.createTempDirectory("graphite-missing-android-sdk")
             .resolve("missing")
-        val invalidPlatforms = Files.createTempDirectory("graphite-invalid-android-platforms")
+        val invalidSdkRoot = Files.createTempDirectory("graphite-invalid-android-sdk")
         try {
             val missing = assertFailsWith<IllegalArgumentException> {
                 invokeLoaderFilePrivate<Path>(
                     "resolveAndroidPlatformsPath",
                     arrayOf(LoaderConfig::class.java),
-                    LoaderConfig(androidSdk = missingPlatforms)
+                    LoaderConfig(androidSdk = missingSdkRoot)
                 )
             }
             val invalid = assertFailsWith<IllegalArgumentException> {
                 invokeLoaderFilePrivate<Path>(
                     "resolveAndroidPlatformsPath",
                     arrayOf(LoaderConfig::class.java),
-                    LoaderConfig(androidSdk = invalidPlatforms)
+                    LoaderConfig(androidSdk = invalidSdkRoot)
                 )
             }
 
             assertTrue(missing.message.orEmpty().contains("does not exist"))
-            assertTrue(invalid.message.orEmpty().contains("SDK root or platforms directory"))
+            assertTrue(invalid.message.orEmpty().contains("SDK root must contain"))
         } finally {
-            missingPlatforms.parent.toFile().deleteRecursively()
-            invalidPlatforms.toFile().deleteRecursively()
+            missingSdkRoot.parent.toFile().deleteRecursively()
+            invalidSdkRoot.toFile().deleteRecursively()
         }
     }
 

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/JavaProjectLoaderTest.kt
@@ -6,6 +6,7 @@ import io.johnsonlee.graphite.input.JavaArchiveLayout
 import io.johnsonlee.graphite.input.LoaderConfig
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.tools.StandardLocation
@@ -21,6 +22,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -72,6 +74,272 @@ class JavaProjectLoaderTest {
             assertTrue(loader.canLoad(tempZip), "Should be able to load ZIP files")
         } finally {
             Files.deleteIfExists(tempZip)
+        }
+    }
+
+    @Test
+    fun `canLoad should return true for apk files`() {
+        val loader = JavaProjectLoader()
+        val tempApk = Files.createTempFile("test", ".apk")
+        try {
+            assertTrue(loader.canLoad(tempApk), "Should be able to load APK files")
+        } finally {
+            Files.deleteIfExists(tempApk)
+        }
+    }
+
+    @Test
+    fun `android platforms resolution accepts sdk root and platforms directory`() {
+        val sdkRoot = Files.createTempDirectory("graphite-android-sdk-root")
+        val platformsFromRoot = Files.createDirectories(sdkRoot.resolve("platforms"))
+        val directPlatforms = Files.createTempDirectory("graphite-android-platforms")
+        try {
+            createAndroidJar(platformsFromRoot, 36)
+            createAndroidJar(directPlatforms, 35)
+
+            assertEquals(
+                platformsFromRoot,
+                invokeLoaderFilePrivate<Path>(
+                    "resolveAndroidPlatformsPath",
+                    arrayOf(LoaderConfig::class.java),
+                    LoaderConfig(androidPlatforms = sdkRoot)
+                )
+            )
+            assertEquals(
+                directPlatforms,
+                invokeLoaderFilePrivate<Path>(
+                    "resolveAndroidPlatformsPath",
+                    arrayOf(LoaderConfig::class.java),
+                    LoaderConfig(androidPlatforms = directPlatforms)
+                )
+            )
+            assertTrue(
+                invokeLoaderFilePrivate<Boolean>(
+                    "containsAndroidPlatformJar",
+                    arrayOf(Path::class.java),
+                    directPlatforms
+                )
+            )
+            assertFalse(
+                invokeLoaderFilePrivate<Boolean>(
+                    "containsAndroidPlatformJar",
+                    arrayOf(Path::class.java),
+                    directPlatforms.resolve("missing")
+                )
+            )
+        } finally {
+            sdkRoot.toFile().deleteRecursively()
+            directPlatforms.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `android platforms environment lookup keeps configured priority`() {
+        val androidPlatforms = Path.of("/env/platforms")
+        val androidHome = Path.of("/env/home")
+        val androidSdkRoot = Path.of("/env/sdk-root")
+
+        assertEquals(
+            androidPlatforms,
+            invokeLoaderFilePrivate<Path>(
+                "findAndroidPlatformsFromEnvironment",
+                arrayOf(Map::class.java),
+                mapOf(
+                    "ANDROID_PLATFORMS" to androidPlatforms.toString(),
+                    "ANDROID_HOME" to androidHome.toString(),
+                    "ANDROID_SDK_ROOT" to androidSdkRoot.toString()
+                )
+            )
+        )
+        assertEquals(
+            androidHome,
+            invokeLoaderFilePrivate<Path>(
+                "findAndroidPlatformsFromEnvironment",
+                arrayOf(Map::class.java),
+                mapOf(
+                    "ANDROID_HOME" to androidHome.toString(),
+                    "ANDROID_SDK_ROOT" to androidSdkRoot.toString()
+                )
+            )
+        )
+        assertEquals(
+            androidSdkRoot,
+            invokeLoaderFilePrivate<Path>(
+                "findAndroidPlatformsFromEnvironment",
+                arrayOf(Map::class.java),
+                mapOf("ANDROID_SDK_ROOT" to androidSdkRoot.toString())
+            )
+        )
+        assertNull(
+            invokeLoaderFilePrivate<Path?>(
+                "findAndroidPlatformsFromEnvironment",
+                arrayOf(Map::class.java),
+                mapOf("ANDROID_HOME" to "")
+            )
+        )
+    }
+
+    @Test
+    fun `android platforms discovery includes platform default install roots`() {
+        val home = Path.of("/home/tester")
+
+        val macRoots = invokeLoaderFilePrivate<List<Path>>(
+            "defaultAndroidSdkRoots",
+            arrayOf(String::class.java, Path::class.java),
+            "Mac OS X",
+            home
+        )
+        val linuxRoots = invokeLoaderFilePrivate<List<Path>>(
+            "defaultAndroidSdkRoots",
+            arrayOf(String::class.java, Path::class.java),
+            "Linux",
+            home
+        )
+        val windowsRoots = invokeLoaderFilePrivate<List<Path>>(
+            "defaultAndroidSdkRoots",
+            arrayOf(String::class.java, Path::class.java),
+            "Windows 11",
+            home
+        )
+
+        assertTrue(macRoots.contains(home.resolve("Library").resolve("Android").resolve("sdk")))
+        assertTrue(macRoots.contains(Path.of("/opt/homebrew/share/android-commandlinetools")))
+        assertTrue(linuxRoots.contains(home.resolve("Android").resolve("Sdk")))
+        assertTrue(linuxRoots.contains(Path.of("/usr/lib/android-sdk")))
+        assertTrue(
+            windowsRoots.contains(
+                home.resolve("AppData").resolve("Local").resolve("Android").resolve("Sdk")
+            )
+        )
+    }
+
+    @Test
+    fun `android platforms discovery tries default roots before tool paths`() {
+        val defaultSdkRoot = Files.createTempDirectory("graphite-default-android-sdk")
+        val toolSdkRoot = Files.createTempDirectory("graphite-tool-android-sdk")
+        val defaultPlatforms = Files.createDirectories(defaultSdkRoot.resolve("platforms"))
+        val toolPlatforms = Files.createDirectories(toolSdkRoot.resolve("platforms"))
+        val sdkmanagerDir = Files.createDirectories(toolSdkRoot.resolve("cmdline-tools/latest/bin"))
+        try {
+            createAndroidJar(defaultPlatforms, 34)
+            createAndroidJar(toolPlatforms, 35)
+            createAndroidTool(sdkmanagerDir, "sdkmanager")
+
+            assertEquals(
+                defaultPlatforms,
+                invokeLoaderFilePrivate<Path>(
+                    "discoverAndroidPlatformsPath",
+                    arrayOf(List::class.java, String::class.java),
+                    listOf(defaultSdkRoot),
+                    sdkmanagerDir.toString()
+                )
+            )
+        } finally {
+            defaultSdkRoot.toFile().deleteRecursively()
+            toolSdkRoot.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `android platforms discovery infers sdk roots from android tools on path`() {
+        val sdkRoot = Files.createTempDirectory("graphite-tool-path-android-sdk")
+        val platforms = Files.createDirectories(sdkRoot.resolve("platforms"))
+        val platformToolsDir = Files.createDirectories(sdkRoot.resolve("platform-tools"))
+        val emulatorDir = Files.createDirectories(sdkRoot.resolve("emulator"))
+        val sdkmanagerDir = Files.createDirectories(sdkRoot.resolve("cmdline-tools/latest/bin"))
+        try {
+            createAndroidJar(platforms, 36)
+            createAndroidTool(platformToolsDir, "adb")
+            createAndroidTool(emulatorDir, "emulator")
+            createAndroidTool(sdkmanagerDir, "sdkmanager")
+
+            listOf(platformToolsDir, emulatorDir, sdkmanagerDir).forEach { toolDir ->
+                assertEquals(
+                    platforms,
+                    invokeLoaderFilePrivate<Path>(
+                        "discoverAndroidPlatformsPath",
+                        arrayOf(List::class.java, String::class.java),
+                        emptyList<Path>(),
+                        toolDir.toString()
+                    )
+                )
+            }
+        } finally {
+            sdkRoot.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `android platforms discovery returns null when no fallback candidates are valid`() {
+        assertNull(
+            invokeLoaderFilePrivate<Path?>(
+                "discoverAndroidPlatformsPath",
+                arrayOf(List::class.java, String::class.java),
+                emptyList<Path>(),
+                ""
+            )
+        )
+    }
+
+    @Test
+    fun `android platforms resolution reports missing and invalid directories`() {
+        val missingPlatforms = Files.createTempDirectory("graphite-missing-android-platforms")
+            .resolve("missing")
+        val invalidPlatforms = Files.createTempDirectory("graphite-invalid-android-platforms")
+        try {
+            val missing = assertFailsWith<IllegalArgumentException> {
+                invokeLoaderFilePrivate<Path>(
+                    "resolveAndroidPlatformsPath",
+                    arrayOf(LoaderConfig::class.java),
+                    LoaderConfig(androidPlatforms = missingPlatforms)
+                )
+            }
+            val invalid = assertFailsWith<IllegalArgumentException> {
+                invokeLoaderFilePrivate<Path>(
+                    "resolveAndroidPlatformsPath",
+                    arrayOf(LoaderConfig::class.java),
+                    LoaderConfig(androidPlatforms = invalidPlatforms)
+                )
+            }
+
+            assertTrue(missing.message.orEmpty().contains("does not exist"))
+            assertTrue(invalid.message.orEmpty().contains("must contain android-<api>/android.jar"))
+        } finally {
+            missingPlatforms.parent.toFile().deleteRecursively()
+            invalidPlatforms.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `android jar resolution picks the available platform API`() {
+        val platforms = Files.createTempDirectory("graphite-android-platforms-api")
+        val invalidPlatforms = Files.createTempDirectory("graphite-android-platforms-empty")
+        val appInput = Files.createTempFile("graphite-plain-input", ".jar")
+        try {
+            val androidJar = createAndroidJar(platforms, 16)
+
+            assertEquals(
+                androidJar,
+                invokeLoaderFilePrivate<Path>(
+                    "resolveAndroidJar",
+                    arrayOf(Path::class.java, Path::class.java),
+                    appInput,
+                    platforms
+                )
+            )
+            val missingJar = assertFailsWith<IllegalArgumentException> {
+                invokeLoaderFilePrivate<Path>(
+                    "resolveAndroidJar",
+                    arrayOf(Path::class.java, Path::class.java),
+                    appInput,
+                    invalidPlatforms
+                )
+            }
+            assertTrue(missingJar.message.orEmpty().contains("android.jar not found for API"))
+        } finally {
+            platforms.toFile().deleteRecursively()
+            invalidPlatforms.toFile().deleteRecursively()
+            Files.deleteIfExists(appInput)
         }
     }
 
@@ -1104,6 +1372,36 @@ class JavaProjectLoaderTest {
         val submodulePath = projectDir.resolve("build/classes/java/test")
         val rootPath = projectDir.resolve("graphite-sootup/build/classes/java/test")
         return if (submodulePath.exists()) submodulePath else rootPath
+    }
+
+    private fun createAndroidJar(platforms: Path, api: Int): Path {
+        val platform = Files.createDirectories(platforms.resolve("android-$api"))
+        val androidJar = platform.resolve("android.jar")
+        Files.write(androidJar, ByteArray(0))
+        return androidJar
+    }
+
+    private fun createAndroidTool(directory: Path, name: String): Path {
+        val tool = directory.resolve(name)
+        Files.write(tool, ByteArray(0))
+        tool.toFile().setExecutable(true)
+        return tool
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> invokeLoaderFilePrivate(
+        name: String,
+        parameterTypes: Array<Class<*>>,
+        vararg args: Any?
+    ): T {
+        val method = Class.forName("io.johnsonlee.graphite.sootup.JavaProjectLoaderKt")
+            .getDeclaredMethod(name, *parameterTypes)
+        method.isAccessible = true
+        return try {
+            method.invoke(null, *args) as T
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapterInternalCoverageTest.kt
+++ b/graphite-sootup/src/test/kotlin/io/johnsonlee/graphite/sootup/SootUpAdapterInternalCoverageTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FunctionOnlyReturningConstant", "LargeClass", "LongMethod", "MaxLineLength")
+
 package io.johnsonlee.graphite.sootup
 
 import io.johnsonlee.graphite.graph.DefaultGraph
@@ -17,6 +19,8 @@ import io.johnsonlee.graphite.core.LocalVariable
 import io.johnsonlee.graphite.core.ResourceFileNode
 import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.core.NodeId
+import java.io.ByteArrayInputStream
+import java.util.stream.Stream
 import kotlin.io.path.exists
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -24,27 +28,46 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.InsnNode
 import org.objectweb.asm.tree.LdcInsnNode
 import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.VarInsnNode
+import sootup.core.IdentifierFactory
+import sootup.core.frontend.BodySource
+import sootup.core.frontend.SootClassSource
+import sootup.core.jimple.basic.NoPositionInformation
 import sootup.core.jimple.basic.StmtPositionInfo
 import sootup.core.jimple.common.constant.MethodHandle
 import sootup.core.jimple.common.constant.StringConstant as SootStringConstant
 import sootup.core.jimple.common.expr.JDynamicInvokeExpr
+import sootup.core.jimple.common.expr.JNewExpr
+import sootup.core.jimple.common.expr.JSpecialInvokeExpr
 import sootup.core.jimple.common.expr.JStaticInvokeExpr
+import sootup.core.jimple.common.expr.JVirtualInvokeExpr
 import sootup.core.jimple.common.ref.JStaticFieldRef
 import sootup.core.jimple.common.stmt.JAssignStmt
 import sootup.core.inputlocation.AnalysisInputLocation
+import sootup.core.model.Body
+import sootup.core.model.ClassModifier
+import sootup.core.model.MethodModifier
+import sootup.core.model.SootClass
+import sootup.core.model.SootField
+import sootup.core.model.SootMethod
 import sootup.core.model.SourceType
+import sootup.core.signatures.FieldSignature
 import sootup.core.signatures.MethodSignature
+import sootup.core.typehierarchy.TypeHierarchy
+import sootup.core.types.ClassType
 import sootup.core.types.VoidType
 import sootup.java.bytecode.frontend.inputlocation.PathBasedAnalysisInputLocation
 import sootup.java.core.JavaIdentifierFactory
 import sootup.java.core.JavaSootClass
 import sootup.java.core.jimple.basic.JavaLocal
 import sootup.java.core.views.JavaView
+import sootup.core.views.View
 
 class SootUpAdapterInternalCoverageTest {
     private val identifierFactory = JavaIdentifierFactory.getInstance()
@@ -130,11 +153,16 @@ class SootUpAdapterInternalCoverageTest {
         assertEquals("alpha", invokePrivate<Any?>(adapter, "normalizeAnnotationValue", arrayOf(Any::class.java), "\"alpha\""))
         assertEquals(listOf("a"), invokePrivate<Any?>(adapter, "normalizeAnnotationValue", arrayOf(Any::class.java), listOf("a", "")))
         assertEquals(listOf("b"), invokePrivate<Any?>(adapter, "normalizeAnnotationValue", arrayOf(Any::class.java), arrayOf("b", "")))
+        assertEquals(1, invokePrivate<Any?>(adapter, "normalizeAnnotationValue", arrayOf(Any::class.java), 1))
+        assertNull(invokePrivate<Any?>(adapter, "normalizeAnnotationValue", arrayOf(Any::class.java), emptyList<String>()))
+        assertNull(invokePrivate<Any?>(adapter, "normalizeAnnotationValue", arrayOf(Any::class.java), emptyArray<String>()))
         assertNull(invokePrivate<Any?>(adapter, "normalizeAnnotationValue", arrayOf(Any::class.java), object {
             override fun toString(): String = "null"
         }))
         assertEquals("", invokePrivate<String>(adapter, "getAnnotationFullName", arrayOf(Any::class.java), null))
         assertTrue(invokePrivate<Map<String, Any?>>(adapter, "getAnnotationValues", arrayOf(Any::class.java), null).isEmpty())
+        assertEquals("sample.Annotation", invokePrivate<String>(adapter, "getAnnotationFullName", arrayOf(Any::class.java), FakeAnnotationUsage()))
+        assertEquals(mapOf("value" to "\"ok\""), invokePrivate<Map<String, Any?>>(adapter, "getAnnotationValues", arrayOf(Any::class.java), FakeAnnotationUsage()))
     }
 
     @Test
@@ -157,6 +185,45 @@ class SootUpAdapterInternalCoverageTest {
                 TypeDescriptor("fallback.Type")
             )
         )
+
+        val method = MethodDescriptor(TypeDescriptor("sample.Owner"), "read", emptyList(), TypeDescriptor("void"))
+        val otherMethod = MethodDescriptor(TypeDescriptor("sample.Owner"), "read", emptyList(), TypeDescriptor("void"))
+        val bindingClass = Class.forName("io.johnsonlee.graphite.sootup.SootUpAdapter\$ParameterBinding")
+        val bindingConstructor = bindingClass.getDeclaredConstructor(MethodDescriptor::class.java, Int::class.javaPrimitiveType!!)
+            .also { it.isAccessible = true }
+        val firstBinding = bindingConstructor.newInstance(method, 0)
+
+        assertEquals(firstBinding, bindingConstructor.newInstance(method, 0))
+        assertFalse(firstBinding == bindingConstructor.newInstance(otherMethod, 0))
+        assertFalse(firstBinding == bindingConstructor.newInstance(method, 1))
+        assertFalse(firstBinding == "not-a-binding")
+
+        assertNotNull(
+            invokePrivate<Any>(
+                adapter,
+                "parameterBinding",
+                arrayOf(MethodDescriptor::class.java, Int::class.javaPrimitiveType!!),
+                method,
+                1
+            )
+        )
+        writeField(adapter, "activeMethod", method)
+        val activeBinding = invokePrivate<Any>(
+            adapter,
+            "parameterBinding",
+            arrayOf(MethodDescriptor::class.java, Int::class.javaPrimitiveType!!),
+            method,
+            0
+        )
+        val activeBindingAgain = invokePrivate<Any>(
+            adapter,
+            "parameterBinding",
+            arrayOf(MethodDescriptor::class.java, Int::class.javaPrimitiveType!!),
+            method,
+            0
+        )
+        assertEquals(activeBinding, activeBindingAgain)
+        assertEquals(1, readField<MutableList<Any>>(adapter, "activeMethodParameters").size)
     }
 
     @Test
@@ -170,6 +237,127 @@ class SootUpAdapterInternalCoverageTest {
         )
 
         assertTrue(references.any { it == "java.lang.invoke.LambdaMetafactory" || it == "sample.lambda.LambdaExample" })
+
+        val descriptorReferences = invokePrivate<Set<String>>(
+            adapter,
+            "extractReferencedClasses",
+            arrayOf(ByteArray::class.java),
+            referencedClassBytes()
+        )
+        assertTrue(descriptorReferences.contains("java.io.Serializable"))
+        assertTrue(descriptorReferences.contains("java.util.List"))
+        assertTrue(descriptorReferences.contains("java.util.Map"))
+        assertTrue(descriptorReferences.contains("java.util.Optional"))
+        assertTrue(descriptorReferences.contains("java.io.IOException"))
+    }
+
+    @Test
+    fun `resource indexing helpers record class resources profiles and formats`() {
+        val entries = listOf(
+            ResourceEntry("com/example/Helper.class", "lib/helper.jar"),
+            ResourceEntry("config/application-dev.yaml", "app.jar"),
+            ResourceEntry("config/feature.json", "app.jar"),
+            ResourceEntry("config/service.xml", "app.jar"),
+            ResourceEntry("notes.txt", "app.jar")
+        )
+        val adapter = createAdapter(resourceAccessor = object : ResourceAccessor {
+            override fun list(pattern: String): Sequence<ResourceEntry> = entries.asSequence()
+            override fun open(path: String) = ByteArrayInputStream(ByteArray(0))
+        })
+
+        val unloadedClasses = invokePrivate<List<ResourceEntry>>(
+            adapter,
+            "indexResourceValues",
+            arrayOf(Set::class.java),
+            setOf("app.jar")
+        )
+        val resourceFilesByPath = readField<MutableMap<String, MutableList<ResourceFileNode>>>(adapter, "resourceFilesByPath")
+        val configurationResourcePaths = readField<LinkedHashSet<String>>(adapter, "configurationResourcePaths")
+        val classOrigins = readField<MutableMap<String, String>>(adapter, "classOriginsByName")
+
+        assertEquals(listOf(ResourceEntry("com/example/Helper.class", "lib/helper.jar")), unloadedClasses)
+        assertEquals("lib/helper.jar", classOrigins["com.example.Helper"])
+        assertEquals("yaml", resourceFilesByPath.getValue("config/application-dev.yaml").single().format)
+        assertEquals("dev", resourceFilesByPath.getValue("config/application-dev.yaml").single().profile)
+        assertEquals("json", resourceFilesByPath.getValue("config/feature.json").single().format)
+        assertEquals("xml", resourceFilesByPath.getValue("config/service.xml").single().format)
+        assertEquals("text", resourceFilesByPath.getValue("notes.txt").single().format)
+        assertTrue(configurationResourcePaths.contains("config/application-dev.yaml"))
+        assertTrue(configurationResourcePaths.contains("config/feature.json"))
+        assertTrue(configurationResourcePaths.contains("config/service.xml"))
+        assertFalse(configurationResourcePaths.contains("notes.txt"))
+        assertTrue(invokePrivate<Boolean>(adapter, "isResourceConfig", arrayOf(String::class.java), "application.yml"))
+        assertTrue(invokePrivate<Boolean>(adapter, "isResourceConfig", arrayOf(String::class.java), "application.yaml"))
+        assertEquals("local", invokePrivate<String?>(adapter, "resourceProfile", arrayOf(String::class.java), "config/application-local.json"))
+        assertNull(invokePrivate<String?>(adapter, "resourceProfile", arrayOf(String::class.java), "config/feature.json"))
+    }
+
+    @Test
+    fun `method resolution fallbacks handle missing bodies and failing classes`() {
+        val adapter = createAdapter()
+        val enumType = identifierFactory.getClassType("sample.fake.EmptyEnum")
+        val clinitSignature = identifierFactory.getMethodSignature("sample.fake.EmptyEnum", "<clinit>", "void", emptyList())
+        val clinit = object : FakeSootMethod(clinitSignature, listOf(MethodModifier.STATIC)) {
+            override fun hasBody(): Boolean = false
+        }
+        val enumClass = FakeSootClass(enumType, methods = setOf(clinit), enumClass = true)
+
+        invokePrivate<Unit>(adapter, "extractEnumValues", arrayOf(SootClass::class.java), enumClass)
+
+        assertTrue(
+            invokePrivate<Set<SootMethod>>(
+                adapter,
+                "resolveMethodsOrEmpty",
+                arrayOf(SootClass::class.java),
+                FakeSootClass(identifierFactory.getClassType("sample.fake.Oom"), failure = OutOfMemoryError("boom"))
+            ).isEmpty()
+        )
+        assertTrue(
+            invokePrivate<Set<SootMethod>>(
+                adapter,
+                "resolveMethodsOrEmpty",
+                arrayOf(SootClass::class.java),
+                FakeSootClass(identifierFactory.getClassType("sample.fake.Illegal"), failure = IllegalStateException("missing"))
+            ).isEmpty()
+        )
+
+        writeField(adapter, "classesByNameCache", mapOf("sample.fake.EmptyEnum" to enumClass))
+        assertTrue(
+            invokePrivate<Set<String>>(
+                adapter,
+                "collectDeclaredMethodSubSignatures",
+                arrayOf(String::class.java),
+                "sample.fake.EmptyEnum"
+            ).any { it.contains("<clinit>") }
+        )
+
+        val throwingMethod = object : FakeSootMethod(
+            identifierFactory.getMethodSignature("sample.fake.Owner", "boom", "void", emptyList())
+        ) {
+            override fun hasBody(): Boolean = throw OutOfMemoryError("boom")
+        }
+        invokePrivate<Unit>(adapter, "processMethod", arrayOf(SootMethod::class.java), throwingMethod)
+    }
+
+    @Test
+    fun `build graph reports progress for large class sets`() {
+        val logs = mutableListOf<String>()
+        val classes = (1..500).map {
+            FakeSootClass(identifierFactory.getClassType("sample.fake.Progress$it"))
+        }
+        val adapter = SootUpAdapter(
+            view = FakeView(classes, identifierFactory),
+            config = LoaderConfig(includePackages = listOf("sample.fake"), buildCallGraph = false, verbose = logs::add),
+            extensions = emptyList(),
+            resourceAccessor = EmptyResourceAccessor,
+            inputLocationSources = emptyMap(),
+            graphBuilder = DefaultGraph.Builder()
+        )
+
+        adapter.buildGraph()
+
+        assertTrue(logs.any { it.contains("Pass 1 processed 500 classes") })
+        assertTrue(logs.any { it.contains("Pass 2 processed 500 classes") })
     }
 
     @Test
@@ -275,6 +463,7 @@ class SootUpAdapterInternalCoverageTest {
         assertEquals(5, invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), iconstReturnMethod(Opcodes.ICONST_5)))
         assertNull(invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), localeCtorMethod()))
         assertEquals(listOf("java.class", "java.properties"), invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), arraysAsListMethod()))
+        assertEquals("stored", invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), storedStringMethod()))
         assertEquals(setOf("java.class"), invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), singleFormatMethod("java.class")))
         assertEquals(setOf("java.properties"), invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), singleFormatMethod("java.properties")))
         assertNull(invokePrivate<Set<String>?>(adapter, "extractControlFormatsFromMethod", arrayOf(MethodNode::class.java), singleIntListOfMethod(7)))
@@ -282,11 +471,34 @@ class SootUpAdapterInternalCoverageTest {
 
         val bundle = ResourceBundle.getBundle("sample.resources.MessagesListBundle", Locale.KOREA)
         invokePrivate<Unit>(adapter, "indexRuntimeBundle", arrayOf(ResourceBundle::class.java), bundle)
-        val indexed = readField<MutableMap<String, *>>(adapter, "resourceFilesByPath")
+        invokePrivate<Unit>(
+            adapter,
+            "indexRuntimeBundle",
+            arrayOf(ResourceBundle::class.java),
+            java.util.PropertyResourceBundle(ByteArrayInputStream("hello=world\n".toByteArray()))
+        )
+        val indexed = readField<MutableMap<String, MutableList<ResourceFileNode>>>(adapter, "resourceFilesByPath")
         assertTrue(indexed.containsKey("sample.resources.MessagesListBundle_ko_KR"))
+        assertEquals("propertybundle", indexed.getValue("java.util.PropertyResourceBundle").single().format)
         val parent = SimpleBundle("parent")
         val child = SimpleBundle("child").withParent(parent)
         assertNull(invokePrivate<ResourceBundle?>(adapter, "bundleParent", arrayOf(ResourceBundle::class.java), child))
+
+        indexed["messages_ko_KR.properties"] = mutableListOf(ResourceFileNode(NodeId.next(), "messages_ko_KR.properties", "test", "properties", null))
+        indexed["messages_ko.properties"] = mutableListOf(ResourceFileNode(NodeId.next(), "messages_ko.properties", "test", "properties", null))
+        val controlSpecClass = Class.forName("io.johnsonlee.graphite.sootup.SootUpAdapter\$BundleControlSpec")
+        assertEquals(
+            linkedSetOf("messages_ko_KR.properties", "messages_ko.properties", "messages.properties", "messages"),
+            invokePrivate<LinkedHashSet<String>>(
+                adapter,
+                "buildResourceBundleCandidatePaths",
+                arrayOf(String::class.java, String::class.java, String::class.java, controlSpecClass),
+                "messages",
+                "messages",
+                "ko_KR",
+                null
+            )
+        )
     }
 
     @Test
@@ -414,6 +626,11 @@ class SootUpAdapterInternalCoverageTest {
         val integerValueOf = identifierFactory.getMethodSignature("java.lang.Integer", "valueOf", "java.lang.Integer", listOf("int"))
         val stringValueOf = identifierFactory.getMethodSignature("java.lang.String", "valueOf", "java.lang.String", listOf("java.lang.Object"))
         val resourceBundleGetBundle = identifierFactory.getMethodSignature("java.util.ResourceBundle", "getBundle", "java.util.ResourceBundle", listOf("java.lang.String", "java.util.Locale"))
+        val gsonFromJson = identifierFactory.getMethodSignature("com.google.gson.Gson", "fromJson", "java.lang.Object", listOf("java.lang.String", "java.lang.Class"))
+        val documentBuilderParse = identifierFactory.getMethodSignature("javax.xml.parsers.DocumentBuilder", "parse", "org.w3c.dom.Document", listOf("java.io.InputStream"))
+        val urlOpenStream = identifierFactory.getMethodSignature("java.net.URL", "openStream", "java.io.InputStream", emptyList())
+        val channelsNewReader = identifierFactory.getMethodSignature("java.nio.channels.Channels", "newReader", "java.io.Reader", listOf("java.nio.channels.ReadableByteChannel", "java.lang.String"))
+        val irrelevantUrlMethod = identifierFactory.getMethodSignature("java.net.URL", "toString", "java.lang.String", emptyList())
         val listBundle = resolveJavaSootClass(adapter, "sample.resources.MessagesListBundle")
 
         assertNull(
@@ -461,6 +678,22 @@ class SootUpAdapterInternalCoverageTest {
                 JStaticInvokeExpr(resourceBundleGetBundle, listOf(local, local))
             )
         )
+        readField<MutableMap<String, MutableList<ResourceFileNode>>>(adapter, "resourceFilesByPath")["messages.properties"] =
+            mutableListOf(ResourceFileNode(NodeId.next(), "messages.properties", "test", "properties", null))
+        assertEquals(
+            linkedSetOf("messages.properties"),
+            invokePrivate<LinkedHashSet<String>?>(
+                adapter,
+                "extractResourceBundlePaths",
+                arrayOf(MethodDescriptor::class.java, MethodSignature::class.java, sootup.core.jimple.common.expr.AbstractInvokeExpr::class.java),
+                caller,
+                resourceBundleGetBundle,
+                JStaticInvokeExpr(
+                    resourceBundleGetBundle,
+                    listOf(SootStringConstant("messages", identifierFactory.getType("java.lang.String")), local)
+                )
+            )
+        )
         assertNull(
             invokePrivate<Any?>(
                 adapter,
@@ -495,9 +728,113 @@ class SootUpAdapterInternalCoverageTest {
                 JStaticInvokeExpr(integerValueOf, emptyList())
             )
         )
+        assertTrue(invokePrivate<Boolean>(adapter, "isResourceRelevantCall", arrayOf(MethodSignature::class.java), gsonFromJson))
+        assertTrue(invokePrivate<Boolean>(adapter, "isResourceRelevantCall", arrayOf(MethodSignature::class.java), documentBuilderParse))
+        assertTrue(invokePrivate<Boolean>(adapter, "isResourceRelevantCall", arrayOf(MethodSignature::class.java), urlOpenStream))
+        assertTrue(invokePrivate<Boolean>(adapter, "isResourceRelevantCall", arrayOf(MethodSignature::class.java), channelsNewReader))
+        assertFalse(invokePrivate<Boolean>(adapter, "isResourceRelevantCall", arrayOf(MethodSignature::class.java), irrelevantUrlMethod))
+
+        val localeLocal = JavaLocal("locale", identifierFactory.getType("java.util.Locale"), emptyList())
+        val localeCtor = identifierFactory.getMethodSignature("java.util.Locale", "<init>", "void", listOf("java.lang.String", "java.lang.String"))
+        val localeCtorInvoke = JSpecialInvokeExpr(
+            localeLocal,
+            localeCtor,
+            listOf(
+                SootStringConstant("ko", identifierFactory.getType("java.lang.String")),
+                SootStringConstant("KR", identifierFactory.getType("java.lang.String"))
+            )
+        )
+        invokePrivate<Unit>(
+            adapter,
+            "trackResourceAssociations",
+            arrayOf(
+                io.johnsonlee.graphite.core.CallSiteNode::class.java,
+                MethodSignature::class.java,
+                sootup.core.jimple.common.expr.AbstractInvokeExpr::class.java,
+                MethodDescriptor::class.java,
+                io.johnsonlee.graphite.core.ValueNode::class.java
+            ),
+            io.johnsonlee.graphite.core.CallSiteNode(NodeId.next(), caller, MethodDescriptor(TypeDescriptor("java.util.Locale"), "<init>", emptyList(), TypeDescriptor("void")), null, null, emptyList()),
+            localeCtor,
+            localeCtorInvoke,
+            caller,
+            null
+        )
+        val localeKey = invokePrivate<Any>(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, localeLocal.name)
+        assertEquals("ko_KR", readField<MutableMap<Any, String>>(adapter, "localeSpecsByLocal")[localeKey])
+
+        val urlLocal = JavaLocal("url", identifierFactory.getType("java.net.URL"), emptyList())
+        val streamNode = LocalVariable(NodeId.next(), "stream", TypeDescriptor("java.io.InputStream"), caller)
+        readField<MutableMap<Any, LinkedHashSet<String>>>(adapter, "resourceHandlePathsByLocal")[
+            invokePrivate(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, urlLocal.name)
+        ] = linkedSetOf("config/service.xml")
+        invokePrivate<Unit>(
+            adapter,
+            "trackResourceAssociations",
+            arrayOf(
+                io.johnsonlee.graphite.core.CallSiteNode::class.java,
+                MethodSignature::class.java,
+                sootup.core.jimple.common.expr.AbstractInvokeExpr::class.java,
+                MethodDescriptor::class.java,
+                io.johnsonlee.graphite.core.ValueNode::class.java
+            ),
+            io.johnsonlee.graphite.core.CallSiteNode(NodeId.next(), caller, MethodDescriptor(TypeDescriptor("java.net.URL"), "openStream", emptyList(), TypeDescriptor("java.io.InputStream")), null, null, emptyList()),
+            urlOpenStream,
+            JVirtualInvokeExpr(urlLocal, urlOpenStream, emptyList()),
+            caller,
+            streamNode
+        )
+        val streamKey = invokePrivate<Any>(adapter, "localKey", arrayOf(MethodDescriptor::class.java, String::class.java), caller, "stream")
+        assertEquals(linkedSetOf("config/service.xml"), readField<MutableMap<Any, LinkedHashSet<String>>>(adapter, "resourceHandlePathsByLocal")[streamKey])
+
+        assertNull(invokePrivate<Any?>(adapter, "evaluateLiteralMethod", arrayOf(MethodNode::class.java), emptyMethod()))
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "extractBundleControlSpec",
+                arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java, String::class.java, String::class.java),
+                caller,
+                JNewExpr(identifierFactory.getClassType("missing.Control")),
+                "sample.resources.MessagesListBundle",
+                "ko_KR"
+            )
+        )
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "extractBundleControlSpec",
+                arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java, String::class.java, String::class.java),
+                caller,
+                SootStringConstant("not-control", identifierFactory.getType("java.lang.String")),
+                "sample.resources.MessagesListBundle",
+                "ko_KR"
+            )
+        )
+        val unsupportedControl = identifierFactory.getMethodSignature("java.util.ResourceBundle\$Control", "unsupported", "java.util.ResourceBundle\$Control", emptyList())
+        assertNull(
+            invokePrivate<Any?>(
+                adapter,
+                "extractBundleControlSpec",
+                arrayOf(MethodDescriptor::class.java, MethodSignature::class.java, sootup.core.jimple.common.expr.AbstractInvokeExpr::class.java),
+                caller,
+                unsupportedControl,
+                JStaticInvokeExpr(unsupportedControl, emptyList())
+            )
+        )
+        val unknownFormatRef = JStaticFieldRef(identifierFactory.getFieldSignature("UNKNOWN", identifierFactory.getClassType("java.util.ResourceBundle\$Control"), identifierFactory.getType("java.lang.Object")))
+        assertNull(invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, unknownFormatRef))
+        assertNull(invokePrivate<String?>(adapter, "extractControlFormat", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, sootup.core.jimple.common.constant.IntConstant.getInstance(1)))
+        assertNull(invokePrivate<String?>(adapter, "extractLocaleSpec", arrayOf(MethodDescriptor::class.java, sootup.core.jimple.basic.Value::class.java), caller, SootStringConstant("ko", identifierFactory.getType("java.lang.String"))))
+        val plainBundle = SimpleBundle("plain")
+        invokePrivate<Unit>(adapter, "indexRuntimeBundle", arrayOf(ResourceBundle::class.java), plainBundle)
+        assertEquals("bundle", readField<MutableMap<String, MutableList<ResourceFileNode>>>(adapter, "resourceFilesByPath").getValue(plainBundle.javaClass.name).single().format)
     }
 
-    private fun createAdapter(includePackages: List<String> = listOf("sample.resources"), buildCallGraph: Boolean = false): SootUpAdapter {
+    private fun createAdapter(
+        includePackages: List<String> = listOf("sample.resources"),
+        buildCallGraph: Boolean = false,
+        resourceAccessor: ResourceAccessor = EmptyResourceAccessor
+    ): SootUpAdapter {
         val testClassesDir = findTestClassesDir()
         assertTrue(testClassesDir.exists(), "Test classes directory should exist: $testClassesDir")
         val location = PathBasedAnalysisInputLocation.create(testClassesDir, SourceType.Application)
@@ -507,10 +844,32 @@ class SootUpAdapterInternalCoverageTest {
             config = LoaderConfig(includePackages = includePackages, buildCallGraph = buildCallGraph),
             signatureReader = BytecodeSignatureReader(),
             extensions = emptyList(),
-            resourceAccessor = EmptyResourceAccessor,
+            resourceAccessor = resourceAccessor,
             inputLocationSources = mapOf(location to testClassesDir.fileName.toString()),
             graphBuilder = DefaultGraph.Builder()
         )
+    }
+
+    private fun referencedClassBytes(): ByteArray {
+        val writer = ClassWriter(0)
+        writer.visit(
+            Opcodes.V1_8,
+            Opcodes.ACC_PUBLIC,
+            "sample/refs/Owner",
+            null,
+            "java/lang/Object",
+            arrayOf("java/io/Serializable")
+        )
+        writer.visitField(Opcodes.ACC_PRIVATE, "items", "[Ljava/util/List;", null, null).visitEnd()
+        writer.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "read",
+            "(Ljava/util/Map;[Ljava/lang/String;)Ljava/util/Optional;",
+            null,
+            arrayOf("java/io/IOException")
+        ).visitEnd()
+        writer.visitEnd()
+        return writer.toByteArray()
     }
 
     private fun createResourceBackedAdapter(): SootUpAdapter {
@@ -546,6 +905,9 @@ class SootUpAdapterInternalCoverageTest {
             instructions.add(InsnNode(Opcodes.ACONST_NULL))
             instructions.add(InsnNode(Opcodes.ARETURN))
         }
+
+    private fun emptyMethod(): MethodNode =
+        MethodNode(ASM_API_VERSION, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "empty", "()Ljava/lang/Object;", null, null)
 
     private fun listOfMethod(): MethodNode =
         MethodNode(ASM_API_VERSION, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/util/List;", null, null).apply {
@@ -598,6 +960,15 @@ class SootUpAdapterInternalCoverageTest {
             instructions.add(InsnNode(Opcodes.ARETURN))
         }
 
+    private fun storedStringMethod(): MethodNode =
+        MethodNode(ASM_API_VERSION, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "stored", "()Ljava/lang/Object;", null, null).apply {
+            instructions.add(LdcInsnNode("stored"))
+            instructions.add(VarInsnNode(Opcodes.ASTORE, 0))
+            instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+            instructions.add(InsnNode(Opcodes.DUP))
+            instructions.add(InsnNode(Opcodes.ARETURN))
+        }
+
     private fun singleFormatMethod(value: String): MethodNode =
         MethodNode(ASM_API_VERSION, Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "formats", "()Ljava/lang/Object;", null, null).apply {
             instructions.add(LdcInsnNode(value))
@@ -633,6 +1004,12 @@ class SootUpAdapterInternalCoverageTest {
         return field.get(target) as T
     }
 
+    private fun writeField(target: Any, name: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun <T> invokePrivate(target: Any, name: String, parameterTypes: Array<Class<*>>, vararg args: Any?): T {
         val method = target.javaClass.getDeclaredMethod(name, *parameterTypes)
@@ -657,5 +1034,75 @@ class SootUpAdapterInternalCoverageTest {
             setParent(parent)
             return this
         }
+    }
+
+    private class FakeAnnotationUsage {
+        fun getAnnotation(): FakeAnnotation = FakeAnnotation()
+        fun getValues(): Map<String, Any?> = mapOf("value" to "\"ok\"")
+    }
+
+    private class FakeAnnotation {
+        fun getFullyQualifiedName(): String = "sample.Annotation"
+    }
+
+    private open class FakeSootMethod(
+        signature: MethodSignature,
+        modifiers: Iterable<MethodModifier> = emptyList()
+    ) : SootMethod(
+        FakeBodySource(signature),
+        signature,
+        modifiers,
+        emptyList<ClassType>(),
+        NoPositionInformation.getInstance()
+    )
+
+    private class FakeBodySource(private val signature: MethodSignature) : BodySource {
+        override fun resolveBody(modifiers: Iterable<MethodModifier>): Body =
+            error("Fake method has no body")
+
+        override fun resolveAnnotationsDefaultValue(): Any? = null
+
+        override fun getSignature(): MethodSignature = signature
+    }
+
+    private open class FakeSootClass(
+        classType: ClassType,
+        private val methods: Set<SootMethod> = emptySet(),
+        private val failure: Throwable? = null,
+        private val enumClass: Boolean = false
+    ) : SootClass(FakeClassSource(classType), SourceType.Application) {
+        override fun getMethods(): Set<SootMethod> {
+            failure?.let { throw it }
+            return methods
+        }
+
+        override fun isEnum(): Boolean = enumClass
+    }
+
+    private class FakeClassSource(classType: ClassType) : SootClassSource(
+        PathBasedAnalysisInputLocation.create(Path.of(System.getProperty("java.io.tmpdir")), SourceType.Application),
+        classType,
+        Path.of("fake.class")
+    ) {
+        override fun resolveMethods(): Collection<SootMethod> = emptyList()
+        override fun resolveFields(): Collection<SootField> = emptyList()
+        override fun resolveModifiers(): Set<ClassModifier> = emptySet()
+        override fun resolveInterfaces(): Set<ClassType> = emptySet()
+        override fun resolveSuperclass(): java.util.Optional<ClassType> = java.util.Optional.empty()
+        override fun resolveOuterClass(): java.util.Optional<ClassType> = java.util.Optional.empty()
+        override fun resolvePosition() = NoPositionInformation.getInstance()
+        override fun buildClass(sourceType: SourceType): SootClass = FakeSootClass(classType)
+    }
+
+    private class FakeView(
+        private val classes: List<SootClass>,
+        private val identifierFactory: IdentifierFactory
+    ) : View {
+        override fun getClasses(): Stream<out SootClass> = classes.stream()
+        override fun getClass(type: ClassType) = classes.firstOrNull { it.type == type }.let { java.util.Optional.ofNullable(it) }
+        override fun getField(signature: FieldSignature): java.util.Optional<out SootField> = java.util.Optional.empty()
+        override fun getMethod(signature: MethodSignature): java.util.Optional<out SootMethod> = java.util.Optional.empty()
+        override fun getTypeHierarchy(): TypeHierarchy = error("Fake view does not provide a type hierarchy")
+        override fun getIdentifierFactory(): IdentifierFactory = identifierFactory
     }
 }


### PR DESCRIPTION
## Summary

### APK Loading

- Add the SootUp APK frontend dependency to the SootUp adapter module.
- Teach `JavaProjectLoader` to accept `.apk` inputs and create an `ApkAnalysisInputLocation` with the default Dex body interceptors.
- Keep Android platform classes out of the graph by default; `--include-libs` opts into loading the selected platform `android.jar` as library code.

### Android SDK Discovery

- Add `--android-sdk` for APK builds. It accepts an Android SDK root only; Graphite derives the internal `platforms` directory from that root.
- When `--android-sdk` is omitted, discovery follows this order:
  1. `ANDROID_HOME`, then `ANDROID_SDK_ROOT`
  2. Default SDK roots for the current OS:
     - macOS: `~/Library/Android/sdk`, `/opt/homebrew/share/android-commandlinetools`, `/usr/local/share/android-commandlinetools`
     - Linux: `~/Android/Sdk`, `~/android-sdk`, `/opt/android-sdk`, `/usr/local/android-sdk`, `/usr/lib/android-sdk`
     - Windows: `%USERPROFILE%\AppData\Local\Android\Sdk`
  3. SDK roots inferred from `adb`, `emulator`, or `sdkmanager` on `PATH`
- Surface that same SDK-root discovery order in `graphite build --help` and the README.

### APK Resource Indexing

- Index APK ZIP resources so manifest, `res/**`, and `assets/**` entries can appear as resource nodes.
- Reuse the archive resource accessor path for APK contents.
- Preserve manifest/resource queryability after saving and reloading the persisted graph.

### Mmap Graph Build Memory

- Reduce heap pressure during graph build by scanning node records in two passes and allocating exact-sized node/type indexes.
- Store outgoing edge offset indexes in a memory-mapped sidecar instead of a heap `LongArray`.
- Build incoming edge offset indexes lazily and mmap-backed, so builds no longer eagerly allocate both outgoing and incoming offset arrays.
- Cover the mmap offset-index paths and lazy incoming-index scan behavior with tests.

### Documentation and Tests

- Document APK build usage and Android SDK root discovery order in the README.
- Cover `LoaderConfig.androidSdk`, `.apk` loader eligibility, SDK root fallback behavior, APK resource listing, CLI help text, and mmap offset-index behavior.

## Validation

- `./gradlew :core:test :query:test :sootup:test --no-daemon` - passed
- `./gradlew check koverLog :query:shadowJar --no-daemon` - passed; all modules remain above the 98% PR threshold
- `./gradlew :query:test :query:shadowJar --no-daemon` - passed after the SDK-root help text update
- `java -jar graphite-query/build/libs/graphite.jar build --help` shows `--android-sdk` as an SDK-root option with `ANDROID_HOME` / `ANDROID_SDK_ROOT` discovery and no picocli formatting warnings

### Supplied APK

- Installed a real Homebrew Android SDK under `/opt/homebrew/share/android-commandlinetools` with `platforms;android-36`.
- Verified `/Users/admin/Downloads/app.apk` with `targetSdkVersion=36`, `minSdkVersion=24`.
- Smoke APK build: `14,758` nodes, persisted graph query returned the same count, and `AndroidManifest.xml` was queryable.
- Full APK build with `--include com.coupang.mobile`: `5,302,028` nodes, `1,325,114` call sites, output graph `457M`, and `AndroidManifest.xml` was queryable after reload.
- Full APK build without include filtering under `JAVA_TOOL_OPTIONS=-Xmx8g`: `8,060,832` nodes, persisted query returned the same count, and the build completed in `115.03` seconds.
