### PR TITLE
Add memory-safe multi-graph topology overview

### DIFF
--- a/docs/webgraph-optimization-attempts.md
+++ b/docs/webgraph-optimization-attempts.md
@@ -3630,3 +3630,75 @@ loader tests passed.
 field lookup, the top-level cached-field path made the Android build-only score
 worse. Since build-only regressed, no end-to-end benchmark was run. The
 candidate was reverted and no product code from this attempt is retained.
+
+### 2026-08-07 — Attempt 093: Bound multi-graph overview heap with a declaring-class sidecar
+
+**Problem:** a production Explorer loaded 42 graphs containing 80,000,940
+nodes and 91,388,243 edges, then reached almost the full 12 GiB Java heap. The
+multi-graph topology route discovered class ownership by requesting up to
+100,001 fully deserialized `MethodDescriptor` objects per graph. At 42 graphs,
+one request could temporarily materialize more than 4.2 million descriptors,
+while the 100K-per-graph cutoff also made topology incomplete.
+
+**Change:** persisted graphs now write `graph.declaredclasses`, a compact sorted
+list of declaring-class string-table IDs. `Graph.declaredClasses()` exposes the
+same information to the Explorer. MAPPED graphs load the sidecar lazily; old
+graphs without it stream only the declaring-class ID from every method record
+in `graph.metadata` and skip the rest of each descriptor. The graph-overview
+route builds ownership one graph at a time and no longer retains both all
+per-graph class sets and the combined ownership map.
+
+The product's forward adjacency, labels, prefix table, string table, backward
+adjacency, node decoding, and Cypher execution paths are unchanged. An
+experimental mapped-backward-graph change was removed before final baseline
+measurement because the targeted fix did not require it.
+
+**Real-corpus gate:** `RealMultiGraphMemoryBenchmark` runs in a fork with
+`-Xms512m -Xmx8g`. It requires exactly 50 distinct graph directories, rejects
+node-data files that resolve to the same file, and requires at least 100M total
+nodes. It measures both an absent-class call-site search, which forces all 50
+graphs to scan, and `/api/graph-overview`, sampling used heap every 5 ms during
+load and request execution.
+
+Run it on the production corpus with:
+
+```
+./gradlew :explore:realMultiGraphAcceptance \
+  -Pgraphite.multigraph.root=/data/graphs \
+  --no-daemon
+```
+
+The task writes its auditable JSON result to
+`graphite-explore/build/results/jmh/real-multigraph-acceptance.json`.
+
+**Implementation stress result:** before adding the hard-link rejection to the
+final acceptance gate, the implementation was exercised with 50 mapped graph
+directories backed by a repeated 5,336,480-node / 5,380,825-edge production
+graph. This is intentionally not reported as the real-corpus acceptance result;
+it is a 266,824,000-node / 269,041,250-edge pressure test of the code path.
+
+| Operation | Setup peak heap | Request peak heap | Retained heap | Time |
+|-----------|----------------:|------------------:|--------------:|-----:|
+| Global absent call-site search | 2,995,484,720 B | 4,464,016,928 B | 555,848 B | 57,841.856 ms |
+| Multi-graph topology | 2,988,842,256 B | 4,699,806,968 B | 324,534,040 B | 9,157.662 ms |
+
+Both operations completed under `-Xmx8g`; the larger observed request peak was
+about 4.38 GiB.
+
+**Same-machine negative controls:** a detached HEAD worktree and the candidate
+were benchmarked back-to-back with the same fixture and JVM.
+
+| Baseline | HEAD | Candidate | Change |
+|----------|-----:|----------:|-------:|
+| Android build-save-load-query | 30,831.631 ms | 30,799.302 ms | -0.10% |
+| Explorer initial session | 779.317 ms | 772.625 ms | -0.86% |
+| Explorer initial-session max used heap | 96,681,240 B | 96,689,712 B | +8,472 B |
+| MAPPED integer filter | 0.214 ms | 0.225 ms | within JMH error interval |
+| MAPPED simple node match | 0.111 ms | 0.118 ms | within JMH error interval |
+| MAPPED single-hop relationship | 0.869 ms | 0.791 ms | -8.98% |
+
+**Conclusion:** retain the targeted sidecar and streaming compatibility path.
+Functional, build, serve, and representative query baselines show no material
+regression. The implementation stress clears the 8 GiB heap cap with substantial
+headroom, but the final acceptance result remains pending until the benchmark is
+run where the 50 genuinely distinct production graphs are available.

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -14,6 +14,7 @@ graph-dir/
 ├── graph.nodeoffsets  Mmap Node ID -> offset lookup
 ├── graph.typeindex    Mmap node type -> Node ID ranges lookup
 ├── graph.metadata     Methods, type hierarchy, enums, annotations, branch scopes
+├── graph.declaredclasses Compact declaring-class string IDs for multi-graph ownership
 ├── graph.classoverview Persisted explorer overview summary
 └── graph.comparisons  BranchComparison data for ControlFlowEdges
 ```
@@ -40,6 +41,7 @@ transpose construction during load.
 | graph.nodeindex | `GRI` | `0x47524903` |
 | graph.nodeoffsets | `GRL` | `0x47524C03` |
 | graph.typeindex | `GRT` | `0x47525403` |
+| graph.declaredclasses | `GRD` | `0x47524403` |
 | graph.classoverview | `GRO` | `0x47524F03` |
 | graph.comparisons | `GRC` | `0x47524303` |
 
@@ -67,6 +69,7 @@ SootUpAdapter                  GraphStore.save()                 GraphStore.load
                                  5. Labels + label prefix + comparisons write
                                  6. Nodedata + node indexes write
                                  7. Metadata write
+                                 8. Declared-class + overview summaries
 ```
 
 ### Save Flow
@@ -84,6 +87,7 @@ graph TD
     E --> F[5. Write labels + label prefix + comparisons]
     F --> G["6. Write nodedata + nodeindex + mmap node indexes"]
     G --> H[7. Write metadata]
+    H --> I[8. Write declared-class + overview summaries]
 ```
 
 ### Load Flow
@@ -108,6 +112,14 @@ graph TD
 C & D & B3 & B4 & E & F --> G[Construct Graph]
 ```
 
+`graph.declaredclasses` contains only string-table IDs, sorted by class name.
+The Explorer uses it to resolve class ownership across many graphs without
+deserializing millions of `MethodDescriptor` objects. A mapped load does not
+read the sidecar until the graph-overview route needs it. Graphs written by an
+older Graphite version remain compatible: if the sidecar is absent, the reader
+streams only declaring-class IDs from `graph.metadata`, skipping method names,
+parameters, return types, and all trailing metadata.
+
 ### Load Modes
 
 | Mode | Behavior | Threshold | Heap |
@@ -125,6 +137,7 @@ Every optimization must satisfy both simultaneously — trading one for the othe
 |------------|--------|-------------|
 | **Time** | Minimize build + save + load | JMH SingleShotTime, same-session back-to-back |
 | **Peak memory** | <= 4 GB for 10M nodes | `-Xmx4g`, no OOM |
+| **Multi-graph peak heap** | <= 8 GB for 50 distinct graphs / >=100M total nodes | real-corpus JMH, `-Xmx8g`, sampled request peak |
 
 ### Methodology
 
@@ -143,8 +156,17 @@ Use both micro and end-to-end benchmarks. A change is not accepted based on synt
 | `GraphBuildPersistBenchmark` | Synthetic 10M save/load guardrail | `./gradlew :webgraph:jmh -Pjmh.filter=GraphBuildPersistBenchmark` |
 | `GraphEndToEndBenchmark` | Real JAR `build -> save -> load -> query` | `./gradlew :webgraph:jmh -Pjmh.filter=GraphEndToEndBenchmark` |
 | `GraphBenchmark` | Persisted-graph load/query comparisons | `./gradlew :webgraph:jmh -Pjmh.filter='(Es|Android).*(Load|Query)Benchmark'` |
