### PR TITLE
Fix CI failure propagation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,9 @@ jobs:
         java-version: '17'
 
     - name: Build
-      id: build
       run: |
+        set -o pipefail
         ./gradlew check -S --no-daemon 2>&1 | tee build-output.txt
-        echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
       env:
         JAVA_OPTS: -Xmx8g -XX:MetaspaceSize=1g -Dfile.encoding=UTF-8
         JVM_OPTS:  -Xmx8g -XX:MetaspaceSize=1g -Dfile.encoding=UTF-8
@@ -39,6 +38,7 @@ jobs:
     - name: Generate coverage report
       if: success() && github.event_name == 'pull_request'
       run: |
+        set -o pipefail
         ./gradlew koverLog --no-daemon 2>&1 | tee coverage-output.txt
 
     - name: Comment coverage on PR

--- a/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
+++ b/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
@@ -6,7 +6,6 @@ import java.io.PrintStream
 import java.io.PrintWriter
 import java.nio.file.Files
 import java.nio.file.Path
-import picocli.CommandLine
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue


### PR DESCRIPTION
## Summary

- propagate Gradle failures through the `tee` pipelines in the build and coverage steps
- remove the duplicate `picocli.CommandLine` import that currently breaks `:query:compileTestKotlin`

## Root cause

PR #85's merge ref did fail during both `./gradlew check` and `./gradlew koverLog`, but each command was piped through `tee` without `pipefail`. The successful `tee`/follow-up `echo` masked Gradle's non-zero exit status, so the required check incorrectly passed.

The duplicate import was introduced when the PR branch and its updated base each contributed the same import at different positions, producing no textual merge conflict.

## Impact

Future Gradle build or coverage failures will fail the GitHub Actions job and trigger the existing build-failure reporting step instead of producing a false-green check.

## Validation

- `./gradlew :query:test :query:shadowJar --no-daemon`
- `./gradlew check -S --no-daemon`
- `./gradlew koverLog --no-daemon`
- parsed `.github/workflows/build.yml` with Ruby YAML
- verified a failing pipeline returns non-zero with `set -o pipefail`