+| `RealMultiGraphMemoryBenchmark` | 50 distinct persisted graphs, global search + topology heap gate | `./gradlew :explore:realMultiGraphAcceptance -Pgraphite.multigraph.root=/data/graphs` |
 
 `GraphEndToEndBenchmark` and `GraphBenchmark` auto-discover fixture JARs from Gradle cache, or accept explicit overrides via `-Delasticsearch.jar.path`, `-Dandroid.jar.path`, `-Delasticsearch.graph.path`, and `-Dandroid.graph.path`.
+
+The real multi-graph suite intentionally does not synthesize scale. Its root
+must contain exactly 50 different persisted graph directories, node-data files
+must not resolve to the same file, and their combined node count must be at
+least 100,000,000. Both setup and requests run in a fork capped at `-Xmx8g`.
+The acceptance task writes a machine-readable report to
+`graphite-explore/build/results/jmh/real-multigraph-acceptance.json` and fails
+the build on the first invalid corpus, OOM, HTTP error, or heap-gate failure.
 
 ### Results Summary
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/DefaultGraph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/DefaultGraph.kt
@@ -129,6 +129,9 @@ class DefaultGraph private constructor(
     override fun methodSlice(pattern: MethodPattern, limit: Int): List<MethodDescriptor> =
         methods(pattern).take(limit.coerceAtLeast(0)).toList()
 
+    override fun declaredClasses(): Set<String> =
+        methodIndex.values.asSequence().mapTo(linkedSetOf()) { it.declaringClass.className }
+
     override fun enumValues(enumClass: String, enumName: String): List<Any?>? =
         enumValues["$enumClass#$enumName"]
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -103,6 +103,12 @@ interface Graph {
     fun methodSlice(pattern: MethodPattern, limit: Int): List<MethodDescriptor>? = null
 
     /**
+     * Return every class that declares at least one method in this graph when
+     * the backend can answer without materializing the complete method index.
+     */
+    fun declaredClasses(): Set<String>? = null
+
+    /**
      * Get the underlying values for an enum constant.
      * Enum constructors can have multiple user-defined arguments.
      *

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/MmapGraph.kt
@@ -167,6 +167,9 @@ class MmapGraph internal constructor(
     override fun methodSlice(pattern: MethodPattern, limit: Int): List<MethodDescriptor> =
         methods(pattern).take(limit.coerceAtLeast(0)).toList()
 
+    override fun declaredClasses(): Set<String> =
+        methodIndex.values.asSequence().mapTo(linkedSetOf()) { it.declaringClass.className }
+
     override fun enumValues(enumClass: String, enumName: String): List<Any?>? =
         enumValuesMap["$enumClass#$enumName"]
 

--- a/graphite-explore/build.gradle.kts
+++ b/graphite-explore/build.gradle.kts
@@ -37,6 +37,18 @@ val integrationFixtureJvmArgs = providers.provider {
     }
 }
 
+val realMultiGraphJvmArgs = providers.provider {
+    listOfNotNull(
+        System.getProperty("graphite.multigraph.root")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "-Dgraphite.multigraph.root=$it" }
+    )
+}
+
+val realMultiGraphRoot = providers.gradleProperty("graphite.multigraph.root")
+    .orElse(providers.systemProperty("graphite.multigraph.root"))
+    .orElse(providers.environmentVariable("GRAPHITE_MULTIGRAPH_ROOT"))
+
 jmh {
     val filter = project.findProperty("jmh.filter") as String?
     if (filter != null) {
@@ -44,6 +56,38 @@ jmh {
     }
     failOnError.set(true)
     jvmArgsAppend.addAll(integrationFixtureJvmArgs)
+    jvmArgsAppend.addAll(realMultiGraphJvmArgs)
+}
+
+val jmhJarTask = tasks.named<Jar>("jmhJar")
+
+tasks.register<JavaExec>("realMultiGraphAcceptance") {
+    group = "verification"
+    description = "Runs the strict 50-graph / 100M-node acceptance suite with an 8 GiB max heap"
+    dependsOn(jmhJarTask)
+    classpath(files(jmhJarTask.flatMap { it.archiveFile }))
+    mainClass.set("org.openjdk.jmh.Main")
+
+    val resultFile = layout.buildDirectory.file("results/jmh/real-multigraph-acceptance.json")
+    outputs.file(resultFile)
+    outputs.upToDateWhen { false }
+
+    doFirst {
+        val graphRoot = realMultiGraphRoot.orNull
+        require(!graphRoot.isNullOrBlank()) {
+            "Set -Pgraphite.multigraph.root=<root>, -Dgraphite.multigraph.root=<root>, " +
+                "or GRAPHITE_MULTIGRAPH_ROOT for the real 50-graph corpus"
+        }
+        val report = resultFile.get().asFile
+        report.parentFile.mkdirs()
+        args(
+            "RealMultiGraphMemoryBenchmark.*",
+            "-foe", "true",
+            "-rf", "json",
+            "-rff", report.absolutePath,
+            "-jvmArgsAppend", "-Dgraphite.multigraph.root=$graphRoot"
+        )
+    }
 }
 
 tasks.jar {

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
@@ -29,7 +29,11 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Comparator
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.LockSupport
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
@@ -505,6 +509,213 @@ open class MultiGraphExplorerBenchmark {
     }
 }
 
+/**
+ * Acceptance benchmark for a real multi-service corpus. The configured root
+ * must contain exactly 50 distinct persisted graph directories totalling at
+ * least 100M nodes. Unlike [MultiGraphExplorerBenchmark], this never repeats a
+ * single fixture to simulate services.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Measurement(iterations = 1)
+@Fork(1, jvmArgs = ["-Xms512m", "-Xmx8g"])
+open class RealMultiGraphMemoryBenchmark {
+
+    @Param("50")
+    var expectedGraphCount: Int = 0
+
+    @Param("100000000")
+    var minimumNodeCount: Long = 0
+
+    @Param("8589934592")
+    var memoryLimitBytes: Long = 0
+
+    private lateinit var registry: GraphRegistry
+    private lateinit var app: Javalin
+    private var port: Int = 0
+    private var setupMaxUsedHeapBytes: Long = 0
+    private var totalNodes: Long = 0
+    private var totalEdges: Long = 0
+
+    @Setup
+    fun setup() {
+        totalNodes = 0
+        totalEdges = 0
+        val root = configuredGraphRoot()
+        val graphPaths = discoverPersistedGraphs(root)
+        require(graphPaths.size == expectedGraphCount) {
+            "Real corpus must contain exactly $expectedGraphCount graphs, found ${graphPaths.size} under $root"
+        }
+        require(graphPaths.map { it.toRealPath() }.distinct().size == expectedGraphCount) {
+            "Real corpus contains duplicate graph directories"
+        }
+        requireDistinctGraphData(graphPaths)
+
+        registry = GraphRegistry(root, GraphStore.LoadMode.MAPPED)
+        val loadMeasurement = measurePeakHeap {
+            graphPaths.forEachIndexed { index, path ->
+                val descriptor = registry.load("service-${index.toString().padStart(2, '0')}", path)
+                totalNodes += descriptor.stats.nodes
+                totalEdges += descriptor.stats.edges
+            }
+        }
+        setupMaxUsedHeapBytes = loadMeasurement.maxUsedHeapBytes
+        require(totalNodes >= minimumNodeCount) {
+            "Real corpus has $totalNodes nodes; at least $minimumNodeCount are required"
+        }
+        check(setupMaxUsedHeapBytes <= memoryLimitBytes) {
+            "50-graph load exceeded heap gate: peak=$setupMaxUsedHeapBytes limit=$memoryLimitBytes"
+        }
+
+        app = Javalin.create { config ->
+            config.jsonMapper(JavalinGson(GsonBuilder().create()))
+        }.start(0)
+        ExploreRoutes().register(app, registry)
+        port = app.port()
+    }
+
+    @TearDown
+    fun tearDown() {
+        runCatching { app.stop() }
+        runCatching { registry.close() }
+    }
+
+    @Benchmark
+    fun real50GraphFullCallSiteSearch(counters: ExplorerMemoryCounters): Long {
+        return measureRealCorpusRequest(counters, "/api/call-sites?class=__graphite_absent__&limit=50")
+    }
+
+    @Benchmark
+    fun real50GraphTopology(counters: ExplorerMemoryCounters): Long =
+        measureRealCorpusRequest(counters, "/api/graph-overview")
+
+    private fun measureRealCorpusRequest(counters: ExplorerMemoryCounters, path: String): Long {
+        forceGcForRealCorpus()
+        val before = realCorpusMemorySample()
+        val measurement = measurePeakHeap {
+            requestRealCorpus(path)
+        }
+        forceGcForRealCorpus()
+        val after = realCorpusMemorySample()
+
+        counters.usedHeapBeforeBytes = before.usedHeapBytes
+        counters.usedHeapAfterBytes = after.usedHeapBytes
+        counters.retainedHeapBytes = after.usedHeapBytes - before.usedHeapBytes
+        counters.maxUsedHeapBytes = maxOf(setupMaxUsedHeapBytes, measurement.maxUsedHeapBytes)
+        counters.committedHeapBeforeBytes = before.committedHeapBytes
+        counters.committedHeapAfterBytes = after.committedHeapBytes
+        counters.maxCommittedHeapBytes = maxOf(before.committedHeapBytes, after.committedHeapBytes)
+        counters.residentSetBeforeBytes = before.residentSetBytes
+        counters.residentSetAfterBytes = after.residentSetBytes
+        counters.maxResidentSetBytes = maxOf(before.residentSetBytes, after.residentSetBytes)
+        counters.memoryLimitBytes = memoryLimitBytes
+        counters.graphCount = expectedGraphCount.toLong()
+        counters.totalNodes = totalNodes
+        counters.totalEdges = totalEdges
+        counters.setupMaxUsedHeapBytes = setupMaxUsedHeapBytes
+
+        check(counters.maxUsedHeapBytes <= memoryLimitBytes) {
+            "50-graph request exceeded heap gate for $path: max=${counters.maxUsedHeapBytes} limit=$memoryLimitBytes"
+        }
+        return measurement.result
+    }
+
+    private fun requestRealCorpus(path: String): Long {
+        val connection = URI("http://localhost:$port$path").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        connection.connectTimeout = REAL_CORPUS_HTTP_TIMEOUT_MS
+        connection.readTimeout = REAL_CORPUS_HTTP_TIMEOUT_MS
+        val code = connection.responseCode
+        val body = if (code in REAL_CORPUS_HTTP_SUCCESS_RANGE) {
+            connection.inputStream.use { it.readBytes() }
+        } else {
+            connection.errorStream?.use { it.readBytes() } ?: ByteArray(0)
+        }
+        connection.disconnect()
+        check(code in REAL_CORPUS_HTTP_SUCCESS_RANGE) { "GET $path returned $code: ${body.decodeToString()}" }
+        return body.size.toLong()
+    }
+
+    private fun configuredGraphRoot(): Path {
+        val configured = System.getProperty(REAL_CORPUS_ROOT_PROPERTY)
+            ?: System.getenv(REAL_CORPUS_ROOT_ENV)
+        require(!configured.isNullOrBlank()) {
+            "Set -D$REAL_CORPUS_ROOT_PROPERTY=<root> or $REAL_CORPUS_ROOT_ENV for the real 50-graph corpus"
+        }
+        return Path.of(configured).toAbsolutePath().normalize().also { root ->
+            require(root.isDirectory()) { "Real multi-graph root is not a directory: $root" }
+        }
+    }
+
+    private fun discoverPersistedGraphs(root: Path): List<Path> =
+        Files.walk(root, REAL_CORPUS_MAX_DEPTH).use { paths ->
+            paths.filter { path -> path.fileName.toString() == REAL_CORPUS_NODE_DATA_FILE && path.isRegularFile() }
+                .map { it.parent }
+                .sorted()
+                .toList()
+        }
+
+    private fun requireDistinctGraphData(graphPaths: List<Path>) {
+        val nodeDataFiles = graphPaths.map { it.resolve(REAL_CORPUS_NODE_DATA_FILE) }
+        nodeDataFiles.forEachIndexed { index, current ->
+            for (otherIndex in 0 until index) {
+                require(!Files.isSameFile(current, nodeDataFiles[otherIndex])) {
+                    "Real corpus reuses graph data: ${graphPaths[otherIndex]} and ${graphPaths[index]}"
+                }
+            }
+        }
+    }
+
+    private companion object {
+        private const val REAL_CORPUS_ROOT_PROPERTY = "graphite.multigraph.root"
+        private const val REAL_CORPUS_ROOT_ENV = "GRAPHITE_MULTIGRAPH_ROOT"
+        private const val REAL_CORPUS_NODE_DATA_FILE = "graph.nodedata"
+        private const val REAL_CORPUS_MAX_DEPTH = 6
+        private const val REAL_CORPUS_HTTP_TIMEOUT_MS = 30 * 60 * 1_000
+        private val REAL_CORPUS_HTTP_SUCCESS_RANGE = 200..299
+    }
+}
+
+private data class PeakHeapMeasurement<T>(val result: T, val maxUsedHeapBytes: Long)
+
+private fun <T> measurePeakHeap(block: () -> T): PeakHeapMeasurement<T> {
+    val running = AtomicBoolean(true)
+    val maximum = AtomicLong(realCorpusMemorySample().usedHeapBytes)
+    val sampler = thread(start = true, isDaemon = true, name = "graphite-heap-peak-sampler") {
+        while (running.get()) {
+            maximum.accumulateAndGet(realCorpusMemorySample().usedHeapBytes, ::maxOf)
+            LockSupport.parkNanos(REAL_CORPUS_SAMPLE_NANOS)
+        }
+    }
+    return try {
+        val result = block()
+        maximum.accumulateAndGet(realCorpusMemorySample().usedHeapBytes, ::maxOf)
+        PeakHeapMeasurement(result, maximum.get())
+    } finally {
+        running.set(false)
+        sampler.join()
+    }
+}
+
+private fun realCorpusMemorySample(): MemorySample {
+    val runtime = Runtime.getRuntime()
+    val committed = runtime.totalMemory()
+    return MemorySample(committed - runtime.freeMemory(), committed, committed)
+}
+
+private fun forceGcForRealCorpus() {
+    repeat(REAL_CORPUS_GC_ATTEMPTS) {
+        System.gc()
+        System.runFinalization()
+        Thread.sleep(REAL_CORPUS_GC_PAUSE_MS)
+    }
+}
+
+private const val REAL_CORPUS_SAMPLE_NANOS = 5_000_000L
+private const val REAL_CORPUS_GC_ATTEMPTS = 3
+private const val REAL_CORPUS_GC_PAUSE_MS = 100L
+
 private data class MemorySample(
     val usedHeapBytes: Long,
     val committedHeapBytes: Long,
@@ -567,6 +778,18 @@ open class ExplorerMemoryCounters {
 
     @JvmField
     var residentSetMeasured: Long = 0
+
+    @JvmField
+    var graphCount: Long = 0
+
+    @JvmField
+    var totalNodes: Long = 0
+
+    @JvmField
+    var totalEdges: Long = 0
+
+    @JvmField
+    var setupMaxUsedHeapBytes: Long = 0
 }
 
 private object ExplorerBenchmarkCorpus {

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
@@ -31,6 +31,7 @@ internal class ExploreRoutes {
     internal fun register(app: Javalin, graph: Graph) {
         val provider = StaticGraphProvider(STANDALONE_GRAPH_ID, graph)
         registerStaticGraphRoutes(app, graphStats(graph))
+        registerGraphOverviewRoute(app) { ctx -> listOfNotNull(provider.acquire(ctx)) }
         registerGraphRoutes(app, API_ROOT, provider)
         val scopedPrefix = "$API_ROOT/graphs/{$API_FIELD_GRAPH_ID}"
         registerGraphRoutes(app, scopedPrefix, provider)
@@ -40,6 +41,7 @@ internal class ExploreRoutes {
 
     internal fun register(app: Javalin, registry: GraphRegistry) {
         registerRegistryRoutes(app, registry)
+        registerGraphOverviewRoute(app) { registry.acquireAll() }
         registerAllGraphRoutes(app) { registry.acquireAll() }
         val scopedPrefix = "$API_ROOT/graphs/{$API_FIELD_GRAPH_ID}"
         val provider = RegistryPathGraphProvider(registry)
@@ -72,6 +74,20 @@ internal class ExploreRoutes {
                 .onFailure { error ->
                     ctx.status(HTTP_BAD_REQUEST).json(mapOf(API_FIELD_ERROR to error.message))
                 }
+        }
+    }
+
+    private fun registerGraphOverviewRoute(
+        app: Javalin,
+        acquire: (Context) -> List<GraphLease>
+    ) {
+        app.get("$API_ROOT/graph-overview") { ctx ->
+            withAllGraphs(ctx, acquire) { leases ->
+                val inputs = leases.map { lease ->
+                    GraphOverviewInput(lease.id, lease.graph, graphStats(lease.graph))
+                }
+                ctx.json(buildGraphOverview(inputs))
+            }
         }
     }
 

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/GraphOverviewInput.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/GraphOverviewInput.kt
@@ -1,0 +1,117 @@
+package io.johnsonlee.graphite.cli
+
+import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.graph.ClassDependency
+import io.johnsonlee.graphite.graph.ClassOverview
+import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.MethodPattern
+
+internal data class GraphOverviewInput(
+    val id: String,
+    val graph: Graph,
+    val stats: GraphStats
+)
+
+private data class GraphRelation(
+    val callerGraph: String,
+    val calleeGraph: String
+)
+
+private data class DeclaredClassesResult(val classes: Set<String>, val truncated: Boolean)
+
+internal fun buildGraphOverview(inputs: List<GraphOverviewInput>): Map<String, Any?> {
+    val summaries = inputs.associate { input -> input.id to loadClassOverview(input.graph) }
+    val classOwners = mutableMapOf<String, MutableSet<String>>()
+    var ownershipTruncated = false
+    inputs.forEach { input ->
+        val declared = loadDeclaredClasses(input.graph, summaries.getValue(input.id))
+        ownershipTruncated = ownershipTruncated || declared.truncated
+        declared.classes.forEach { className ->
+            classOwners.getOrPut(className, ::linkedSetOf).add(input.id)
+        }
+    }
+
+    val relationWeights = mutableMapOf<GraphRelation, Int>()
+    summaries.forEach { (sourceGraph, overview) ->
+        overview.classEdges.forEach { (dependency, weight) ->
+            val owners = classOwners[dependency.calleeClass].orEmpty()
+            if (sourceGraph !in owners && owners.size == 1) {
+                val targetGraph = owners.single()
+                val relation = GraphRelation(sourceGraph, targetGraph)
+                relationWeights[relation] = (relationWeights[relation] ?: 0) + weight
+            }
+        }
+    }
+
+    val nodes = inputs.map { input ->
+        mapOf(
+            API_FIELD_ID to input.id,
+            API_FIELD_GRAPH_ID to input.id,
+            API_FIELD_TYPE to GRAPH_NODE_TYPE,
+            API_FIELD_LABEL to input.id
+        ) + input.stats.toApiMap()
+    }
+    val edges = relationWeights.entries
+        .sortedWith(compareBy({ it.key.callerGraph }, { it.key.calleeGraph }))
+        .map { (relation, weight) ->
+            mapOf(
+                "from" to relation.callerGraph,
+                "to" to relation.calleeGraph,
+                API_FIELD_TYPE to GRAPH_CALL_EDGE_TYPE,
+                "weight" to weight
+            )
+        }
+
+    return mapOf(
+        "graphCount" to inputs.size,
+        API_FIELD_NODES to nodes,
+        API_FIELD_EDGES to edges,
+        "relationCount" to edges.size,
+        "crossGraphCallSites" to relationWeights.values.sum(),
+        "truncated" to ownershipTruncated
+    )
+}
+
+private fun loadDeclaredClasses(graph: Graph, overview: ClassOverview): DeclaredClassesResult {
+    graph.declaredClasses()?.let { return DeclaredClassesResult(it, false) }
+    val classes = linkedSetOf<String>()
+    overview.classEdges.keys.forEach { classes.add(it.callerClass) }
+    val methods = graph.methodSlice(MethodPattern(), MAX_GRAPH_OVERVIEW_METHODS + 1)
+        ?: graph.methods(MethodPattern()).take(MAX_GRAPH_OVERVIEW_METHODS + 1).toList()
+    methods.asSequence()
+        .take(MAX_GRAPH_OVERVIEW_METHODS)
+        .mapTo(classes) { it.declaringClass.className }
+    return DeclaredClassesResult(
+        classes,
+        graph.methodCount()?.let { it > MAX_GRAPH_OVERVIEW_METHODS } ?: (methods.size > MAX_GRAPH_OVERVIEW_METHODS)
+    )
+}
+
+private fun loadClassOverview(graph: Graph): ClassOverview =
+    runCatching { graph.classOverview(MAX_GRAPH_OVERVIEW_CLASSES) }.getOrNull()
+        ?: buildClassOverviewFromCallSites(graph)
+
+private fun buildClassOverviewFromCallSites(graph: Graph): ClassOverview {
+    val classEdges = mutableMapOf<ClassDependency, Int>()
+    val classCounts = mutableMapOf<String, Int>()
+    var scanned = 0
+    for (callSite in graph.nodes(CallSiteNode::class.java)) {
+        if (scanned >= MAX_GRAPH_OVERVIEW_CALL_SITES) break
+        scanned++
+        val callerClass = callSite.caller.declaringClass.className
+        val calleeClass = callSite.callee.declaringClass.className
+        classCounts[callerClass] = (classCounts[callerClass] ?: 0) + 1
+        classCounts[calleeClass] = (classCounts[calleeClass] ?: 0) + 1
+        if (callerClass != calleeClass) {
+            val dependency = ClassDependency(callerClass, calleeClass)
+            classEdges[dependency] = (classEdges[dependency] ?: 0) + 1
+        }
+    }
+    return ClassOverview(classCounts, classEdges, scanned)
+}
+
+private const val GRAPH_NODE_TYPE = "Graph"
+private const val GRAPH_CALL_EDGE_TYPE = "GraphCall"
+private const val MAX_GRAPH_OVERVIEW_CLASSES = 1_000
+private const val MAX_GRAPH_OVERVIEW_METHODS = 100_000
+private const val MAX_GRAPH_OVERVIEW_CALL_SITES = 100_000

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
@@ -11,6 +11,13 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf("200" to response("Loaded graph registry, per-graph statistics, and totals"))
                 )
             ),
+            "/api/graph-overview" to mapOf(
+                "get" to operation(
+                    "Build the loaded graph topology from cross-graph call relationships",
+                    parameters = emptyList(),
+                    responses = mapOf("200" to response("Graph-level nodes and aggregated cross-graph call edges"))
+                )
+            ),
             "/api/graphs/{graphId}" to mapOf(
                 "get" to operation(
                     "Get metadata and cached statistics for one graph",

--- a/graphite-explore/src/main/resources/web/app.js
+++ b/graphite-explore/src/main/resources/web/app.js
@@ -1,7 +1,8 @@
 let cy;
+let dashboardInfo;
 
 const NODE_COLORS = {
-    Class: '#58a6ff',
+    Graph: '#58a6ff', Class: '#58a6ff',
     CallSiteNode: '#f85149',
     IntConstant: '#39d2c0', StringConstant: '#58a6ff', EnumConstant: '#d29922',
     FieldNode: '#bc8cff', ParameterNode: '#3fb950', ReturnNode: '#f778ba',
@@ -11,10 +12,10 @@ const NODE_COLORS = {
 };
 
 const NODE_SIZES = {
-    Class: 32, CallSiteNode: 28, FieldNode: 22, ParameterNode: 18, ReturnNode: 18, LocalVariable: 14
+    Graph: 72, Class: 32, CallSiteNode: 28, FieldNode: 22, ParameterNode: 18, ReturnNode: 18, LocalVariable: 14
 };
 
-const EDGE_COLORS = { DataFlow: '#30363d', Call: '#f85149', Type: '#bc8cff', ControlFlow: '#d29922' };
+const EDGE_COLORS = { GraphCall: '#f85149', DataFlow: '#30363d', Call: '#f85149', Type: '#bc8cff', ControlFlow: '#d29922' };
 
 function initCytoscape() {
     cy = cytoscape({
@@ -27,9 +28,19 @@ function initCytoscape() {
                 'border-width': 0, 'text-max-width': '120px', 'text-wrap': 'ellipsis'
             }},
             { selector: 'edge', style: {
-                'width': 1.2, 'line-color': 'data(color)', 'target-arrow-color': 'data(color)',
+                'width': 'data(width)', 'line-color': 'data(color)', 'target-arrow-color': 'data(color)',
                 'target-arrow-shape': 'triangle', 'arrow-scale': 0.8,
                 'curve-style': 'bezier', 'opacity': 0.6
+            }},
+            { selector: 'node[nodeType = "Graph"]', style: {
+                'shape': 'round-rectangle', 'color': '#e6edf3', 'font-size': '12px', 'font-weight': 600,
+                'text-valign': 'center', 'text-margin-y': 0, 'border-width': 2, 'border-color': '#79c0ff',
+                'text-max-width': '150px'
+            }},
+            { selector: 'edge[edgeType = "GraphCall"]', style: {
+                'label': 'data(label)', 'color': '#d29922', 'font-size': '10px',
+                'text-background-color': '#0d1117', 'text-background-opacity': 0.85,
+                'text-background-padding': '3px', 'text-rotation': 'autorotate', 'opacity': 0.85
             }},
             { selector: 'node:selected', style: { 'border-width': 2, 'border-color': '#58a6ff' }},
             { selector: 'node.highlighted', style: { 'border-width': 2, 'border-color': '#fff', 'z-index': 10 }},
@@ -41,21 +52,34 @@ function initCytoscape() {
 
     cy.on('tap', 'node', e => {
         const nodeId = e.target.data('nodeId');
-        if (Number.isInteger(nodeId)) showNodeDetail(e.target.data('graphId'), nodeId);
+        if (Number.isInteger(nodeId)) {
+            showNodeDetail(e.target.data('graphId'), nodeId);
+        } else if (e.target.data('nodeType') === 'Graph') {
+            showGraphDetail(e.target.data('nodeData'));
+        }
     });
     cy.on('dbltap', 'node', e => {
         const nodeId = e.target.data('nodeId');
-        if (Number.isInteger(nodeId)) loadSubgraph(e.target.data('graphId'), nodeId, 2);
+        if (Number.isInteger(nodeId)) {
+            loadSubgraph(e.target.data('graphId'), nodeId, 2);
+        } else if (e.target.data('nodeType') === 'Graph') {
+            loadSingleGraphOverview(e.target.data('graphId'));
+        }
     });
     cy.on('tap', 'edge', e => {
         const nodeId = e.target.data('targetNodeId');
-        if (Number.isInteger(nodeId)) showNodeDetail(e.target.data('graphId'), nodeId);
+        if (Number.isInteger(nodeId)) {
+            showNodeDetail(e.target.data('graphId'), nodeId);
+        } else if (e.target.data('edgeType') === 'GraphCall') {
+            showGraphRelationDetail(e.target.data('edgeData'));
+        }
     });
 }
 
 async function loadDashboard() {
     const res = await fetch('/api/graphs');
     const info = await res.json();
+    dashboardInfo = info;
 
     const totals = info.totals || info;
     document.querySelector('#stat-nodes .stat-value').textContent = totals.nodes.toLocaleString();
@@ -63,11 +87,54 @@ async function loadDashboard() {
     document.querySelector('#stat-methods .stat-value').textContent = totals.methods.toLocaleString();
     document.querySelector('#stat-callsites .stat-value').textContent = totals.callSites.toLocaleString();
 
-    await loadTopClasses();
-    await loadInitialGraph();
+    if ((info.count || 0) > 1) {
+        loadGraphList(info.graphs || []);
+        await loadGraphTopology();
+    } else {
+        await loadTopClasses();
+        await loadInitialGraph();
+    }
+}
+
+function loadGraphList(graphs) {
+    document.getElementById('navigation-title').textContent = 'Graphs';
+    const list = document.getElementById('class-list');
+    list.innerHTML = '';
+    graphs.forEach(function(graph) {
+        const div = document.createElement('div');
+        div.className = 'item';
+        div.innerHTML = '<span class="item-badge badge-graph">' + Number(graph.callSites || 0).toLocaleString() + '</span>' + graph.id;
+        div.title = Number(graph.nodes || 0).toLocaleString() + ' nodes, ' + Number(graph.edges || 0).toLocaleString() + ' edges';
+        div.onclick = function() {
+            const node = cy.getElementById(graphElementId(graph.id));
+            if (node.length) {
+                cy.elements().removeClass('highlighted');
+                node.addClass('highlighted');
+                cy.animate({ center: { eles: node }, zoom: 1.3, duration: 250 });
+            }
+            showGraphDetail(graph);
+        };
+        list.appendChild(div);
+    });
+}
+
+async function loadGraphTopology() {
+    const res = await fetch('/api/graph-overview');
+    const data = await res.json();
+    data.nodes.forEach(function(node) { node.elementId = graphElementId(node.id); });
+    data.edges.forEach(function(edge) {
+        edge.fromElementId = graphElementId(edge.from);
+        edge.toElementId = graphElementId(edge.to);
+    });
+    renderGraph(data, null, 'graphs');
+    let info = data.graphCount + ' graphs, ' + data.relationCount + ' call relations, ' +
+        Number(data.crossGraphCallSites || 0).toLocaleString() + ' cross-graph calls';
+    if (data.truncated) info += ' (ownership sample limited)';
+    document.getElementById('graph-info').textContent = info;
 }
 
 async function loadTopClasses() {
+    document.getElementById('navigation-title').textContent = 'Top Classes';
     const res = await fetch('/api/methods?limit=200');
     const response = await res.json();
     const methods = flattenGroupedData(response);
@@ -104,6 +171,50 @@ async function loadInitialGraph() {
     renderGraph(data, null);
     document.getElementById('graph-info').textContent = `${data.nodes.length} nodes, ${data.edges.length} edges`;
 }
+
+async function loadSingleGraphOverview(graphId) {
+    const res = await fetch('/api/graphs/' + encodeURIComponent(graphId) + '/overview');
+    const data = await res.json();
+    data.nodes.forEach(function(node) {
+        node.graphId = graphId;
+        node.elementId = graphId + ':' + node.id;
+    });
+    data.edges.forEach(function(edge) {
+        edge.graphId = graphId;
+        edge.fromElementId = graphId + ':' + edge.from;
+        edge.toElementId = graphId + ':' + edge.to;
+    });
+    renderGraph(data, null);
+    document.getElementById('graph-info').textContent = graphId + ': ' + data.nodes.length + ' classes, ' + data.edges.length + ' calls';
+}
+
+function showGraphDetail(graph) {
+    cy.elements().removeClass('highlighted');
+    const cyNode = cy.getElementById(graphElementId(graph.graphId || graph.id));
+    if (cyNode.length) cyNode.addClass('highlighted');
+    const graphId = graph.graphId || graph.id;
+    const panel = document.getElementById('detail-content');
+    panel.innerHTML = '<div class="detail-block"><h4>Graph</h4>' +
+        '<div class="detail-row"><span class="detail-key">ID</span><span class="detail-value">' + graphId + '</span></div>' +
+        graphMetricRow('Nodes', graph.nodes) + graphMetricRow('Edges', graph.edges) +
+        graphMetricRow('Methods', graph.methods) + graphMetricRow('Call sites', graph.callSites) +
+        '</div><div class="detail-block"><button onclick="loadSingleGraphOverview(' + htmlJsString(graphId) + ')">Explore classes</button></div>' +
+        '<p class="hint">Double-click the graph node to drill down.</p>';
+}
+
+function showGraphRelationDetail(edge) {
+    const panel = document.getElementById('detail-content');
+    panel.innerHTML = '<div class="detail-block"><h4>Cross-graph calls</h4>' +
+        '<div class="relation-route"><span>' + edge.from + '</span><strong>&rarr;</strong><span>' + edge.to + '</span></div>' +
+        graphMetricRow('Call sites', edge.weight) + '</div>';
+}
+
+function graphMetricRow(label, value) {
+    return '<div class="detail-row"><span class="detail-key">' + label + '</span><span class="detail-value">' +
+        Number(value || 0).toLocaleString() + '</span></div>';
+}
+
+function graphElementId(graphId) { return 'graph:' + graphId; }
 
 async function showNodeDetail(graphId, nodeId) {
     const prefix = '/api/graphs/' + encodeURIComponent(graphId);
@@ -161,7 +272,7 @@ async function loadSubgraph(graphId, centerId, depth) {
     document.getElementById('graph-info').textContent = data.nodes.length + ' nodes, ' + data.edges.length + ' edges';
 }
 
-function renderGraph(data, centerId) {
+function renderGraph(data, centerId, viewMode) {
     const elements = [];
     const seen = new Set();
 
@@ -171,9 +282,10 @@ function renderGraph(data, centerId) {
         seen.add(elementId);
         elements.push({ data: {
             id: elementId, graphId: n.graphId, nodeId: n.id,
+            nodeType: n.type, nodeData: n,
             label: truncate(n.label || n.type, 25),
             color: NODE_COLORS[n.type] || '#8b949e',
-            size: NODE_SIZES[n.type] || 16
+            size: n.type === 'Graph' ? graphNodeSize(n.callSites) : (NODE_SIZES[n.type] || 16)
         }});
     });
 
@@ -182,9 +294,10 @@ function renderGraph(data, centerId) {
         const to = e.toElementId || (e.graphId + ':' + e.to);
         if (!seen.has(from) || !seen.has(to)) return;
         elements.push({ data: {
-            id: e.graphId + ':e:' + e.from + '-' + e.to + '-' + i,
+            id: (e.graphId || 'graphs') + ':e:' + e.from + '-' + e.to + '-' + i,
             source: from, target: to, graphId: e.graphId, targetNodeId: e.to,
-            color: EDGE_COLORS[e.type] || '#30363d'
+            edgeType: e.type, edgeData: e, label: e.type === 'GraphCall' ? Number(e.weight || 0).toLocaleString() : '',
+            color: EDGE_COLORS[e.type] || '#30363d', width: graphEdgeWidth(e)
         }});
     });
 
@@ -193,7 +306,9 @@ function renderGraph(data, centerId) {
 
     // Use fast layout for large graphs, detailed layout for small subgraphs
     var isLarge = elements.length > 200;
-    var layoutOpts = isLarge
+    var layoutOpts = viewMode === 'graphs'
+        ? { name: 'cose', animate: true, animationDuration: 500, nodeRepulsion: function() { return 28000; }, idealEdgeLength: function() { return 180; }, gravity: 0.2, numIter: 400 }
+        : isLarge
         ? { name: 'concentric', concentric: function(n) { return n.degree(); }, levelWidth: function() { return 3; }, animate: false, minNodeSpacing: 10 }
         : { name: 'cose', animate: true, animationDuration: 400, nodeRepulsion: function() { return 12000; }, idealEdgeLength: function() { return 80; }, gravity: 0.3, numIter: 200 };
     cy.layout(layoutOpts).run();
@@ -208,6 +323,15 @@ function renderGraph(data, centerId) {
     } else {
         cy.fit(null, 30);
     }
+}
+
+function graphNodeSize(callSites) {
+    return Math.max(NODE_SIZES.Graph, Math.min(112, 64 + Math.log10(Number(callSites || 0) + 1) * 8));
+}
+
+function graphEdgeWidth(edge) {
+    if (edge.type !== 'GraphCall') return 1.2;
+    return Math.max(1.5, Math.min(8, 1.5 + Math.log10(Number(edge.weight || 0) + 1) * 1.8));
 }
 
 function truncate(s, len) { return s.length > len ? s.substring(0, len) + '...' : s; }
@@ -309,7 +433,10 @@ document.getElementById('search-btn').addEventListener('click', search);
 document.getElementById('search').addEventListener('keypress', function(e) { if (e.key === 'Enter') search(); });
 document.getElementById('close-results').addEventListener('click', function() { document.getElementById('results-section').style.display = 'none'; });
 document.getElementById('btn-fit').addEventListener('click', function() { cy.fit(null, 30); });
-document.getElementById('btn-reset').addEventListener('click', function() { cy.elements().remove(); loadInitialGraph(); });
+document.getElementById('btn-reset').addEventListener('click', function() {
+    cy.elements().remove();
+    if (dashboardInfo && (dashboardInfo.count || 0) > 1) loadGraphTopology(); else loadInitialGraph();
+});
 
 // Load Cypher result nodes onto the canvas
 async function loadCypherResults(nodeRefs) {

--- a/graphite-explore/src/main/resources/web/index.html
+++ b/graphite-explore/src/main/resources/web/index.html
@@ -41,7 +41,7 @@
             </section>
 
             <section id="top-classes">
-                <h3>Top Classes</h3>
+                <h3 id="navigation-title">Top Classes</h3>
                 <div id="class-list" class="item-list"></div>
             </section>
 
@@ -56,7 +56,7 @@
             <section id="detail-section">
                 <h3>Details</h3>
                 <div id="detail-content">
-                    <p class="hint">Click a node in the graph to inspect it</p>
+                    <p class="hint">Click a node to inspect it; double-click a graph to explore its classes</p>
                 </div>
             </section>
         </aside>

--- a/graphite-explore/src/main/resources/web/style.css
+++ b/graphite-explore/src/main/resources/web/style.css
@@ -141,6 +141,7 @@ main { flex: 1; display: flex; overflow: hidden; }
 }
 .badge-methods { background: rgba(88, 166, 255, 0.15); color: var(--accent); }
 .badge-callsite { background: rgba(248, 81, 73, 0.15); color: var(--red); }
+.badge-graph { background: rgba(63, 185, 80, 0.15); color: var(--green); min-width: 44px; text-align: center; }
 
 .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
 .btn-icon { background: none; border: none; color: var(--text-secondary); font-size: 18px; cursor: pointer; line-height: 1; }
@@ -166,6 +167,10 @@ main { flex: 1; display: flex; overflow: hidden; }
 .detail-value { color: var(--text-primary); word-break: break-all; }
 .detail-edge { padding: 4px 8px; margin: 2px 0; border-radius: 4px; background: var(--bg-primary); font-size: 11px; font-family: monospace; cursor: pointer; }
 .detail-edge:hover { background: var(--bg-tertiary); }
+.detail-block button { padding: 5px 10px; background: var(--bg-tertiary); border: 1px solid var(--border); color: var(--text-primary); border-radius: 5px; cursor: pointer; }
+.detail-block button:hover { border-color: var(--accent); }
+.relation-route { display: flex; align-items: center; gap: 8px; padding: 10px; margin-bottom: 8px; background: var(--bg-primary); border: 1px solid var(--border); border-radius: 6px; font-family: monospace; color: var(--accent); }
+.relation-route strong { color: var(--red); }
 
 #graph-area { flex: 1; position: relative; background: var(--bg-primary); }
 #cy { width: 100%; height: 100%; }

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -390,6 +390,14 @@ class ExploreCommandTest {
         assertEquals(404, get("/api/graphs/missing").first)
         assertEquals(400, get("/api/graphs/bad%20id").first)
         assertEquals(404, get("/api/info").first)
+
+        val (overviewCode, overviewBody) = get("/api/graph-overview")
+        assertEquals(200, overviewCode, overviewBody)
+        val graphOverview: Map<String, Any?> = parseJson(overviewBody)
+        assertEquals(1.0, graphOverview["graphCount"])
+        @Suppress("UNCHECKED_CAST")
+        val graphNodes = graphOverview[API_FIELD_NODES] as List<Map<String, Any?>>
+        assertEquals(STANDALONE_GRAPH_ID, graphNodes.single()[API_FIELD_ID])
     }
 
     @Test
@@ -1331,6 +1339,7 @@ class ExploreCommandTest {
         val paths = result["paths"] as Map<String, Map<String, Any?>>
         assertTrue(paths.containsKey("/api/cypher"))
         assertTrue(paths.containsKey("/api/graphs"))
+        assertTrue(paths.containsKey("/api/graph-overview"))
         assertTrue(paths.containsKey("/api/graphs/{graphId}"))
         assertTrue(paths.containsKey("/api/graphs/{graphId}/cypher"))
         assertFalse(paths.containsKey("/api/info"))

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/GraphOverviewTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/GraphOverviewTest.kt
@@ -1,0 +1,94 @@
+package io.johnsonlee.graphite.cli
+
+import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.core.MethodDescriptor
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.TypeDescriptor
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.Graph
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GraphOverviewTest {
+
+    private val sourceMethod = method("com.example.orders.OrderService", "submit")
+    private val targetMethod = method("com.example.payments.PaymentService", "charge")
+
+    @Test
+    fun `aggregates calls between graphs`() {
+        val source = graph(
+            methods = listOf(sourceMethod),
+            calls = listOf(sourceMethod to targetMethod, sourceMethod to targetMethod)
+        )
+        val target = graph(methods = listOf(targetMethod))
+
+        val overview = buildGraphOverview(listOf(input("orders", source), input("payments", target)))
+
+        @Suppress("UNCHECKED_CAST")
+        val nodes = overview[API_FIELD_NODES] as List<Map<String, Any?>>
+        @Suppress("UNCHECKED_CAST")
+        val edges = overview[API_FIELD_EDGES] as List<Map<String, Any?>>
+        assertEquals(listOf("orders", "payments"), nodes.map { it[API_FIELD_ID] })
+        assertEquals(1, edges.size)
+        assertEquals("orders", edges.single()["from"])
+        assertEquals("payments", edges.single()["to"])
+        assertEquals("GraphCall", edges.single()[API_FIELD_TYPE])
+        assertEquals(2, edges.single()["weight"])
+        assertEquals(2, overview["graphCount"])
+        assertEquals(1, overview["relationCount"])
+        assertEquals(2, overview["crossGraphCallSites"])
+        assertFalse(overview["truncated"] as Boolean)
+    }
+
+    @Test
+    fun `does not infer ambiguous or internal calls as cross graph calls`() {
+        val sourceOwningTarget = graph(
+            methods = listOf(sourceMethod, targetMethod),
+            calls = listOf(sourceMethod to targetMethod)
+        )
+        val duplicateOwner = graph(methods = listOf(targetMethod))
+
+        val internal = buildGraphOverview(
+            listOf(input("orders", sourceOwningTarget), input("payments", duplicateOwner))
+        )
+        @Suppress("UNCHECKED_CAST")
+        assertTrue((internal[API_FIELD_EDGES] as List<Any>).isEmpty())
+
+        val externalSource = graph(
+            methods = listOf(sourceMethod),
+            calls = listOf(sourceMethod to targetMethod)
+        )
+        val ambiguous = buildGraphOverview(
+            listOf(
+                input("orders", externalSource),
+                input("payments-primary", graph(methods = listOf(targetMethod))),
+                input("payments-copy", graph(methods = listOf(targetMethod)))
+            )
+        )
+        @Suppress("UNCHECKED_CAST")
+        assertTrue((ambiguous[API_FIELD_EDGES] as List<Any>).isEmpty())
+    }
+
+    private fun input(id: String, graph: Graph) = GraphOverviewInput(id, graph, graphStats(graph))
+
+    private fun graph(
+        methods: List<MethodDescriptor>,
+        calls: List<Pair<MethodDescriptor, MethodDescriptor>> = emptyList()
+    ): Graph {
+        val builder = DefaultGraph.Builder()
+        methods.forEach(builder::addMethod)
+        calls.forEach { (caller, callee) ->
+            builder.addNode(CallSiteNode(NodeId.next(), caller, callee, 1, null, emptyList()))
+        }
+        return builder.build()
+    }
+
+    private fun method(className: String, name: String) = MethodDescriptor(
+        TypeDescriptor(className),
+        name,
+        emptyList(),
+        TypeDescriptor("void")
+    )
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/DeclaredClassStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/DeclaredClassStore.kt
@@ -1,0 +1,48 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.MethodDescriptor
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal object DeclaredClassStore {
+    const val FILE_NAME = "graph.declaredclasses"
+    private const val MAGIC_DECLARED_CLASSES = 0x47524400 // "GRD"
+
+    fun save(methods: Collection<MethodDescriptor>, dir: Path, strings: StringTable) {
+        val classes = methods.asSequence()
+            .map { it.declaringClass.className }
+            .distinct()
+            .sorted()
+            .toList()
+        DataOutputStream(BufferedOutputStream(dir.resolve(FILE_NAME).toFile().outputStream())).use { dos ->
+            NodeSerializer.writeHeader(dos, MAGIC_DECLARED_CLASSES)
+            dos.writeInt(classes.size)
+            classes.forEach { className ->
+                val index = strings.indexOf(className)
+                require(index >= 0) { "String not found in persisted table: $className" }
+                dos.writeInt(index)
+            }
+        }
+    }
+
+    fun load(dir: Path, metadataFile: Path, strings: StringTable): Set<String> {
+        val file = dir.resolve(FILE_NAME)
+        if (!Files.isRegularFile(file)) {
+            return DataInputStream(BufferedInputStream(metadataFile.toFile().inputStream())).use { dis ->
+                NodeSerializer.readMetadataDeclaredClasses(dis, strings)
+            }
+        }
+        return DataInputStream(BufferedInputStream(file.toFile().inputStream())).use { dis ->
+            NodeSerializer.readHeader(dis, MAGIC_DECLARED_CLASSES)
+            val count = dis.readInt()
+            require(count >= 0) { "Invalid declared class count: $count" }
+            LinkedHashSet<String>(count).apply {
+                repeat(count) { add(strings.get(dis.readInt())) }
+            }
+        }
+    }
+}

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -607,7 +607,8 @@ object GraphStore {
             NodeSerializer.saveMetadata(metadata, dos, stringTable)
         }
 
-        // 8. Save class-level overview summary for explorer routes
+        // 8. Save compact class-ownership and Explorer overview summaries
+        DeclaredClassStore.save(metadata.methods.values, dir, stringTable)
         ClassOverviewStore.save(
             ClassOverview(
                 classCounts = classOverviewCounts,
@@ -818,6 +819,7 @@ object GraphStore {
             }
         }
         val classOverview = PersistedClassOverviewProvider(dir, stringTable)::load
+        val declaredClasses = { DeclaredClassStore.load(dir, metadataFile, stringTable) }
 
         return MappedWebGraphBackedGraph(
             forward = forward,
@@ -832,6 +834,7 @@ object GraphStore {
             edgeCount = labelBytes.size.toLong(),
             metadataFile = metadataFile.toFile(),
             methodCount = methodCount,
+            declaredClassProvider = declaredClasses,
             comparisonLookup = comparisonLookup,
             metadata = metadata,
             classOverviewProvider = classOverview,

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -60,6 +60,7 @@ internal class MappedWebGraphBackedGraph(
     private val edgeCount: Long,
     private val metadataFile: File,
     private val methodCount: Long,
+    private val declaredClassProvider: () -> Set<String>,
     private val comparisonLookup: BranchComparisonLookup,
     private val metadata: Lazy<GraphMetadata>,
     private val classOverviewProvider: (Int) -> ClassOverview?,
@@ -164,6 +165,8 @@ internal class MappedWebGraphBackedGraph(
         DataInputStream(BufferedInputStream(metadataFile.inputStream())).use { dis ->
             NodeSerializer.readMetadataMethodSlice(dis, stringTable, pattern, limit)
         }
+
+    override fun declaredClasses(): Set<String> = declaredClassProvider()
 
     override fun enumValues(enumClass: String, enumName: String): List<Any?>? =
         metadata.value.enumValues["$enumClass#$enumName"]

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/NodeSerializer.kt
@@ -776,6 +776,22 @@ internal object NodeSerializer {
         return result
     }
 
+    fun readMetadataDeclaredClasses(dis: DataInput, strings: StringTable): Set<String> {
+        readHeader(dis, MAGIC_METADATA)
+        val methodCount = dis.readInt()
+        require(methodCount >= 0) { "Invalid metadata method count: $methodCount" }
+        val result = linkedSetOf<String>()
+        repeat(methodCount) {
+            result += strings.get(dis.readInt())
+            dis.readInt() // method name
+            val parameterCount = dis.readInt()
+            require(parameterCount >= 0) { "Invalid method parameter count: $parameterCount" }
+            repeat(parameterCount) { dis.readInt() }
+            dis.readInt() // return type
+        }
+        return result
+    }
+
     // ========================================================================
     // ControlFlowEdge comparison writing / reading
     // ========================================================================

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/WebGraphBackedGraph.kt
@@ -133,6 +133,9 @@ internal class WebGraphBackedGraph(
     override fun methodSlice(pattern: MethodPattern, limit: Int): List<MethodDescriptor> =
         methods(pattern).take(limit.coerceAtLeast(0)).toList()
 
+    override fun declaredClasses(): Set<String> =
+        metadata.methods.values.asSequence().mapTo(linkedSetOf()) { it.declaringClass.className }
+
     override fun enumValues(enumClass: String, enumName: String): List<Any?>? =
         metadata.enumValues["$enumClass#$enumName"]
 

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -1113,6 +1113,34 @@ class GraphStoreTest {
     }
 
     @Test
+    fun `mapped graphs expose declared classes without materializing method metadata`() {
+        val graph = buildTestGraph()
+        val dir = Files.createTempDirectory("webgraph-declared-classes-test")
+        try {
+            GraphStore.save(graph, dir)
+            assertTrue(Files.isRegularFile(dir.resolve(DeclaredClassStore.FILE_NAME)))
+            GraphStore.loadMapped(dir).let { loaded ->
+                try {
+                    assertEquals(graph.declaredClasses(), loaded.declaredClasses())
+                } finally {
+                    (loaded as Closeable).close()
+                }
+            }
+
+            Files.delete(dir.resolve(DeclaredClassStore.FILE_NAME))
+            GraphStore.loadMapped(dir).let { loaded ->
+                try {
+                    assertEquals(graph.declaredClasses(), loaded.declaredClasses())
+                } finally {
+                    (loaded as Closeable).close()
+                }
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `class overview store bounds reads and provider cache`() {
         val overview = ClassOverview(
             classCounts = linkedMapOf(
@@ -2273,6 +2301,7 @@ class GraphStoreTest {
         assertEquals(1, matched.size)
         val noMatch = loaded.callSites(MethodPattern(name = "nonexistent")).toList()
         assertTrue(noMatch.isEmpty())
+        assertEquals(original.declaredClasses(), loaded.declaredClasses())
 
         // supertypes and subtypes
         val child = TypeDescriptor("com.example.Child")


### PR DESCRIPTION
## Summary

### Explorer Graph Topology

- Add a graph-level topology endpoint for multi-graph Explorer deployments.
- Represent each loaded graph as one topology node and derive weighted cross-graph call relationships from method/call-site ownership.
- Keep the overview route memory-safe by avoiding large `MethodDescriptor` materialization while resolving class ownership.

### WebGraph Storage and Compatibility

- Persist a compact `graph.declaredclasses` sidecar for built-in persisted graph backends.
- Add graph APIs for streaming declared class names without forcing callers through full method descriptor batches.
- Preserve backward compatibility by streaming declaring-class IDs from legacy metadata when the sidecar is absent.

### Explorer UI and API Surface

- Add the graph topology model and OpenAPI coverage for the new overview shape.
- Update the web UI to render multi-graph topology with graph nodes and weighted relationships.
- Keep existing per-graph overview behavior intact while adding the multi-graph topology view.

### Benchmarks and Acceptance Gate

- Add an Explorer memory benchmark covering global absent call-site search and graph topology generation.
- Add a strict real-corpus JMH acceptance task that requires exactly 50 distinct graphs, at least 100M total nodes, and an 8 GiB maximum heap.
- Document the measured negative controls and the remaining real-corpus acceptance step.

### Documentation and Tests

- Document the `graph.declaredclasses` storage addition and compatibility path in `docs/webgraph-storage.md`.
- Move optimization-attempt notes into `docs/webgraph-optimization-attempts.md`.
- Add tests for graph overview input generation, graph topology behavior, declared-class persistence, and route wiring.

## Why

A production Explorer instance with 42 graphs, 80,000,940 nodes, and 91,388,243 edges was observed near its 12 GiB heap limit. Code inspection identified a concrete high-allocation path in the graph-overview route: it could deserialize up to 100,001 complete method descriptors per graph to infer class ownership, while still truncating topology for larger graphs.

This change removes that allocation pattern and makes ownership complete for built-in graph backends. The remote heap dominator has not yet been captured, so the PR treats this as elimination of a proven high-risk path rather than claiming it is the only production root cause.

## Validation

- `./gradlew check --no-daemon` - passed (70 tasks)
- Android build/save/load/query: 30,799.302 ms vs 30,831.631 ms on HEAD
- Explorer initial session: 772.625 ms vs 779.317 ms on HEAD
- Representative MAPPED query results remained within JMH error intervals; single-hop improved from 0.869 ms to 0.791 ms
- Implementation pressure test with 50 mapped directories / 266,824,000 total nodes:
  - Global absent call-site search peak heap: 4,464,016,928 B
  - Graph topology peak heap: 4,699,806,968 B

The pressure corpus repeated one production graph, so it is not presented as the final real-corpus acceptance result.

## Real-Corpus Acceptance Still Required

Run on the remote corpus containing 50 genuinely distinct persisted graphs:

```bash
./gradlew :explore:realMultiGraphAcceptance \
  -Pgraphite.multigraph.root=/data/graphs \
  --no-daemon
```

The task writes `graphite-explore/build/results/jmh/real-multigraph-acceptance.json` and fails on an invalid corpus, OOM, HTTP error, or heap-gate violation.
