### PR TITLE
Optimize cross-graph Cypher search and traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ For agent-driven discovery, probe `/openapi.json` first. It describes the full
 root-all and graph-scoped REST surface, including the two explicit modes of
 `/api/cypher/graphs`.
 
+A global discovery query belongs on `/api/cypher`. Enumerating `/api/graphs`
+and then calling `/api/graphs/{graphId}/cypher` for each entry performs
+client-side fan-out and repeats HTTP and Cypher parsing overhead.
+
 For multi-graph startup, `--topology` accepts one Cypher file (or a directory
 of `.cypher` files). The configured `--graph` entries are the catalog: Graphite
 loads them once, runs the topology query over those loaded graph instances,

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -387,6 +387,86 @@ trigram budget exhaustion returns the same matches through dictionary scan.
 cold and amortized performance beyond Attempt 006, and replaces cardinality-only
 guards with explicit posting and byte budgets plus result-preserving fallback.
 
+### 2026-08-27 - Attempt 009: Agent broad-discovery query
+
+**Production evidence:** an agent using Graphite 2.2.2 began feature discovery
+with this query shape over the aggregate server:
+
+```cypher
+MATCH (n)
+WHERE (exists(n.class) AND n.class CONTAINS 'ThankYou')
+   OR (exists(n.name) AND n.name CONTAINS 'ThankYou')
+   OR (exists(n.caller_class) AND n.caller_class CONTAINS 'ThankYou')
+   OR (exists(n.caller_name) AND n.caller_name CONTAINS 'ThankYou')
+   OR (exists(n.callee_class) AND n.callee_class CONTAINS 'ThankYou')
+   OR (exists(n.callee_name) AND n.callee_name CONTAINS 'ThankYou')
+RETURN DISTINCT n.class AS class, n.name AS name,
+    n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 120
+```
+
+The agent also enumerated `/api/graphs` and called each scoped Cypher route,
+which is client-side fan-out. The aggregate server already exposes
+`/api/cypher` for one cross-graph query. `/api/graphs` itself reads cached graph
+descriptors, so its timeout while these searches were running is consistent
+with server saturation rather than graph-list computation.
+
+**Root cause:** `RETURN DISTINCT` excluded the filtered-node fast path, while
+the guarded six-way `OR` could not compile as a direct string filter. The
+generic pipeline therefore materialized every unlabeled node and binding,
+interpreted the full expression per node, projected every match, deduplicated
+the projected rows, and only then applied `LIMIT 120`.
+
+**Design:** filtered single-node `DISTINCT ... LIMIT` queries now stream rows
+and retain at most the requested distinct results. Qualified cross-graph
+execution continues scanning after the limit so later duplicate rows still
+contribute complete graph provenance.
+
+For a disjunction of direct `STARTS WITH`, `ENDS WITH`, or `CONTAINS`
+predicates, with an optional matching `exists(property)` guard, the planner
+narrows an unlabeled scan to node types that can expose those properties. It
+uses each graph's storage-aware string lookup, unions matching node IDs, and
+materializes matching nodes only. Annotation nodes retain generic evaluation
+because their dynamic value map can expose the same property names. Any
+unsupported property, mismatched guard, aggregation, ordering, or more complex
+expression stays on the generic evaluator.
+
+**Benchmark fixture:** 16 persisted mapped graphs, each with 5,000 string
+constants and 2,000 call sites (112,000 nodes total). Every tenth call site has
+a unique `ThankYou` caller class. The benchmark uses the production query
+above and checks all 120 returned rows. The `main` comparison uses an identical
+fixture in a separate clone at `e4d1c6a`.
+
+```shell
+./gradlew :webgraph:jmh \
+  -Pjmh.filter='AgentBroadDiscoveryMappedQueryBenchmark.*' \
+  --no-daemon
+
+java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
+  '.*AgentBroadDiscoveryMappedQueryBenchmark.coldBroadDiscoveryAcrossAllMappedGraphs' \
+  -wi 2 -i 3 -w 1s -r 1s -f 1 -prof gc
+```
+
+| Agent discovery benchmark | `main` | Attempt 009 | Speedup |
+|---------------------------|-------:|------------:|--------:|
+| repeated query | `59.394 ms/op` | `3.359 ms/op` | `17.68x` |
+| cold hit after index reset | `59.394 ms/op` | `11.984 ms/op` | `4.96x` |
+| cold miss after index reset | not measured | `9.162 ms/op` | n/a |
+
+The profiler run allocates `137.930 MB/op` on `main` and `25.202 MB/op` on the
+cold branch path, an 81.7% reduction. The corresponding profiler times are
+`60.139 ms/op` and `11.637 ms/op`.
+
+**Limit:** this is query planning and allocation control, not a hard CPU
+budget. Arbitrary Cypher outside the recognized shape can still perform a
+large scan. Request deadlines, cooperative cancellation, and a Cypher
+concurrency bulkhead remain separate availability work.
+
+**Conclusion:** retained. This attempt covers the reported 2.2.2 query shape
+and removes the main deserialization and intermediate-row costs without
+changing `DISTINCT`, `LIMIT`, or provenance semantics.
+
 ## PR verification summary
 
 **Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK
@@ -403,19 +483,19 @@ used the same machine and dependency caches.
 
 | `CypherBenchmark` | `main` | Branch | Change |
 |-------------------|-------:|-------:|-------:|
-| `aggregationCountGroupBy` | `35.208 us/op` | `34.609 us/op` | `-1.7%` |
-| `countStar` | `2.238 us/op` | `2.268 us/op` | `+1.3%` |
-| `functionCalls` | `24.702 us/op` | `24.269 us/op` | `-1.8%` |
-| `nodeMatchWithWhere` | `57.774 us/op` | `57.605 us/op` | `-0.3%` |
-| `regexFilter` | `23.097 us/op` | `22.926 us/op` | `-0.7%` |
-| `returnDistinct` | `100.328 us/op` | `92.856 us/op` | `-7.4%` |
-| `simpleNodeMatch` | `19.969 us/op` | `19.645 us/op` | `-1.6%` |
-| `singleHopRelationship` | `30.402 us/op` | `29.201 us/op` | `-4.0%` |
-| `variableLengthPath` | `26.319 us/op` | `25.500 us/op` | `-3.1%` |
-| `withPipeline` | `75.915 us/op` | `76.749 us/op` | `+1.1%` |
+| `aggregationCountGroupBy` | `34.778 us/op` | `34.363 us/op` | `-1.2%` |
+| `countStar` | `2.294 us/op` | `2.349 us/op` | `+2.4%` |
+| `functionCalls` | `24.524 us/op` | `24.989 us/op` | `+1.9%` |
+| `nodeMatchWithWhere` | `58.112 us/op` | `57.659 us/op` | `-0.8%` |
+| `regexFilter` | `23.525 us/op` | `23.821 us/op` | `+1.3%` |
+| `returnDistinct` | `101.836 us/op` | `102.761 us/op` | `+0.9%` |
+| `simpleNodeMatch` | `19.313 us/op` | `20.098 us/op` | `+4.1%` |
+| `singleHopRelationship` | `29.468 us/op` | `30.438 us/op` | `+3.3%` |
+| `variableLengthPath` | `25.370 us/op` | `26.370 us/op` | `+3.9%` |
+| `withPipeline` | `75.281 us/op` | `75.869 us/op` | `+0.8%` |
 
-The two small increases have overlapping confidence intervals. There is no
-measured method-level regression.
+All confidence intervals overlap. There is no measured method-level
+regression.
 
 ### Large mapped graph regression
 
@@ -430,17 +510,17 @@ nodes. Values are `ms/op`.
 
 | `EsQueryBenchmark` | `main` | Branch |
 |--------------------|-------:|-------:|
-| `mapped_countStar` | `0.002` | `0.002` |
-| `mapped_intConstantFilter` | `0.300` | `0.295` |
-| `mapped_regexFilter` | `0.076` | `0.078` |
-| `mapped_returnDistinct` | `0.095` | `0.093` |
-| `mapped_simpleNodeMatch` | `0.067` | `0.068` |
-| `mapped_singleHopRelationship` | `0.151` | `0.152` |
+| `mapped_countStar` | `0.002` | `0.003` |
+| `mapped_intConstantFilter` | `0.300` | `0.302` |
+| `mapped_regexFilter` | `0.076` | `0.077` |
+| `mapped_returnDistinct` | `0.095` | `0.100` |
+| `mapped_simpleNodeMatch` | `0.067` | `0.069` |
+| `mapped_singleHopRelationship` | `0.151` | `0.149` |
 
-`mapped_returnDistinct` was repeated with five warmups and ten measurements
-after an initial noisy result; the repeated branch result is `0.093 ms/op`
-versus `0.095 ms/op` on `main`. The remaining differences are at most
-`0.002 ms/op`; there is no measured large-corpus query regression.
+`mapped_returnDistinct` was repeated with five warmups and ten measurements;
+the repeated branch result is `0.093 ms/op` versus `0.095 ms/op` on `main`.
+The remaining absolute differences are at most `0.002 ms/op`; there is no
+measured large-corpus query regression.
 
 ### End-to-end regression
 
@@ -452,7 +532,7 @@ versus `0.095 ms/op` on `main`. The remaining differences are at most
 
 `GraphEndToEndBenchmark` covers Android JAR analysis, graph build, save, mapped
 load, and Cypher count query. The single-shot result was `30,182.415 ms/op` on
-`main` and `24,435.361 ms/op` on the branch. This benchmark is intentionally
+`main` and `26,668.587 ms/op` on the branch. This benchmark is intentionally
 coarse and noisy, but it shows no end-to-end regression. The optimization does
 not change graph building or the persisted format.
 
@@ -468,14 +548,14 @@ This covers every module's tests, baseline-aware detekt task, and Kover
 verification. Direct `detektMain` currently fails on both `main` and this branch
 with the same pre-existing totals: 17 Cypher findings and 11 WebGraph findings;
 that task does not apply the repository baselines used by `check`. No new
-finding remains in a changed code path. New complexity and return-count
-findings were resolved or narrowly suppressed following existing project
-practice.
+finding remains in a changed code path. New behavior tests cover the exact
+six-property agent query, cross-graph provenance merging, dynamic annotation
+properties, generic fallback, and streaming `DISTINCT ... LIMIT` execution.
 
 The first PR workflow run exposed coverage below the repository's separate 98%
 per-module threshold even though `check` passed locally before coverage was
 printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
 access, and the unsupported `DataInput.readLine` contract. Final application
-line coverage is `98.0043%` for Cypher and `98.1162%` for WebGraph; the complete
+line coverage is `98.04%` for Cypher and `98.1162%` for WebGraph; the complete
 CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -615,8 +615,46 @@ absent after both stages. It measures `0.518 +/- 0.392 ms/op` on `main` and
 `2.884 ms/op` repeated on the 16-graph fixture and `202.359/199.474 ms/op`
 cold/repeated on Android.
 
-**Conclusion:** retained. The query remains lazy for limits, is correct for old
-unordered mapped graphs, and keeps the 36-37x Android-scale speedup.
+**Conclusion:** rejected and replaced by Attempt 014. The primitive set is lazy
+for an unqualified query that stops at its limit, but qualified cross-graph
+execution drains every source to collect complete provenance. In that path the
+set grows with every unique match and can again consume tens of megabytes on
+the Android corpus.
+
+### 2026-08-27 - Attempt 014: Filter-owned candidate streams
+
+**Review finding:** cross-graph `DISTINCT ... LIMIT 1` cannot stop after the
+first visible row because later graphs may contribute to that row's provenance.
+Attempt 013 therefore retained every unique matching node ID while draining the
+remaining candidate streams. At 5.9 million IDs, the primitive hash table alone
+would require roughly a 32 MiB backing array and would keep growing on larger
+corpora.
+
+**Design:** each candidate stream is owned by its corresponding direct string
+filter. The first filter emits all its matches. A later stream emits a node only
+when none of the earlier filters matches that node. This works with arbitrary
+storage order and retains no node IDs: deduplication memory is bounded by the
+number of query filters, which is six for the broad-discovery query. The CPU
+tradeoff is at most one property check per earlier filter for each candidate in
+a later stream.
+
+The unordered-stream regression now uses contract-correct lookup results: one
+node matches both filters, while the other two match only the second filter. It
+still produces `[1, 2, 0]` exactly once each. A qualified regression builds two
+graphs with 5,000 nodes apiece, where every node matches both filters. It proves
+that execution consumes all 20,000 indexed candidates, returns one distinct
+row, and merges provenance from both graphs without match-sized deduplication
+state. The single-graph `LIMIT 1` guard still consumes only one candidate.
+
+The final Android JAR benchmark measures `207.392 ms/op` cold and `204.300
+ms/op` repeated, versus `7,426.015` and `7,433.167 ms/op` on `main`: `35.81x`
+and `36.38x` speedups. The 16-graph cross-graph benchmark measures `2.861
+ms/op` repeated, `11.661 ms/op` cold hit, and `7.949 ms/op` cold miss.
+
+**Conclusion:** retained. Candidate deduplication is correct for unordered
+persisted graphs, remains lazy for single-graph limits, uses memory independent
+of match count for qualified execution, and preserves the Android-scale
+speedup.
 
 ## PR verification summary
 
@@ -699,7 +737,7 @@ verification. Direct `detektMain` currently fails on both `main` and this branch
 with the same pre-existing totals: 17 Cypher findings and 11 WebGraph findings;
 that task does not apply the repository baselines used by `check`. No new
 finding remains in a changed code path. New behavior tests cover the exact
-six-property agent query, cross-graph provenance merging, dynamic annotation
+six-property broad-discovery query, cross-graph provenance merging, dynamic annotation
 properties, generic fallback, and streaming `DISTINCT ... LIMIT` execution.
 
 The first PR workflow run exposed coverage below the repository's separate 98%
@@ -708,5 +746,5 @@ printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
 access, ABI fallback, predicate admission bounds, and admission reset after
 cache clearing or LRU eviction. Final application line coverage is `98.3471%`
-for Core, `98.0873%` for Cypher, and `98.0072%` for WebGraph; the complete
+for Core, `98.0897%` for Cypher, and `98.0072%` for WebGraph; the complete
 CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -1,0 +1,56 @@
+# Cross-Graph Cypher Optimization Attempts
+
+This log records each benchmark and implementation attempt for cross-graph
+Cypher performance. Product changes are accepted only when existing query
+semantics and performance guardrails remain intact.
+
+## Goal
+
+- Improve the representative cross-graph agent workflow by at least `10x`.
+- Preserve complete cross-graph identity, provenance, aggregation, and traversal
+  semantics.
+- Avoid regressions in the existing `CypherBenchmark` and end-to-end graph
+  benchmark.
+
+### 2026-08-26 - Attempt 000: Representative cross-graph JMH baseline
+
+**Problem:** the existing Cypher benchmark uses one graph with roughly one
+thousand nodes. Its variable-length path fixture contains only one-hop edges,
+and it does not cover graph-qualified identity or an agent's search-then-expand
+workflow. It therefore cannot validate cross-graph performance work.
+
+**Benchmark design:** add `CrossGraphCypherBenchmark` with 16 graphs and 5,000
+nodes per graph. Local node IDs intentionally collide across graphs. The only
+keyword hit and the eight-edge call chain are in the final graph, ensuring that
+the baseline cannot stop after scanning an early graph.
+
+The benchmark covers:
+
+- a keyword miss that must inspect all 80,000 candidate nodes
+- a late keyword hit in the final graph
+- a two-request agent workflow that discovers an `elementId`, then uses it as
+  the seed for a variable-length call-chain query
+
+This attempt changes benchmark and documentation code only. Baseline results
+were measured with:
+
+```shell
+./gradlew :cypher:jmh \
+  -Pjmh.filter='.*CrossGraphCypherBenchmark.*' \
+  --no-daemon
+```
+
+**Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK
+17.0.18, JMH 1.37, one benchmark thread, one fork, three 1-second warmups,
+and five 1-second measurements.
+
+| Benchmark | `main` baseline |
+|-----------|----------------:|
+| `keywordMissAcrossAllGraphs` | `5.018 ms/op` |
+| `keywordLateHitAcrossAllGraphs` | `4.974 ms/op` |
+| `keywordThenCallChain` | `13.875 ms/op` |
+
+**Conclusion:** baseline established. A miss and a late hit cost the same,
+confirming that the filtered fast path still scans every qualified candidate
+when fewer than the requested 20 rows match. The two-stage workflow adds a
+second full candidate scan plus eager `WITH` materialization and path traversal.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -157,3 +157,35 @@ during the profiler run.
 for both worst-case keyword query shapes. It does not yet cross the target for
 the complete agent workflow because the graph-qualified seed query still scans
 and materializes all 80,000 candidates before `WITH`.
+
+### 2026-08-26 - Attempt 004: Seek graph-qualified element IDs
+
+**Hypothesis:** after keyword discovery, the agent already has a globally unique
+`elementId`, but `MATCH (n) WHERE elementId(n) = 'graph:id' WITH n ...` still
+scans every node. Pushing this equality into `MATCH` can select the owning graph
+and call `Graph.node(NodeId)` directly before the rest of the pipeline runs.
+
+**Semantic boundary:** the seek applies only to a non-optional, single-node
+`MATCH` immediately followed by equality between a literal string and either
+`elementId(variable)`, `variable.elementId`, or `variable.qualifiedId`. The
+resolved candidate is still checked against labels, inline properties, and the
+original complete `WHERE` expression. Missing graphs, malformed IDs, missing
+nodes, and label mismatches produce no rows. Every other shape falls back to
+the existing matcher.
+
+**Build/save impact:** none. The optimization uses the existing graph ID list
+and `Graph.node` lookup. Results are recorded after tests and benchmarks.
+
+| Benchmark | Baseline | Attempt 003 | Attempt 004 | Speedup vs baseline |
+|-----------|---------:|------------:|------------:|--------------------:|
+| `keywordMissAcrossAllGraphs` | `5.018 ms/op` | `0.437 ms/op` | `0.436 ms/op` | `11.51x` |
+| `keywordLateHitAcrossAllGraphs` | `4.974 ms/op` | `0.437 ms/op` | `0.441 ms/op` | `11.28x` |
+| `keywordThenCallChain` | `13.875 ms/op` | `8.145 ms/op` | `0.466 ms/op` | `29.77x` |
+
+Workflow allocation falls from `83.335 MB/op` at baseline to `0.126 MB/op`, a
+`99.85%` reduction.
+
+**Conclusion:** effective and retained. Attempt 004 crosses the `10x` target
+for the complete search-then-expand workflow while preserving the keyword gains.
+The result confirms that direct graph-qualified lookup, rather than parallel
+fan-out, removes the dominant second-stage CPU and allocation cost.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -387,7 +387,7 @@ trigram budget exhaustion returns the same matches through dictionary scan.
 cold and amortized performance beyond Attempt 006, and replaces cardinality-only
 guards with explicit posting and byte budgets plus result-preserving fallback.
 
-### 2026-08-27 - Attempt 009: Agent broad-discovery query
+### 2026-08-27 - Attempt 009: Production broad-discovery query
 
 **Production evidence:** an agent using Graphite 2.2.2 began feature discovery
 with this query shape over the aggregate server:
@@ -450,9 +450,9 @@ java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
 
 | Broad discovery benchmark | `main` | Attempt 009 | Speedup |
 |---------------------------|-------:|------------:|--------:|
-| repeated query | `59.394 ms/op` | `3.014 ms/op` | `19.71x` |
-| cold hit after index reset | `59.394 ms/op` | `10.855 ms/op` | `5.47x` |
-| cold miss after index reset | not measured | `9.378 ms/op` | n/a |
+| repeated query | `59.394 ms/op` | `3.230 ms/op` | `18.39x` |
+| cold hit after index reset | `59.394 ms/op` | `11.373 ms/op` | `5.22x` |
+| cold miss after index reset | not measured | `8.512 ms/op` | n/a |
 
 The profiler run allocates `137.930 MB/op` on `main` and `25.203 MB/op` on the
 cold branch path, an 81.7% reduction. The corresponding profiler times are
@@ -554,14 +554,37 @@ clear hook is a no-op there because `main` has no mapped string index.
 
 | Android broad discovery | `main` | Branch | Speedup |
 |-------------------------|-------:|-------:|--------:|
-| cold query | `7,426.015 ms/op` | `393.236 ms/op` | `18.89x` |
-| repeated query | `7,433.167 ms/op` | `361.439 ms/op` | `20.57x` |
+| cold query | `7,426.015 ms/op` | `190.103 ms/op` | `39.06x` |
+| repeated query | `7,433.167 ms/op` | `217.750 ms/op` | `34.14x` |
 
-**Conclusion:** retained. The production query shape improves by about 20x on
+**Conclusion:** retained. The production query shape improves by 34-39x on
 the real Android-scale corpus. This replaces the ES query table as the primary
-large-graph performance evidence. The remaining `361-393 ms` cost is a real
+large-graph performance evidence. The remaining `190-218 ms` cost is a real
 raw mapped-field scan across 5.9 million nodes, so request-level CPU budgets and
 concurrency isolation remain valid follow-up work.
+
+### 2026-08-27 - Attempt 012: Lazy ordered candidate union
+
+**Review finding:** the storage-aware disjunction still consumed every matching
+candidate into a `LinkedHashMap` and sorted all unique nodes before yielding the
+first result. A `DISTINCT ... LIMIT 1` reproduction with 1,000 matching nodes
+therefore consumed all 1,000 candidates. This retained `O(matches)` nodes and
+paid `O(matches log matches)` sorting cost before `LIMIT` could stop execution.
+
+**Design:** each storage lookup already yields nodes in ascending node-ID order.
+The query pipeline now performs a lazy k-way merge across the property streams,
+retaining one head per stream and deduplicating equal node IDs as it advances.
+Memory is `O(property filters)`, and a downstream limit can suspend candidate
+production immediately. The lookup capability documents the ordering contract.
+
+A regression test uses two matching property streams over 1,000 nodes and
+asserts that `LIMIT 1` consumes exactly two candidates, one head from each
+stream. The Android results in Attempt 011 include this change; compared with
+the eager-union branch, cold time falls from `393.236` to `190.103 ms/op` and
+repeated time falls from `361.439` to `217.750 ms/op`.
+
+**Conclusion:** retained. The fast path now streams candidates through
+`DISTINCT` and `LIMIT` instead of collecting and sorting every match first.
 
 ## PR verification summary
 
@@ -653,5 +676,5 @@ printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
 access, ABI fallback, predicate admission bounds, and admission reset after
 cache clearing or LRU eviction. Final application line coverage is `98.3471%`
-for Core, `98.0433%` for Cypher, and `98.0061%` for WebGraph; the complete
+for Core, `98.0944%` for Cypher, and `98.0061%` for WebGraph; the complete
 CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -54,3 +54,43 @@ and five 1-second measurements.
 confirming that the filtered fast path still scans every qualified candidate
 when fewer than the requested 20 rows match. The two-stage workflow adds a
 second full candidate scan plus eager `WITH` materialization and path traversal.
+
+### 2026-08-26 - Attempt 001: Defer filtered-row provenance
+
+**Hypothesis:** the filtered-node fast path adds a provenance set to every
+candidate binding before evaluating `WHERE`. Misses discard that binding
+immediately, so broad low-selectivity searches allocate provenance for all
+80,000 candidates while only zero or one row reaches the result. Moving
+provenance creation after a successful predicate should preserve visible and
+metadata semantics while reducing allocation and CPU cost.
+
+**Build/save impact:** none. This only changes query execution order for
+internal result metadata that is not visible to `WHERE` expressions.
+
+**Validation:**
+
+```shell
+./gradlew :cypher:test :cypher:jmh \
+  -Pjmh.filter='.*CrossGraphCypherBenchmark.*' \
+  --no-daemon
+
+java -jar graphite-cypher/build/libs/cypher-1.0.0-SNAPSHOT-jmh.jar \
+  '.*CrossGraphCypherBenchmark.(keywordLateHitAcrossAllGraphs|keywordThenCallChain)' \
+  -wi 2 -i 3 -w 1s -r 1s -f 1 -prof gc
+```
+
+| Benchmark | Baseline | Attempt 001 | Speedup |
+|-----------|---------:|------------:|--------:|
+| `keywordMissAcrossAllGraphs` | `5.018 ms/op` | `2.809 ms/op` | `1.79x` |
+| `keywordLateHitAcrossAllGraphs` | `4.974 ms/op` | `2.794 ms/op` | `1.78x` |
+| `keywordThenCallChain` | `13.875 ms/op` | `10.882 ms/op` | `1.28x` |
+
+| Allocation | Baseline | Attempt 001 | Change |
+|------------|---------:|------------:|-------:|
+| `keywordLateHitAcrossAllGraphs` | `35.250 MB/op` | `15.410 MB/op` | `-56.3%` |
+| `keywordThenCallChain` | `83.335 MB/op` | `63.495 MB/op` | `-23.8%` |
+
+**Conclusion:** effective and retained, but short of the `10x` target. Deferring
+provenance removes most allocation from the filtered fast path. The remaining
+keyword cost still creates a qualified node and binding map per candidate, and
+the second workflow query still uses the eager generic `WITH` pipeline.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -365,8 +365,16 @@ not change graph building or the persisted format.
 
 ### Tests and lint
 
-The core, Cypher, and WebGraph test suites pass. Direct `detektMain` currently
-fails on both `main` and this branch with the same pre-existing totals: 17
-Cypher findings and 11 WebGraph findings. No new finding remains in a changed
-code path; new complexity and return-count findings were resolved or narrowly
-suppressed following existing project practice.
+The CI-equivalent gate passes:
+
+```shell
+./gradlew check -S --no-daemon
+```
+
+This covers every module's tests, baseline-aware detekt task, and Kover
+verification. Direct `detektMain` currently fails on both `main` and this branch
+with the same pre-existing totals: 17 Cypher findings and 11 WebGraph findings;
+that task does not apply the repository baselines used by `check`. No new
+finding remains in a changed code path. New complexity and return-count
+findings were resolved or narrowly suppressed following existing project
+practice.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -189,3 +189,19 @@ Workflow allocation falls from `83.335 MB/op` at baseline to `0.126 MB/op`, a
 for the complete search-then-expand workflow while preserving the keyword gains.
 The result confirms that direct graph-qualified lookup, rather than parallel
 fan-out, removes the dominant second-stage CPU and allocation cost.
+
+### 2026-08-26 - Attempt 005: Mapped cross-graph benchmark guardrail
+
+**Problem:** the method-level benchmark uses `DefaultGraph`, whose nodes are
+already materialized. Production explorer sessions use mapped WebGraph storage,
+where a scan must decode each node from mmap. An optimization that only removes
+heap-object overhead could overstate the real improvement.
+
+**Benchmark design:** add `CrossGraphMappedQueryBenchmark` in the WebGraph JMH
+module. It persists and maps the same 16 graphs, 80,000 colliding local node IDs,
+late keyword hit, and eight-edge call chain as the in-memory benchmark. Setup
+asserts the keyword result and complete call-chain row count before measurement.
+
+The exact same benchmark commit is run on this branch and on an `origin/main`
+worktree so both implementations use an identical fixture and harness. This
+attempt changes benchmark and documentation code only.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -125,3 +125,35 @@ JMH benchmark, and GC profiler as Attempt 001.
 The filtered scan now allocates very little per candidate. Its remaining cost
 is qualified-node construction plus generic expression dispatch. The workflow
 remains dominated by the eager `MATCH -> WHERE -> WITH` seed lookup.
+
+### 2026-08-26 - Attempt 003: Compile direct string filters
+
+**Hypothesis:** common keyword discovery uses a node property with a literal
+`STARTS WITH`, `ENDS WITH`, or `CONTAINS` predicate. The AST is constant for the
+query, so resolving that shape and dispatching through the generic expression
+evaluator for every candidate is unnecessary. A compiled predicate can inspect
+the raw node and create a graph-qualified value only for matches.
+
+**Semantic boundary:** the direct path is limited to a single node label, no
+inline node properties, one literal string predicate, a non-aggregate return,
+and a literal limit. All other expressions continue through the existing
+evaluator. Tests assert result values, qualified identity, result order, and
+provenance for all three string operators.
+
+**Build/save impact:** none. The graph representation and indexes are unchanged.
+Results are recorded after tests, JMH, and allocation profiling.
+
+| Benchmark | Baseline | Attempt 002 | Attempt 003 | Speedup vs baseline |
+|-----------|---------:|------------:|------------:|--------------------:|
+| `keywordMissAcrossAllGraphs` | `5.018 ms/op` | `2.073 ms/op` | `0.437 ms/op` | `11.48x` |
+| `keywordLateHitAcrossAllGraphs` | `4.974 ms/op` | `2.225 ms/op` | `0.437 ms/op` | `11.38x` |
+| `keywordThenCallChain` | `13.875 ms/op` | `9.599 ms/op` | `8.145 ms/op` | `1.70x` |
+
+`keywordLateHitAcrossAllGraphs` allocation falls from `35.250 MB/op` at
+baseline to `0.048 MB/op`, a `99.86%` reduction, with no measured collections
+during the profiler run.
+
+**Conclusion:** effective and retained. Attempt 003 crosses the `10x` target
+for both worst-case keyword query shapes. It does not yet cross the target for
+the complete agent workflow because the graph-qualified seed query still scans
+and materializes all 80,000 candidates before `WITH`.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -294,6 +294,22 @@ mapped graph, and leaves unsupported query shapes on the existing execution
 path. Save format, build behavior, eager graphs, and public Cypher results are
 unchanged.
 
+### 2026-08-26 - Attempt 007: Preserve qualified-property semantics
+
+**Review finding:** the direct string-filter compiler accepted virtual
+cross-graph properties (`graphId`, `elementId`, and `qualifiedId`) but evaluated
+them against a raw node. It also rejected an existing empty graph namespace
+when seeking an element ID such as `:1`.
+
+**Fix:** virtual qualified properties now stay on the generic evaluator, where
+the binding is a `QualifiedNode`. Element-ID parsing accepts a separator at
+offset zero while continuing to reject missing separators and missing local
+IDs. Regression tests assert concrete results for string operations on all
+three virtual properties and for an empty graph namespace.
+
+**Conclusion:** retained. This restores behavior present on `main`; it does not
+change the indexed raw-property path or its benchmark results.
+
 ## PR verification summary
 
 **Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -310,6 +310,81 @@ three virtual properties and for an empty graph namespace.
 **Conclusion:** retained. This restores behavior present on `main`; it does not
 change the indexed raw-property path or its benchmark results.
 
+### 2026-08-27 - Attempt 008: Demand-aware admission and byte budgets
+
+**Review findings:** the second access built a complete property and trigram
+index even when both queries found their `LIMIT 1` result at the first node. A
+100,000-node reproduction took `21.922 ms` and allocated about `39.9 MB`, versus
+`0.029 ms` and `79 KB` on `main`. The 500,000-distinct-string guard also bounded
+dictionary cardinality rather than trigram postings or retained bytes.
+
+**Design:** Cypher now passes its remaining result limit to the storage-aware
+lookup. Before an index exists, a finite query lazily scans raw mmap string IDs
+and materializes matching nodes only. If the consumer satisfies its limit in
+the first 256 nodes, no index access is recorded. A scan that crosses that
+threshold marks the property as worth indexing on its next access. This keeps
+early hits at scan cost while making a one-off late hit or miss cheaper than
+deserializing every node.
+
+Index retention has independent conservative budgets:
+
+| Retained structure | Per-property limit |
+|--------------------|-------------------:|
+| node ID, string ID, and unique-string arrays | `8 MiB` |
+| trigram builders/postings | `16 MiB`, `1,000,000` postings |
+| predicate-result cache | `2 MiB`, 32 entries |
+
+The existing four-property LRU therefore has an estimated upper bound of
+`104 MiB` per mapped graph for these structures, rather than an unbounded size
+hidden behind an entry count. Trigram construction still rejects more than
+500,000 unique strings. Crossing either trigram limit discards the partial
+builder and scans the unique-string dictionary; crossing the base-array budget
+keeps finite Cypher queries on the raw-field scan and unlimited callers on the
+existing fallback. Neither condition throws or changes query results.
+
+The early-hit and cold-query controls use the same 16 persisted graphs and
+80,000 nodes on `main` and this branch:
+
+```shell
+java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
+  '.*CrossGraphMappedQueryBenchmark.(coldTwoEarlyHitKeywordSearchesAcrossAllMappedGraphs|coldKeywordLateHitAcrossAllMappedGraphs|coldTwoKeywordSearchesAcrossAllMappedGraphs)' \
+  -wi 2 -i 5 -w 1s -r 1s -f 1 -prof gc
+```
+
+| Mapped benchmark | `main` | Attempt 006 | Attempt 008 |
+|------------------|-------:|------------:|------------:|
+| two early `LIMIT 1` searches | `0.038 ms` | not measured on this fixture | `0.038 ms` |
+| cold late hit | `14.719 ms` | `6.850 ms` | `4.853 ms` |
+| two cold late/miss searches | `29.292 ms` | `21.890 ms` | `18.438 ms` |
+
+Early-hit allocation is `96.860 KB/op` on Attempt 008 versus `96.723 KB/op` on
+the identical `main` fixture. Two cold searches allocate `41.310 MB/op` versus
+`97.225 MB/op` on `main`, a 57.5% reduction. Steady-state unique misses remain
+`0.020 ms/op`, and keyword-then-call-chain remains `0.093 ms/op`.
+
+**Retained-memory control:** setup builds one `StringConstant.value` index in
+each of the 16 mapped graphs, then the measurement method only holds the
+fixture. With Native Memory Tracking enabled, `jcmd GC.run` is followed by
+`GC.heap_info`, `VM.native_memory summary`, and `ps` while the fork remains idle.
+
+| Full-GC footprint | `main` | Attempt 008 | Difference |
+|-------------------|-------:|------------:|-----------:|
+| live Java heap | `11,918 KiB` | `16,949 KiB` | `+5,031 KiB` |
+| RSS | `178,592 KiB` | `233,056 KiB` | `+54,464 KiB` |
+| committed Java heap | `69,632 KiB` | `131,072 KiB` | `+61,440 KiB` |
+
+The live-object increase is about `314 KiB` per graph for this fixture. The
+larger RSS delta tracks G1's committed heap, not live index objects; both raw
+numbers are retained here rather than presenting RSS as heap usage.
+
+Regression tests assert that repeated early limited queries leave the index
+count at zero, a later admitted access builds exactly one index, and forced
+trigram budget exhaustion returns the same matches through dictionary scan.
+
+**Conclusion:** retained. Attempt 008 removes the early-hit regression, improves
+cold and amortized performance beyond Attempt 006, and replaces cardinality-only
+guards with explicit posting and byte budgets plus result-preserving fallback.
+
 ## PR verification summary
 
 **Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK
@@ -400,5 +475,5 @@ per-module threshold even though `check` passed locally before coverage was
 printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
 access, and the unsupported `DataInput.readLine` contract. Final application
-line coverage is `98.0017%` for Cypher and `98.0371%` for WebGraph; the complete
+line coverage is `98.0043%` for Cypher and `98.1162%` for WebGraph; the complete
 CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -205,3 +205,168 @@ asserts the keyword result and complete call-chain row count before measurement.
 The exact same benchmark commit is run on this branch and on an `origin/main`
 worktree so both implementations use an identical fixture and harness. This
 attempt changes benchmark and documentation code only.
+
+| Mapped benchmark | `main` | Attempts 001-004 | Speedup |
+|------------------|-------:|-----------------:|--------:|
+| `keywordMissAcrossAllMappedGraphs` | `14.399 ms/op` | `6.628 ms/op` | `2.17x` |
+| `keywordLateHitAcrossAllMappedGraphs` | `14.719 ms/op` | `6.279 ms/op` | `2.34x` |
+| `keywordThenMappedCallChain` | `32.087 ms/op` | `6.510 ms/op` | `4.93x` |
+
+**Conclusion:** the mapped guardrail disproves completion at Attempt 004. The
+in-memory target is met, but mapped node decoding keeps the production workflow
+below `10x`. Further work must avoid deserializing every mapped node during
+keyword discovery.
+
+### 2026-08-26 - Attempt 006: Lazy mapped string-property index
+
+**Hypothesis:** mapped storage already has node offsets, type IDs, and a shared
+string table. A bounded lazy index of `(nodeId, stringTableId)` can be built from
+raw mmap fields without deserializing nodes. A trigram dictionary over distinct
+property strings can then answer arbitrary `CONTAINS` terms without rescanning
+all strings; only matched nodes are materialized.
+
+**Design:** add an optional `Graph.nodesByStringProperty` capability. Unsupported
+graphs and properties retain the direct scan from Attempt 003. Mapped graphs
+support common string fields on constants, call sites, fields, locals,
+parameters, enum constants, and resource files. They retain at most four
+property indexes and 32 small predicate results. Trigram construction is
+disabled above 500,000 distinct property strings, and large match sets are not
+cached, bounding retained memory.
+
+The mapped benchmark adds a unique keyword miss on every invocation so a fixed
+literal result cache cannot manufacture the reported gain. Results are recorded
+after unit, mapped integration, performance, and memory regression checks.
+
+**Cold-start policy:** the first access to a supported `(type, property)` uses
+the existing direct scan. The second access builds the index. This avoids making
+a one-off query pay the index construction cost. The benchmark therefore covers
+the first query, the first two queries together, repeated fixed queries, and
+repeated queries with a different keyword on every invocation.
+
+An implementation variant using a primitive integer set reduced one-time index
+allocation by 12%, but increased the two-query time from `21.9` to `23.2 ms/op`.
+It was rejected because reducing CPU time is the primary objective.
+
+**Validation commands:**
+
+```shell
+./gradlew :core:test :cypher:test :webgraph:test --no-daemon
+
+./gradlew :webgraph:jmh \
+  -Pjmh.filter='CrossGraphMappedQueryBenchmark' \
+  --no-daemon
+
+java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
+  '.*CrossGraphMappedQueryBenchmark.(uncachedKeywordMissAcrossAllMappedGraphs|coldTwoKeywordSearchesAcrossAllMappedGraphs)' \
+  -wi 2 -i 3 -w 1s -r 1s -f 1 -prof gc
+```
+
+The baseline was measured from `main` commit `e4d1c6a` in a separate worktree
+with the same benchmark fixture. For the two new controls, the benchmark source
+was copied to the baseline worktree; the index-reset call was omitted because
+`main` has no index. All other fixture and JMH settings were identical.
+
+| Mapped benchmark | `main` | Attempt 006 | Speedup |
+|------------------|-------:|------------:|--------:|
+| `coldKeywordLateHitAcrossAllMappedGraphs` | `14.719 ms/op` | `6.850 ms/op` | `2.15x` |
+| `coldTwoKeywordSearchesAcrossAllMappedGraphs` | `28.463 ms/op` | `21.890 ms/op` | `1.30x` |
+| `keywordMissAcrossAllMappedGraphs` | `14.399 ms/op` | `0.019 ms/op` | `757.84x` |
+| `keywordLateHitAcrossAllMappedGraphs` | `14.719 ms/op` | `0.060 ms/op` | `245.32x` |
+| `uncachedKeywordMissAcrossAllMappedGraphs` | `15.080 ms/op` | `0.020 ms/op` | `754.00x` |
+| `keywordThenMappedCallChain` | `32.087 ms/op` | `0.091 ms/op` | `352.60x` |
+
+The unique-keyword benchmark proves that the steady-state improvement does not
+come from caching complete query results. It uses the already-built trigram
+dictionary to resolve a new predicate each time. The first query is `2.15x`
+faster due to Attempts 001-003; the first two queries, including full index
+construction, are cumulatively `1.30x` faster than `main`. The target is reached
+for the long-lived mapped graph and agent workflow, not claimed for cold start.
+
+| Allocation benchmark | `main` | Attempt 006 | Change |
+|----------------------|-------:|------------:|-------:|
+| `uncachedKeywordMissAcrossAllMappedGraphs` | `47.333 MB/op` | `0.052 MB/op` | `-99.89%` |
+| `coldTwoKeywordSearchesAcrossAllMappedGraphs` | `94.666 MB/op` | `51.321 MB/op` | `-45.78%` |
+
+**Conclusion:** retained. Mapped steady-state keyword search and the complete
+search-then-expand workflow exceed the `10x` target while cold and amortized
+costs remain below `main`. The index is lazy, bounded to four properties per
+mapped graph, and leaves unsupported query shapes on the existing execution
+path. Save format, build behavior, eager graphs, and public Cypher results are
+unchanged.
+
+## PR verification summary
+
+**Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK
+17.0.18, JMH 1.37, one benchmark thread, one fork. Baseline and branch runs
+used the same machine and dependency caches.
+
+### Method-level Cypher regression
+
+```shell
+./gradlew :cypher:jmh \
+  -Pjmh.filter='io.johnsonlee.graphite.cypher.CypherBenchmark.*' \
+  --no-daemon
+```
+
+| `CypherBenchmark` | `main` | Branch | Change |
+|-------------------|-------:|-------:|-------:|
+| `aggregationCountGroupBy` | `35.208 us/op` | `34.609 us/op` | `-1.7%` |
+| `countStar` | `2.238 us/op` | `2.268 us/op` | `+1.3%` |
+| `functionCalls` | `24.702 us/op` | `24.269 us/op` | `-1.8%` |
+| `nodeMatchWithWhere` | `57.774 us/op` | `57.605 us/op` | `-0.3%` |
+| `regexFilter` | `23.097 us/op` | `22.926 us/op` | `-0.7%` |
+| `returnDistinct` | `100.328 us/op` | `92.856 us/op` | `-7.4%` |
+| `simpleNodeMatch` | `19.969 us/op` | `19.645 us/op` | `-1.6%` |
+| `singleHopRelationship` | `30.402 us/op` | `29.201 us/op` | `-4.0%` |
+| `variableLengthPath` | `26.319 us/op` | `25.500 us/op` | `-3.1%` |
+| `withPipeline` | `75.915 us/op` | `76.749 us/op` | `+1.1%` |
+
+The two small increases have overlapping confidence intervals. There is no
+measured method-level regression.
+
+### Large mapped graph regression
+
+```shell
+./gradlew :webgraph:jmh \
+  -Pjmh.filter='EsQueryBenchmark.mapped_.*' \
+  --no-daemon
+```
+
+This uses the repository's Elasticsearch corpus with approximately 968,000
+nodes. Values are `ms/op`.
+
+| `EsQueryBenchmark` | `main` | Branch |
+|--------------------|-------:|-------:|
+| `mapped_countStar` | `0.002` | `0.002` |
+| `mapped_intConstantFilter` | `0.300` | `0.295` |
+| `mapped_regexFilter` | `0.076` | `0.078` |
+| `mapped_returnDistinct` | `0.095` | `0.093` |
+| `mapped_simpleNodeMatch` | `0.067` | `0.068` |
+| `mapped_singleHopRelationship` | `0.151` | `0.152` |
+
+`mapped_returnDistinct` was repeated with five warmups and ten measurements
+after an initial noisy result; the repeated branch result is `0.093 ms/op`
+versus `0.095 ms/op` on `main`. The remaining differences are at most
+`0.002 ms/op`; there is no measured large-corpus query regression.
+
+### End-to-end regression
+
+```shell
+./gradlew :webgraph:jmh \
+  -Pjmh.filter='GraphEndToEndBenchmark.android_build_save_load_query$' \
+  --no-daemon
+```
+
+`GraphEndToEndBenchmark` covers Android JAR analysis, graph build, save, mapped
+load, and Cypher count query. The single-shot result was `30,182.415 ms/op` on
+`main` and `24,435.361 ms/op` on the branch. This benchmark is intentionally
+coarse and noisy, but it shows no end-to-end regression. The optimization does
+not change graph building or the persisted format.
+
+### Tests and lint
+
+The core, Cypher, and WebGraph test suites pass. Direct `detektMain` currently
+fails on both `main` and this branch with the same pre-existing totals: 17
+Cypher findings and 11 WebGraph findings. No new finding remains in a changed
+code path; new complexity and return-count findings were resolved or narrowly
+suppressed following existing project practice.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -334,6 +334,8 @@ Index retention has independent conservative budgets:
 | trigram builders/postings | `16 MiB`, `1,000,000` postings |
 | predicate-result cache | `2 MiB`, 32 entries |
 
+The predicate-result estimate includes both matching ID arrays and the retained
+query string, so long agent-generated literals consume the same byte budget.
 The existing four-property LRU therefore has an estimated upper bound of
 `104 MiB` per mapped graph for these structures, rather than an unbounded size
 hidden behind an entry count. Trigram construction still rejects more than

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -450,9 +450,9 @@ java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
 
 | Broad discovery benchmark | `main` | Attempt 009 | Speedup |
 |---------------------------|-------:|------------:|--------:|
-| repeated query | `59.394 ms/op` | `3.230 ms/op` | `18.39x` |
-| cold hit after index reset | `59.394 ms/op` | `11.373 ms/op` | `5.22x` |
-| cold miss after index reset | not measured | `8.512 ms/op` | n/a |
+| repeated query | `59.394 ms/op` | `2.884 ms/op` | `20.59x` |
+| cold hit after index reset | `59.394 ms/op` | `11.208 ms/op` | `5.30x` |
+| cold miss after index reset | not measured | `8.368 ms/op` | n/a |
 
 The profiler run allocates `137.930 MB/op` on `main` and `25.203 MB/op` on the
 cold branch path, an 81.7% reduction. The corresponding profiler times are
@@ -510,7 +510,7 @@ java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
 | Admission control | `main` | Attempt 010 |
 |-------------------|-------:|------------:|
 | early hit after full miss | `0.555 ms/op` | `0.390 ms/op` |
-| early hit after same-predicate large-limit scan | `0.484 ms/op` | `0.465 ms/op` |
+| early hit after same-predicate large-limit scan | `0.518 ms/op` | `0.463 ms/op` |
 | early hit after LRU workload | `0.189 ms/op` | `0.263 ms/op` |
 
 All controls are at `main` latency and eliminate the review reproductions'
@@ -557,12 +557,12 @@ clear hook is a no-op there because `main` has no mapped string index.
 
 | Android broad discovery | `main` | Branch | Speedup |
 |-------------------------|-------:|-------:|--------:|
-| cold query | `7,426.015 ms/op` | `217.354 ms/op` | `34.17x` |
-| repeated query | `7,433.167 ms/op` | `231.419 ms/op` | `32.12x` |
+| cold query | `7,426.015 ms/op` | `202.359 ms/op` | `36.70x` |
+| repeated query | `7,433.167 ms/op` | `199.474 ms/op` | `37.26x` |
 
-**Conclusion:** retained. The production query shape improves by 32-34x on
+**Conclusion:** retained. The production query shape improves by 36-37x on
 the real Android-scale corpus. This replaces the ES query table as the primary
-large-graph performance evidence. The remaining `217-231 ms` cost is a real
+large-graph performance evidence. The remaining `199-202 ms` cost is a real
 raw mapped-field scan across 5.9 million nodes, so request-level CPU budgets and
 concurrency isolation remain valid follow-up work.
 
@@ -574,20 +574,49 @@ first result. A `DISTINCT ... LIMIT 1` reproduction with 1,000 matching nodes
 therefore consumed all 1,000 candidates. This retained `O(matches)` nodes and
 paid `O(matches log matches)` sorting cost before `LIMIT` could stop execution.
 
-**Design:** each storage lookup already yields nodes in ascending node-ID order.
-The query pipeline now performs a lazy k-way merge across the property streams,
-retaining one head per stream and deduplicating equal node IDs as it advances.
-Memory is `O(property filters)`, and a downstream limit can suspend candidate
-production immediately. The lookup capability documents the ordering contract.
+**Initial design:** assume each storage lookup yields nodes in ascending node-ID
+order, then perform a lazy k-way merge across the property streams, retaining
+one head per stream and deduplicating equal node IDs as it advances.
 
-A regression test uses two matching property streams over 1,000 nodes and
-asserts that `LIMIT 1` consumes exactly two candidates, one head from each
-stream. The Android results in Attempt 011 include this change; compared with
-the eager-union branch, cold time falls from `393.236` to `190.103 ms/op` and
-repeated time falls from `361.439` to `217.750 ms/op`.
+A regression test using hand-sorted streams reduced a `LIMIT 1` reproduction
+from 1,000 consumed candidates to two. The Android run also improved, but the
+test did not represent persisted mapped ordering.
 
-**Conclusion:** retained. The fast path now streams candidates through
-`DISTINCT` and `LIMIT` instead of collecting and sorting every match first.
+**Conclusion:** rejected and replaced by Attempt 013. Existing mapped type
+indexes preserve source hash iteration order, including graphs already written
+by 2.2.2. The k-way merge could therefore emit the same node more than once.
+
+### 2026-08-27 - Attempt 013: Unordered mapped candidate deduplication
+
+**Review findings:** a real `save -> loadMapped` fixture returned type IDs in
+hash order rather than numeric order. Interleaved property streams could make
+the k-way merge emit IDs such as `[4, 6, 4]`; with `RETURN DISTINCT n.id,
+rand()`, the duplicate node remains a distinct projected row and displaces a
+different match. The large-limit admission JMH also used `path-` in setup and
+`path-0` in measurement, so it changed both predicate and limit and could not
+prove limit-specific admission.
+
+**Design:** candidate streams are now consumed lazily in storage order and
+deduplicated with a primitive node-ID set. No ordering contract is imposed on
+existing persisted graphs. The path retains only IDs actually consumed before
+the downstream distinct limit is met; it never retains matched `Node` objects
+or sorts the complete match set. `LIMIT 1` now consumes one candidate.
+
+A mapped integration test persists an intentionally hash-ordered call-site
+fixture, verifies that ID 90 precedes ID 4 in the stored type index, and runs
+the `DISTINCT n.id, rand()` reproduction. The result is exactly IDs `[4, 90]`
+with no duplicate. A separate unit test supplies explicitly unordered streams
+and verifies lazy cross-stream ID deduplication.
+
+The corrected admission benchmark uses `CONTAINS 'path-0'` for both setup and
+measurement, changing only `LIMIT 50000` to `LIMIT 1`; it asserts the index is
+absent after both stages. It measures `0.518 +/- 0.392 ms/op` on `main` and
+`0.463 +/- 0.356 ms/op` on the branch. The latest broad-discovery results are
+`2.884 ms/op` repeated on the 16-graph fixture and `202.359/199.474 ms/op`
+cold/repeated on Android.
+
+**Conclusion:** retained. The query remains lazy for limits, is correct for old
+unordered mapped graphs, and keeps the 36-37x Android-scale speedup.
 
 ## PR verification summary
 
@@ -679,5 +708,5 @@ printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
 access, ABI fallback, predicate admission bounds, and admission reset after
 cache clearing or LRU eviction. Final application line coverage is `98.3471%`
-for Core, `98.0944%` for Cypher, and `98.0072%` for WebGraph; the complete
+for Core, `98.0873%` for Cypher, and `98.0072%` for WebGraph; the complete
 CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -440,23 +440,23 @@ fixture in a separate clone at `e4d1c6a`.
 
 ```shell
 ./gradlew :webgraph:jmh \
-  -Pjmh.filter='AgentBroadDiscoveryMappedQueryBenchmark.*' \
+  -Pjmh.filter='BroadDiscoveryMappedQueryBenchmark.*' \
   --no-daemon
 
 java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
-  '.*AgentBroadDiscoveryMappedQueryBenchmark.coldBroadDiscoveryAcrossAllMappedGraphs' \
+  '.*BroadDiscoveryMappedQueryBenchmark.coldBroadDiscoveryAcrossAllMappedGraphs' \
   -wi 2 -i 3 -w 1s -r 1s -f 1 -prof gc
 ```
 
-| Agent discovery benchmark | `main` | Attempt 009 | Speedup |
+| Broad discovery benchmark | `main` | Attempt 009 | Speedup |
 |---------------------------|-------:|------------:|--------:|
-| repeated query | `59.394 ms/op` | `3.359 ms/op` | `17.68x` |
-| cold hit after index reset | `59.394 ms/op` | `11.984 ms/op` | `4.96x` |
-| cold miss after index reset | not measured | `9.162 ms/op` | n/a |
+| repeated query | `59.394 ms/op` | `3.014 ms/op` | `19.71x` |
+| cold hit after index reset | `59.394 ms/op` | `10.855 ms/op` | `5.47x` |
+| cold miss after index reset | not measured | `9.378 ms/op` | n/a |
 
-The profiler run allocates `137.930 MB/op` on `main` and `25.202 MB/op` on the
+The profiler run allocates `137.930 MB/op` on `main` and `25.203 MB/op` on the
 cold branch path, an 81.7% reduction. The corresponding profiler times are
-`60.139 ms/op` and `11.637 ms/op`.
+`60.139 ms/op` and `11.881 ms/op`.
 
 **Limit:** this is query planning and allocation control, not a hard CPU
 budget. Arbitrary Cypher outside the recognized shape can still perform a
@@ -466,6 +466,102 @@ concurrency bulkhead remain separate availability work.
 **Conclusion:** retained. This attempt covers the reported 2.2.2 query shape
 and removes the main deserialization and intermediate-row costs without
 changing `DISTINCT`, `LIMIT`, or provenance semantics.
+
+### 2026-08-27 - Attempt 010: Predicate-specific index admission
+
+**Review evidence:** property-level admission created two latency traps. A full
+miss made the next finite lookup build the complete index before learning that
+its different predicate matched the first node. Evicting an index from the
+four-entry LRU left the same property-level admission hot, so the next early
+lookup rebuilt the evicted index. Review reproductions measured `25.074 ms/op`
+after an admitted miss and `9.810 ms/op` after LRU eviction.
+
+The new storage method on `Graph` also compiled as an abstract JVM interface
+method under the project's Kotlin settings. A graph implementation compiled
+against 2.2.2 could therefore fail with `AbstractMethodError` when the new
+Cypher fast path called it.
+
+**Design:** finite admission is now keyed by node type, property, match mode,
+and expected string. A costly scan admits only that exact predicate. A
+different early-hit predicate stays on the lazy raw mmap scan. Admission keeps
+at most 32 entries and 64 KiB of estimated retained state. LRU index eviction
+removes every admission for the evicted property. Rejected indexes remain on
+raw scan without repeatedly attempting construction.
+
+Storage-aware string lookup moved from the `Graph` interface to the optional
+`StringPropertyLookup` capability. A `Graph.nodesByStringProperty` extension
+performs a safe capability check, so existing implementations retain their old
+JVM interface and fall back to `Graph.nodes`. A regression test asserts that
+`Graph.class` has no `nodesByStringProperty` method and verifies the fallback.
+
+**Benchmark fixture:** one persisted mapped graph with 50,000 resource nodes
+and 50,000 field nodes. Invocation setup either performs a full miss before a
+first-node hit, or admits/builds five property keys against the four-entry LRU
+before querying the evicted key. Setup time is excluded from the single-shot
+measurement.
+
+```shell
+java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
+  '.*MappedStringAdmissionBenchmark.*' -f 1
+```
+
+| Admission control | `main` | Attempt 010 |
+|-------------------|-------:|------------:|
+| early hit after full miss | `0.555 ms/op` | `0.395 ms/op` |
+| early hit after LRU workload | `0.189 ms/op` | `0.198 ms/op` |
+
+Both controls are at `main` latency and eliminate the review reproductions'
+index-build spikes. Predicate-specific admission intentionally gives uncached,
+always-changing misses the raw scan instead of a property-level index:
+`5.155 ms/op` versus `15.080 ms/op` on `main`, rather than the unsafe previous
+branch result of `0.020 ms/op`.
+
+The other cross-graph controls remain improved: cold late hit is
+`4.886 ms/op` versus `14.719 ms/op`, two different cold searches are
+`10.176 ms/op` versus `29.292 ms/op`, repeated miss is `0.019 ms/op` versus
+`14.399 ms/op`, and search-then-call-chain is `0.073 ms/op` versus
+`32.087 ms/op`. The cold early-hit pair remains at parity (`0.038 ms/op`).
+
+**Conclusion:** retained. Admission now follows observed cost for the exact
+predicate, eviction resets its decision state, and the optimization no longer
+changes the binary contract of `Graph`.
+
+### 2026-08-27 - Attempt 011: Android-scale broad discovery
+
+**Review finding:** the ES regression corpus is too small for this availability
+problem. Its limited queries finish in less than one millisecond, so they are
+useful smoke tests but do not reproduce CPU pressure from a broad discovery
+query.
+
+**Benchmark design:** `AndroidBroadDiscoveryBenchmark` loads only the mapped
+graph built from the Android fixture JAR: 5.9 million nodes and about 6.5
+million edges. It runs the production six-property guarded disjunction from
+Attempt 009, using the common term `android`, and asserts all 120 requested
+distinct rows. The benchmark name describes the query workload rather than its
+original caller; the agent session is evidence for the query shape, not part of
+its execution semantics.
+
+The cold method clears optional string indexes before every invocation. The
+repeated method measures the same query in a long-lived mapped graph. The exact
+benchmark source was also compiled at `main` commit `e4d1c6a`; its reflective
+clear hook is a no-op there because `main` has no mapped string index.
+
+```shell
+./gradlew :webgraph:jmh \
+  -Pjmh.filter='AndroidBroadDiscoveryBenchmark.*' \
+  --no-daemon
+```
+
+| Android broad discovery | `main` | Branch | Speedup |
+|-------------------------|-------:|-------:|--------:|
+| cold query | `7,426.015 ms/op` | `393.236 ms/op` | `18.89x` |
+| repeated query | `7,433.167 ms/op` | `361.439 ms/op` | `20.57x` |
+
+**Conclusion:** retained. The production query shape improves by about 20x on
+the real Android-scale corpus. This replaces the ES query table as the primary
+large-graph performance evidence. The remaining `361-393 ms` cost is a real
+raw mapped-field scan across 5.9 million nodes, so request-level CPU budgets and
+concurrency isolation remain valid follow-up work.
 
 ## PR verification summary
 
@@ -483,44 +579,43 @@ used the same machine and dependency caches.
 
 | `CypherBenchmark` | `main` | Branch | Change |
 |-------------------|-------:|-------:|-------:|
-| `aggregationCountGroupBy` | `34.778 us/op` | `34.363 us/op` | `-1.2%` |
-| `countStar` | `2.294 us/op` | `2.349 us/op` | `+2.4%` |
-| `functionCalls` | `24.524 us/op` | `24.989 us/op` | `+1.9%` |
-| `nodeMatchWithWhere` | `58.112 us/op` | `57.659 us/op` | `-0.8%` |
-| `regexFilter` | `23.525 us/op` | `23.821 us/op` | `+1.3%` |
-| `returnDistinct` | `101.836 us/op` | `102.761 us/op` | `+0.9%` |
-| `simpleNodeMatch` | `19.313 us/op` | `20.098 us/op` | `+4.1%` |
-| `singleHopRelationship` | `29.468 us/op` | `30.438 us/op` | `+3.3%` |
-| `variableLengthPath` | `25.370 us/op` | `26.370 us/op` | `+3.9%` |
-| `withPipeline` | `75.281 us/op` | `75.869 us/op` | `+0.8%` |
+| `aggregationCountGroupBy` | `34.443 us/op` | `34.449 us/op` | `+0.0%` |
+| `countStar` | `2.263 us/op` | `2.284 us/op` | `+0.9%` |
+| `functionCalls` | `24.868 us/op` | `24.683 us/op` | `-0.7%` |
+| `nodeMatchWithWhere` | `58.748 us/op` | `57.674 us/op` | `-1.8%` |
+| `regexFilter` | `23.571 us/op` | `24.045 us/op` | `+2.0%` |
+| `returnDistinct` | `103.294 us/op` | `102.030 us/op` | `-1.2%` |
+| `simpleNodeMatch` | `20.418 us/op` | `20.417 us/op` | `+0.0%` |
+| `singleHopRelationship` | `30.085 us/op` | `29.920 us/op` | `-0.5%` |
+| `variableLengthPath` | `26.093 us/op` | `26.071 us/op` | `-0.1%` |
+| `withPipeline` | `76.079 us/op` | `76.587 us/op` | `+0.7%` |
 
-All confidence intervals overlap. There is no measured method-level
-regression.
+The noisier regex and distinct rows were repeated across three forks; their
+confidence intervals overlap. There is no measured method-level regression.
 
-### Large mapped graph regression
+### Android mapped graph regression
 
 ```shell
 ./gradlew :webgraph:jmh \
-  -Pjmh.filter='EsQueryBenchmark.mapped_.*' \
+  -Pjmh.filter='AndroidQueryBenchmark.mapped_.*' \
   --no-daemon
 ```
 
-This uses the repository's Elasticsearch corpus with approximately 968,000
-nodes. Values are `ms/op`.
+This uses the 5.9-million-node Android graph. These limited and metadata-backed
+queries are secondary regression guards, not the CPU pressure benchmark.
+Values are `ms/op`.
 
-| `EsQueryBenchmark` | `main` | Branch |
-|--------------------|-------:|-------:|
-| `mapped_countStar` | `0.002` | `0.003` |
-| `mapped_intConstantFilter` | `0.300` | `0.302` |
-| `mapped_regexFilter` | `0.076` | `0.077` |
-| `mapped_returnDistinct` | `0.095` | `0.100` |
-| `mapped_simpleNodeMatch` | `0.067` | `0.069` |
-| `mapped_singleHopRelationship` | `0.151` | `0.149` |
+| `AndroidQueryBenchmark` | `main` | Branch |
+|-------------------------|-------:|-------:|
+| `mapped_countStar` | `0.003` | `0.002` |
+| `mapped_intConstantFilter` | `0.172` | `0.182` |
+| `mapped_returnDistinct` | `0.171` | `0.209` |
+| `mapped_simpleNodeMatch` | `0.070` | `0.087` |
+| `mapped_singleHopRelationship` | `0.651` | `0.653` |
 
-`mapped_returnDistinct` was repeated with five warmups and ten measurements;
-the repeated branch result is `0.093 ms/op` versus `0.095 ms/op` on `main`.
-The remaining absolute differences are at most `0.002 ms/op`; there is no
-measured large-corpus query regression.
+The branch and main confidence intervals overlap for every row. The wide
+intervals also show why these sub-millisecond limited queries are not used as
+the primary pressure result.
 
 ### End-to-end regression
 
@@ -532,7 +627,7 @@ measured large-corpus query regression.
 
 `GraphEndToEndBenchmark` covers Android JAR analysis, graph build, save, mapped
 load, and Cypher count query. The single-shot result was `30,182.415 ms/op` on
-`main` and `26,668.587 ms/op` on the branch. This benchmark is intentionally
+`main` and `23,877.213 ms/op` on the branch. This benchmark is intentionally
 coarse and noisy, but it shows no end-to-end regression. The optimization does
 not change graph building or the persisted format.
 
@@ -556,6 +651,7 @@ The first PR workflow run exposed coverage below the repository's separate 98%
 per-module threshold even though `check` passed locally before coverage was
 printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
-access, and the unsupported `DataInput.readLine` contract. Final application
-line coverage is `98.04%` for Cypher and `98.1162%` for WebGraph; the complete
+access, ABI fallback, predicate admission bounds, and admission reset after
+cache clearing or LRU eviction. Final application line coverage is `98.3471%`
+for Core, `98.0433%` for Cypher, and `98.0061%` for WebGraph; the complete
 CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -482,11 +482,13 @@ against 2.2.2 could therefore fail with `AbstractMethodError` when the new
 Cypher fast path called it.
 
 **Design:** finite admission is now keyed by node type, property, match mode,
-and expected string. A costly scan admits only that exact predicate. A
-different early-hit predicate stays on the lazy raw mmap scan. Admission keeps
-at most 32 entries and 64 KiB of estimated retained state. LRU index eviction
-removes every admission for the evicted property. Rejected indexes remain on
-raw scan without repeatedly attempting construction.
+expected string, and lookup limit. A costly scan admits only that exact
+predicate and query budget. A different early-hit predicate stays on the lazy
+raw mmap scan, and a large-limit scan cannot force a later `LIMIT 1` request to
+build the complete index. Admission keeps at most 32 entries and 64 KiB of
+estimated retained state. LRU index eviction removes every admission for the
+evicted property. Rejected indexes remain on raw scan without repeatedly
+attempting construction.
 
 Storage-aware string lookup moved from the `Graph` interface to the optional
 `StringPropertyLookup` capability. A `Graph.nodesByStringProperty` extension
@@ -495,10 +497,10 @@ JVM interface and fall back to `Graph.nodes`. A regression test asserts that
 `Graph.class` has no `nodesByStringProperty` method and verifies the fallback.
 
 **Benchmark fixture:** one persisted mapped graph with 50,000 resource nodes
-and 50,000 field nodes. Invocation setup either performs a full miss before a
-first-node hit, or admits/builds five property keys against the four-entry LRU
-before querying the evicted key. Setup time is excluded from the single-shot
-measurement.
+and 50,000 field nodes. Invocation setup performs either a full miss, a
+large-limit scan of the same predicate, or an admit/build workload over five
+property keys against the four-entry LRU before a first-node `LIMIT 1` query.
+Setup time is excluded from the single-shot measurement.
 
 ```shell
 java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
@@ -507,12 +509,13 @@ java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
 
 | Admission control | `main` | Attempt 010 |
 |-------------------|-------:|------------:|
-| early hit after full miss | `0.555 ms/op` | `0.395 ms/op` |
-| early hit after LRU workload | `0.189 ms/op` | `0.198 ms/op` |
+| early hit after full miss | `0.555 ms/op` | `0.390 ms/op` |
+| early hit after same-predicate large-limit scan | `0.484 ms/op` | `0.465 ms/op` |
+| early hit after LRU workload | `0.189 ms/op` | `0.263 ms/op` |
 
-Both controls are at `main` latency and eliminate the review reproductions'
-index-build spikes. Predicate-specific admission intentionally gives uncached,
-always-changing misses the raw scan instead of a property-level index:
+All controls are at `main` latency and eliminate the review reproductions'
+index-build spikes. Predicate-and-limit-specific admission intentionally gives
+uncached, always-changing misses the raw scan instead of a property-level index:
 `5.155 ms/op` versus `15.080 ms/op` on `main`, rather than the unsafe previous
 branch result of `0.020 ms/op`.
 
@@ -523,8 +526,8 @@ The other cross-graph controls remain improved: cold late hit is
 `32.087 ms/op`. The cold early-hit pair remains at parity (`0.038 ms/op`).
 
 **Conclusion:** retained. Admission now follows observed cost for the exact
-predicate, eviction resets its decision state, and the optimization no longer
-changes the binary contract of `Graph`.
+predicate and query limit, eviction resets its decision state, and the
+optimization no longer changes the binary contract of `Graph`.
 
 ### 2026-08-27 - Attempt 011: Android-scale broad discovery
 
@@ -554,12 +557,12 @@ clear hook is a no-op there because `main` has no mapped string index.
 
 | Android broad discovery | `main` | Branch | Speedup |
 |-------------------------|-------:|-------:|--------:|
-| cold query | `7,426.015 ms/op` | `190.103 ms/op` | `39.06x` |
-| repeated query | `7,433.167 ms/op` | `217.750 ms/op` | `34.14x` |
+| cold query | `7,426.015 ms/op` | `217.354 ms/op` | `34.17x` |
+| repeated query | `7,433.167 ms/op` | `231.419 ms/op` | `32.12x` |
 
-**Conclusion:** retained. The production query shape improves by 34-39x on
+**Conclusion:** retained. The production query shape improves by 32-34x on
 the real Android-scale corpus. This replaces the ES query table as the primary
-large-graph performance evidence. The remaining `190-218 ms` cost is a real
+large-graph performance evidence. The remaining `217-231 ms` cost is a real
 raw mapped-field scan across 5.9 million nodes, so request-level CPU budgets and
 concurrency isolation remain valid follow-up work.
 
@@ -676,5 +679,5 @@ printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
 access, ABI fallback, predicate admission bounds, and admission reset after
 cache clearing or LRU eviction. Final application line coverage is `98.3471%`
-for Core, `98.0944%` for Cypher, and `98.0061%` for WebGraph; the complete
+for Core, `98.0944%` for Cypher, and `98.0072%` for WebGraph; the complete
 CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -378,3 +378,11 @@ that task does not apply the repository baselines used by `check`. No new
 finding remains in a changed code path. New complexity and return-count
 findings were resolved or narrowly suppressed following existing project
 practice.
+
+The first PR workflow run exposed coverage below the repository's separate 98%
+per-module threshold even though `check` passed locally before coverage was
+printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
+string-filter results, every supported mapped raw string field, mapped metadata
+access, and the unsupported `DataInput.readLine` contract. Final application
+line coverage is `98.0017%` for Cypher and `98.0371%` for WebGraph; the complete
+CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -94,3 +94,34 @@ java -jar graphite-cypher/build/libs/cypher-1.0.0-SNAPSHOT-jmh.jar \
 provenance removes most allocation from the filtered fast path. The remaining
 keyword cost still creates a qualified node and binding map per candidate, and
 the second workflow query still uses the eager generic `WITH` pipeline.
+
+### 2026-08-26 - Attempt 002: Reuse filtered predicate bindings
+
+**Hypothesis:** after Attempt 001, every candidate still creates a new mutable
+binding map solely so the expression evaluator can read one variable. A single
+map can be reused while scanning because predicate evaluation does not retain
+the input binding. Only successful candidates need a durable binding for
+projection and provenance.
+
+**Semantic boundary:** expressions that create nested bindings remain safe:
+the evaluator copies the input map before adding list or predicate variables.
+The reusable map is never returned or stored in a result row.
+
+**Build/save impact:** none. Results are recorded after running the same tests,
+JMH benchmark, and GC profiler as Attempt 001.
+
+| Benchmark | Baseline | Attempt 001 | Attempt 002 | Speedup vs baseline |
+|-----------|---------:|------------:|------------:|--------------------:|
+| `keywordMissAcrossAllGraphs` | `5.018 ms/op` | `2.809 ms/op` | `2.073 ms/op` | `2.42x` |
+| `keywordLateHitAcrossAllGraphs` | `4.974 ms/op` | `2.794 ms/op` | `2.225 ms/op` | `2.24x` |
+| `keywordThenCallChain` | `13.875 ms/op` | `10.882 ms/op` | `9.599 ms/op` | `1.45x` |
+
+| Allocation | Baseline | Attempt 001 | Attempt 002 | Change vs baseline |
+|------------|---------:|------------:|------------:|-------------------:|
+| `keywordLateHitAcrossAllGraphs` | `35.250 MB/op` | `15.410 MB/op` | `1.970 MB/op` | `-94.4%` |
+| `keywordThenCallChain` | `83.335 MB/op` | `63.495 MB/op` | `48.774 MB/op` | `-41.5%` |
+
+**Conclusion:** effective and retained, but still short of the `10x` target.
+The filtered scan now allocates very little per candidate. Its remaining cost
+is qualified-node construction plus generic expression dispatch. The workflow
+remains dominated by the eager `MATCH -> WHERE -> WITH` seed lookup.

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -20,6 +20,12 @@ data class ClassOverview(
     val callSiteCount: Int
 )
 
+enum class StringMatchMode {
+    STARTS_WITH,
+    ENDS_WITH,
+    CONTAINS
+}
+
 /**
  * The unified program graph that combines all analysis graphs.
  * This is the central abstraction of Graphite.
@@ -47,6 +53,19 @@ interface Graph {
      * to indicate callers should fall back to [nodes].
      */
     fun nodeCount(type: Class<out Node>): Long? = null
+
+    /**
+     * Return nodes whose string [property] matches [expected] when the graph has
+     * a storage-aware access path. Implementations may return null when the type
+     * or property is unsupported, or when the access path is not ready, so
+     * callers must fall back to [nodes].
+     */
+    fun <T : Node> nodesByStringProperty(
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String
+    ): Sequence<T>? = null
 
     /**
      * Return a precomputed edge count when the graph can answer without

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -26,7 +26,10 @@ enum class StringMatchMode {
     CONTAINS
 }
 
-/** Optional storage capability for graphs that can avoid materializing a full node scan. */
+/**
+ * Optional storage capability for graphs that can avoid materializing a full node scan.
+ * Matching nodes must be returned in ascending [Node.id] order.
+ */
 interface StringPropertyLookup {
     fun <T : Node> nodesByStringProperty(
         type: Class<T>,

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -26,10 +26,7 @@ enum class StringMatchMode {
     CONTAINS
 }
 
-/**
- * Optional storage capability for graphs that can avoid materializing a full node scan.
- * Matching nodes must be returned in ascending [Node.id] order.
- */
+/** Optional storage capability for graphs that can avoid materializing a full node scan. */
 interface StringPropertyLookup {
     fun <T : Node> nodesByStringProperty(
         type: Class<T>,

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -58,13 +58,15 @@ interface Graph {
      * Return nodes whose string [property] matches [expected] when the graph has
      * a storage-aware access path. Implementations may return null when the type
      * or property is unsupported, or when the access path is not ready, so
-     * callers must fall back to [nodes].
+     * callers must fall back to [nodes]. At most [limit] matching nodes are
+     * returned when a finite limit is supplied.
      */
     fun <T : Node> nodesByStringProperty(
         type: Class<T>,
         property: String,
         mode: StringMatchMode,
-        expected: String
+        expected: String,
+        limit: Int = Int.MAX_VALUE
     ): Sequence<T>? = null
 
     /**

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -26,6 +26,17 @@ enum class StringMatchMode {
     CONTAINS
 }
 
+/** Optional storage capability for graphs that can avoid materializing a full node scan. */
+interface StringPropertyLookup {
+    fun <T : Node> nodesByStringProperty(
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int
+    ): Sequence<T>?
+}
+
 /**
  * The unified program graph that combines all analysis graphs.
  * This is the central abstraction of Graphite.
@@ -53,21 +64,6 @@ interface Graph {
      * to indicate callers should fall back to [nodes].
      */
     fun nodeCount(type: Class<out Node>): Long? = null
-
-    /**
-     * Return nodes whose string [property] matches [expected] when the graph has
-     * a storage-aware access path. Implementations may return null when the type
-     * or property is unsupported, or when the access path is not ready, so
-     * callers must fall back to [nodes]. At most [limit] matching nodes are
-     * returned when a finite limit is supplied.
-     */
-    fun <T : Node> nodesByStringProperty(
-        type: Class<T>,
-        property: String,
-        mode: StringMatchMode,
-        expected: String,
-        limit: Int = Int.MAX_VALUE
-    ): Sequence<T>? = null
 
     /**
      * Return a precomputed edge count when the graph can answer without
@@ -200,6 +196,20 @@ interface Graph {
     fun classOverview(limit: Int): ClassOverview? = null
 
 }
+
+/**
+ * Use a storage-aware string lookup when [Graph] also implements
+ * [StringPropertyLookup]. Existing graph implementations remain binary
+ * compatible and return null through this extension.
+ */
+fun <T : Node> Graph.nodesByStringProperty(
+    type: Class<T>,
+    property: String,
+    mode: StringMatchMode,
+    expected: String,
+    limit: Int = Int.MAX_VALUE
+): Sequence<T>? = (this as? StringPropertyLookup)
+    ?.nodesByStringProperty(type, property, mode, expected, limit)
 
 /**
  * Pattern for matching methods.

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
@@ -87,6 +87,23 @@ class DefaultGraphTest {
         assertEquals(3L, graph.nodeCount(Node::class.java))
     }
 
+    @Test
+    fun `string property lookup stays outside the Graph binary interface`() {
+        val graph: Graph = DefaultGraph.Builder()
+            .addNode(StringConstant(NodeId.next(), "hello"))
+            .build()
+
+        assertTrue(Graph::class.java.methods.none { it.name == "nodesByStringProperty" })
+        assertNull(
+            graph.nodesByStringProperty(
+                StringConstant::class.java,
+                "value",
+                StringMatchMode.CONTAINS,
+                "hello"
+            )
+        )
+    }
+
     // ========================================================================
     // Edge operations
     // ========================================================================

--- a/graphite-cypher/build.gradle.kts
+++ b/graphite-cypher/build.gradle.kts
@@ -26,6 +26,14 @@ dependencies {
     jmhAnnotationProcessor(libs.jmh.generator)
 }
 
+jmh {
+    val filter = project.findProperty("jmh.filter") as String?
+    if (filter != null) {
+        includes.set(listOf(filter))
+    }
+    failOnError.set(true)
+}
+
 tasks.generateGrammarSource {
     val outDir = file("${layout.buildDirectory.get().asFile}/generated-src/antlr/main/io/johnsonlee/graphite/cypher/parser")
     arguments = arguments + listOf("-visitor", "-package", "io.johnsonlee.graphite.cypher.parser")

--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherBenchmark.kt
@@ -1,0 +1,102 @@
+package io.johnsonlee.graphite.cypher
+
+import io.johnsonlee.graphite.core.DataFlowEdge
+import io.johnsonlee.graphite.core.DataFlowKind
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.StringConstant
+import io.johnsonlee.graphite.graph.DefaultGraph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+private const val CROSS_GRAPH_COUNT = 16
+private const val NODES_PER_GRAPH = 5_000
+private const val CALL_CHAIN_DEPTH = 8
+private const val TARGET_GRAPH_INDEX = CROSS_GRAPH_COUNT - 1
+private const val TARGET_VALUE = "needle_feature_entry"
+
+/**
+ * Measures the two query shapes used by an agent researching a feature:
+ * broad keyword discovery followed by graph-qualified call-chain expansion.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+open class CrossGraphCypherBenchmark {
+
+    private lateinit var executor: CrossGraphCypherExecutor
+
+    @Setup
+    fun setup() {
+        val graphs = (0 until CROSS_GRAPH_COUNT).map { graphIndex ->
+            val builder = DefaultGraph.Builder()
+            for (nodeIndex in 0 until NODES_PER_GRAPH) {
+                val value = if (graphIndex == TARGET_GRAPH_INDEX && nodeIndex == 0) {
+                    TARGET_VALUE
+                } else {
+                    "symbol_${graphIndex}_$nodeIndex"
+                }
+                builder.addNode(StringConstant(NodeId(nodeIndex), value))
+            }
+            if (graphIndex == TARGET_GRAPH_INDEX) {
+                for (nodeIndex in 0 until CALL_CHAIN_DEPTH) {
+                    builder.addEdge(
+                        DataFlowEdge(
+                            NodeId(nodeIndex),
+                            NodeId(nodeIndex + 1),
+                            DataFlowKind.PARAMETER_PASS
+                        )
+                    )
+                }
+            }
+            CypherGraph("graph-$graphIndex", builder.build())
+        }
+        executor = CrossGraphCypherExecutor(graphs)
+
+        val search = executor.execute(KEYWORD_QUERY)
+        check(search.rows.size == 1 && search.rows.single()["id"] == "$TARGET_GRAPH_ID:0")
+        val chain = executor.execute(callChainQuery(search.rows.single().getValue("id") as String))
+        check(chain.rows.size == CALL_CHAIN_DEPTH)
+    }
+
+    @Benchmark
+    fun keywordMissAcrossAllGraphs(): CypherResult = executor.execute(
+        "MATCH (n:StringConstant) " +
+            "WHERE n.value CONTAINS 'missing_feature_keyword' " +
+            "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+    )
+
+    @Benchmark
+    fun keywordLateHitAcrossAllGraphs(): CypherResult = executor.execute(KEYWORD_QUERY)
+
+    @Benchmark
+    fun keywordThenCallChain(): CypherResult {
+        val search = executor.execute(KEYWORD_QUERY)
+        val seed = search.rows.single().getValue("id") as String
+        return executor.execute(callChainQuery(seed))
+    }
+
+    private fun callChainQuery(seed: String): String =
+        "MATCH (a:StringConstant) WHERE elementId(a) = '$seed' " +
+            "WITH a MATCH (a)-[:DATAFLOW*1..$CALL_CHAIN_DEPTH]->(b:StringConstant) " +
+            "RETURN elementId(a) AS source, elementId(b) AS target, b.value AS value " +
+            "LIMIT $CALL_CHAIN_DEPTH"
+
+    private companion object {
+        const val TARGET_GRAPH_ID = "graph-$TARGET_GRAPH_INDEX"
+        const val KEYWORD_QUERY =
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS '$TARGET_VALUE' " +
+                "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+    }
+}

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -399,7 +399,8 @@ class QueryPipeline private constructor(
                 nodeClass,
                 filter.property,
                 filter.mode,
-                filter.expected
+                filter.expected,
+                limit - rows.size
             )
             val candidates = indexedNodes ?: source.graph.nodes(nodeClass).filter(filter::matches)
             for (node in candidates) {

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -529,13 +529,31 @@ class QueryPipeline private constructor(
             val candidates = if (accelerated.any { it == null }) {
                 graph.nodes(candidateType).filter(disjunction::matches)
             } else {
-                accelerated.asSequence().filterNotNull().flatten()
+                mergeSortedNodes(accelerated.filterNotNull())
             }
-            val unique = LinkedHashMap<Int, Node>()
-            candidates.forEach { node -> unique.putIfAbsent(node.id.value, node) }
-            unique.values.sortedBy { it.id.value }.forEach { yield(it) }
+            for (node in candidates) yield(node)
         }
     }
+
+    private fun <T : Node> mergeSortedNodes(sequences: List<Sequence<T>>): Sequence<Node> = sequence {
+        val iterators = sequences.map { it.iterator() }
+        val heads = iterators.map { iterator -> iterator.nextOrNull() }.toMutableList()
+        while (true) {
+            var next: Node? = null
+            for (head in heads) {
+                if (head != null && (next == null || head.id.value < next.id.value)) next = head
+            }
+            next ?: break
+            yield(next)
+            heads.indices.forEach { index ->
+                while (heads[index]?.id == next.id) {
+                    heads[index] = iterators[index].nextOrNull()
+                }
+            }
+        }
+    }
+
+    private fun <T> Iterator<T>.nextOrNull(): T? = if (hasNext()) next() else null
 
     private data class DirectStringFilter(
         val property: String,

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -15,6 +15,7 @@ import io.johnsonlee.graphite.core.ResourceEdge
 import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.nodesByStringProperty
 
 private const val COUNT_QUERY_CLAUSES = 2
 private const val DISTINCT_LIMIT_QUERY_CLAUSES = 3
@@ -90,11 +91,14 @@ class QueryPipeline private constructor(
         val earlyLimit = computeEarlyLimit(clauses)
 
         var consumedWhereIndex = -1
-        for ((clauseIndex, clause) in clauses.withIndex()) {
+        for (clauseIndex in clauses.indices) {
+            val clause = clauses[clauseIndex]
             when (clause) {
                 is CypherClause.Match -> {
                     val pushedWhere = clauses.getOrNull(clauseIndex + 1) as? CypherClause.Where
-                    val soughtRows = pushedWhere?.let { tryElementIdSeek(clause, it, rows) }
+                    val soughtRows = pushedWhere
+                        ?.takeIf { it.condition is CypherExpr.Comparison }
+                        ?.let { tryElementIdSeek(clause, it, rows) }
                     rows = if (soughtRows != null) {
                         consumedWhereIndex = clauseIndex + 1
                         soughtRows
@@ -375,7 +379,8 @@ class QueryPipeline private constructor(
         val nodeClass = nodePattern.labels.firstOrNull()
             ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
             ?: Node::class.java
-        val directStringFilter = DirectStringFilter.compile(where.condition, variable)
+        val directStringFilter = (where.condition as? CypherExpr.StringOp)
+            ?.let { DirectStringFilter.compile(it, variable) }
         if (!ret.distinct && directStringFilter != null && nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()) {
             return executeDirectStringFilter(
                 nodeClass,
@@ -386,18 +391,18 @@ class QueryPipeline private constructor(
                 limitCount
             )
         }
-        val directStringDisjunction = DirectStringDisjunction.compile(where.condition, variable)
-        if (ret.distinct && directStringDisjunction != null &&
-            nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()
-        ) {
-            return executeDirectStringDisjunction(
-                nodeClass,
-                variable,
-                directStringDisjunction,
-                ret.items,
-                columns,
-                limitCount
-            )
+        if (ret.distinct && nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()) {
+            val directStringDisjunction = DirectStringDisjunction.compile(where.condition, variable)
+            if (directStringDisjunction != null) {
+                return executeDirectStringDisjunction(
+                    nodeClass,
+                    variable,
+                    directStringDisjunction,
+                    ret.items,
+                    columns,
+                    limitCount
+                )
+            }
         }
 
         val rows = mutableListOf<Map<String, Any?>>()

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -1,9 +1,14 @@
 package io.johnsonlee.graphite.cypher
 
+import io.johnsonlee.graphite.core.AnnotationNode
 import io.johnsonlee.graphite.core.CallEdge
+import io.johnsonlee.graphite.core.CallSiteNode
 import io.johnsonlee.graphite.core.ControlFlowEdge
 import io.johnsonlee.graphite.core.DataFlowEdge
 import io.johnsonlee.graphite.core.Edge
+import io.johnsonlee.graphite.core.EnumConstant
+import io.johnsonlee.graphite.core.FieldNode
+import io.johnsonlee.graphite.core.LocalVariable
 import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.core.ResourceEdge
@@ -18,6 +23,20 @@ private const val SINGLE_HOP_LIMIT_QUERY_CLAUSES = 3
 private const val SINGLE_HOP_PATTERN_ELEMENTS = 3
 private const val SINGLE_GRAPH_ID = "single"
 private val QUALIFIED_NODE_PROPERTIES = setOf(GRAPH_ID_PROPERTY, ELEMENT_ID_PROPERTY, QUALIFIED_ID_PROPERTY)
+private val DIRECT_STRING_NODE_PROPERTIES = listOf(
+    EnumConstant::class.java to setOf("name"),
+    LocalVariable::class.java to setOf("name"),
+    FieldNode::class.java to setOf("class", "name"),
+    CallSiteNode::class.java to setOf("caller_class", "caller_name", "callee_class", "callee_name"),
+    AnnotationNode::class.java to setOf(
+        "class",
+        "name",
+        "caller_class",
+        "caller_name",
+        "callee_class",
+        "callee_name"
+    )
+)
 
 /**
  * Executes a sequence of [CypherClause] elements against a [Graph],
@@ -339,7 +358,7 @@ class QueryPipeline private constructor(
         val where = clauses[1] as? CypherClause.Where ?: return null
         val ret = clauses[2] as? CypherClause.Return ?: return null
         val limit = clauses[3] as? CypherClause.Limit ?: return null
-        if (match.optional || ret.distinct || match.patterns.size != 1 || ret.items.any { containsAggregation(it.expression) }) {
+        if (match.optional || match.patterns.size != 1 || ret.items.any { containsAggregation(it.expression) }) {
             return null
         }
         if (ret.items.any { (it.expression as? CypherExpr.Variable)?.name == "*" }) return null
@@ -357,7 +376,7 @@ class QueryPipeline private constructor(
             ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
             ?: Node::class.java
         val directStringFilter = DirectStringFilter.compile(where.condition, variable)
-        if (directStringFilter != null && nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()) {
+        if (!ret.distinct && directStringFilter != null && nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()) {
             return executeDirectStringFilter(
                 nodeClass,
                 variable,
@@ -367,8 +386,26 @@ class QueryPipeline private constructor(
                 limitCount
             )
         }
+        val directStringDisjunction = DirectStringDisjunction.compile(where.condition, variable)
+        if (ret.distinct && directStringDisjunction != null &&
+            nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()
+        ) {
+            return executeDirectStringDisjunction(
+                nodeClass,
+                variable,
+                directStringDisjunction,
+                ret.items,
+                columns,
+                limitCount
+            )
+        }
 
         val rows = mutableListOf<Map<String, Any?>>()
+        val distinctRows = if (ret.distinct) {
+            LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>()
+        } else {
+            null
+        }
         val predicateBindings = mutableMapOf<String, Any?>(variable to null)
         for (candidate in nodeCandidates(nodeClass)) {
             if (!matchesNodeConstraints(candidate, nodePattern, emptyMap())) continue
@@ -378,11 +415,36 @@ class QueryPipeline private constructor(
 
             val bindings = mutableMapOf<String, Any?>(variable to candidate)
             addProvenance(bindings, candidate)
-            rows.add(projectRow(ret.items, columns, bindings))
-            if (rows.size >= limitCount) return CypherResult(columns, rows)
+            val projected = projectRow(ret.items, columns, bindings)
+            if (distinctRows == null) {
+                rows.add(projected)
+                if (rows.size >= limitCount) return CypherResult(columns, rows)
+            } else {
+                addDistinctRow(distinctRows, projected, limitCount)
+                if (!qualified && distinctRows.size >= limitCount) {
+                    return CypherResult(columns, distinctRows.values.toList())
+                }
+            }
         }
 
-        return CypherResult(columns, rows)
+        return CypherResult(columns, distinctRows?.values?.toList() ?: rows)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun addDistinctRow(
+        rows: LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>,
+        row: Map<String, Any?>,
+        limit: Int
+    ) {
+        val visible = row.filterKeys { it != INTERNAL_PROVENANCE_KEY }
+        val existing = rows[visible]
+        if (existing != null) {
+            val graphIds = (existing[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty() +
+                (row[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty()
+            if (graphIds.isNotEmpty()) existing[INTERNAL_PROVENANCE_KEY] = graphIds
+        } else if (rows.size < limit) {
+            rows[visible] = row.toMutableMap()
+        }
     }
 
     private fun executeDirectStringFilter(
@@ -413,6 +475,61 @@ class QueryPipeline private constructor(
             }
         }
         return CypherResult(columns, rows)
+    }
+
+    private fun executeDirectStringDisjunction(
+        nodeClass: Class<out Node>,
+        variable: String,
+        filter: DirectStringDisjunction,
+        items: List<ReturnItem>,
+        columns: List<String>,
+        limit: Int
+    ): CypherResult {
+        val rows = LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>()
+        for (source in sources) {
+            for (node in directStringCandidates(source.graph, nodeClass, filter)) {
+                val candidate = nodeValue(source, node)
+                val bindings = mutableMapOf<String, Any?>(variable to candidate)
+                addProvenance(bindings, candidate)
+                addDistinctRow(rows, projectRow(items, columns, bindings), limit)
+                if (!qualified && rows.size >= limit) return CypherResult(columns, rows.values.toList())
+            }
+        }
+        return CypherResult(columns, rows.values.toList())
+    }
+
+    private fun directStringCandidates(
+        graph: Graph,
+        nodeClass: Class<out Node>,
+        disjunction: DirectStringDisjunction
+    ): Sequence<Node> = sequence {
+        for ((candidateType, properties) in DIRECT_STRING_NODE_PROPERTIES) {
+            if (!nodeClass.isAssignableFrom(candidateType)) continue
+            val filters = disjunction.filters.filter { it.property in properties }
+            if (filters.isEmpty()) continue
+
+            val completeScanLimit = graph.nodeCount(candidateType)
+                ?.takeIf { it < Int.MAX_VALUE }
+                ?.toInt()
+                ?: Int.MAX_VALUE
+            val accelerated = filters.map { filter ->
+                graph.nodesByStringProperty(
+                    candidateType,
+                    filter.property,
+                    filter.mode,
+                    filter.expected,
+                    completeScanLimit
+                )
+            }
+            val candidates = if (accelerated.any { it == null }) {
+                graph.nodes(candidateType).filter(disjunction::matches)
+            } else {
+                accelerated.asSequence().filterNotNull().flatten()
+            }
+            val unique = LinkedHashMap<Int, Node>()
+            candidates.forEach { node -> unique.putIfAbsent(node.id.value, node) }
+            unique.values.sortedBy { it.id.value }.forEach { yield(it) }
+        }
     }
 
     private data class DirectStringFilter(
@@ -446,6 +563,50 @@ class QueryPipeline private constructor(
                     else -> return null
                 }
                 return DirectStringFilter(property.propertyName, mode, expected)
+            }
+        }
+    }
+
+    private data class DirectStringDisjunction(val filters: List<DirectStringFilter>) {
+        fun matches(node: Node): Boolean = filters.any { it.matches(node) }
+
+        companion object {
+            @Suppress("ReturnCount")
+            fun compile(expression: CypherExpr, variable: String): DirectStringDisjunction? {
+                val terms = flattenOr(expression)
+                if (terms.size < 2) return null
+                val filters = terms.map { guardedFilter(it, variable) ?: return null }.distinct()
+                if (filters.any { filter ->
+                        DIRECT_STRING_NODE_PROPERTIES.none { (_, properties) -> filter.property in properties }
+                    }
+                ) {
+                    return null
+                }
+                return DirectStringDisjunction(filters)
+            }
+
+            private fun flattenOr(expression: CypherExpr): List<CypherExpr> = when (expression) {
+                is CypherExpr.Or -> flattenOr(expression.left) + flattenOr(expression.right)
+                else -> listOf(expression)
+            }
+
+            @Suppress("ReturnCount")
+            private fun guardedFilter(expression: CypherExpr, variable: String): DirectStringFilter? {
+                DirectStringFilter.compile(expression, variable)?.let { return it }
+                val and = expression as? CypherExpr.And ?: return null
+                val left = DirectStringFilter.compile(and.left, variable)
+                if (left != null && isExistenceGuard(and.right, variable, left.property)) return left
+                val right = DirectStringFilter.compile(and.right, variable)
+                if (right != null && isExistenceGuard(and.left, variable, right.property)) return right
+                return null
+            }
+
+            @Suppress("ReturnCount")
+            private fun isExistenceGuard(expression: CypherExpr, variable: String, property: String): Boolean {
+                val call = expression as? CypherExpr.FunctionCall ?: return false
+                if (!call.name.equals("exists", ignoreCase = true) || call.distinct) return false
+                val argument = call.args.singleOrNull() as? CypherExpr.Property ?: return false
+                return argument.expression == CypherExpr.Variable(variable) && argument.propertyName == property
             }
         }
     }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -17,6 +17,7 @@ private const val FILTERED_LIMIT_QUERY_CLAUSES = 4
 private const val SINGLE_HOP_LIMIT_QUERY_CLAUSES = 3
 private const val SINGLE_HOP_PATTERN_ELEMENTS = 3
 private const val SINGLE_GRAPH_ID = "single"
+private val QUALIFIED_NODE_PROPERTIES = setOf(GRAPH_ID_PROPERTY, ELEMENT_ID_PROPERTY, QUALIFIED_ID_PROPERTY)
 
 /**
  * Executes a sequence of [CypherClause] elements against a [Graph],
@@ -190,7 +191,7 @@ class QueryPipeline private constructor(
         }
 
         val separator = elementId.lastIndexOf(':')
-        if (separator <= 0 || separator == elementId.lastIndex) return null
+        if (separator < 0 || separator == elementId.lastIndex) return null
         val graphId = elementId.substring(0, separator)
         val nodeId = elementId.substring(separator + 1).toIntOrNull() ?: return null
         val source = sources.firstOrNull { it.id == graphId } ?: return null
@@ -436,6 +437,7 @@ class QueryPipeline private constructor(
                 val literal = stringOp.right as? CypherExpr.Literal ?: return null
                 val expected = literal.value as? String ?: return null
                 if (owner.name != variable) return null
+                if (property.propertyName in QUALIFIED_NODE_PROPERTIES) return null
                 val mode = when (stringOp.op) {
                     "STARTS WITH" -> StringMatchMode.STARTS_WITH
                     "ENDS WITH" -> StringMatchMode.ENDS_WITH

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -277,6 +277,18 @@ class QueryPipeline private constructor(
         val nodeClass = nodePattern.labels.firstOrNull()
             ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
             ?: Node::class.java
+        val directStringFilter = DirectStringFilter.compile(where.condition, variable)
+        if (directStringFilter != null && nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()) {
+            return executeDirectStringFilter(
+                nodeClass,
+                variable,
+                directStringFilter,
+                ret.items,
+                columns,
+                limitCount
+            )
+        }
+
         val rows = mutableListOf<Map<String, Any?>>()
         val predicateBindings = mutableMapOf<String, Any?>(variable to null)
         for (candidate in nodeCandidates(nodeClass)) {
@@ -292,6 +304,57 @@ class QueryPipeline private constructor(
         }
 
         return CypherResult(columns, rows)
+    }
+
+    private fun executeDirectStringFilter(
+        nodeClass: Class<out Node>,
+        variable: String,
+        filter: DirectStringFilter,
+        items: List<ReturnItem>,
+        columns: List<String>,
+        limit: Int
+    ): CypherResult {
+        val rows = mutableListOf<Map<String, Any?>>()
+        for (source in sources) {
+            for (node in source.graph.nodes(nodeClass)) {
+                if (!filter.matches(node)) continue
+
+                val candidate = nodeValue(source, node)
+                val bindings = mutableMapOf<String, Any?>(variable to candidate)
+                addProvenance(bindings, candidate)
+                rows.add(projectRow(items, columns, bindings))
+                if (rows.size >= limit) return CypherResult(columns, rows)
+            }
+        }
+        return CypherResult(columns, rows)
+    }
+
+    private data class DirectStringFilter(
+        val property: String,
+        val operation: String,
+        val expected: String
+    ) {
+        fun matches(node: Node): Boolean {
+            val actual = NodePropertyAccessor.getProperty(node, property) as? String ?: return false
+            return when (operation) {
+                "STARTS WITH" -> actual.startsWith(expected)
+                "ENDS WITH" -> actual.endsWith(expected)
+                "CONTAINS" -> actual.contains(expected)
+                else -> false
+            }
+        }
+
+        companion object {
+            fun compile(expression: CypherExpr, variable: String): DirectStringFilter? {
+                val stringOp = expression as? CypherExpr.StringOp ?: return null
+                val property = stringOp.left as? CypherExpr.Property ?: return null
+                val owner = property.expression as? CypherExpr.Variable ?: return null
+                val literal = stringOp.right as? CypherExpr.Literal ?: return null
+                val expected = literal.value as? String ?: return null
+                if (owner.name != variable) return null
+                return DirectStringFilter(property.propertyName, stringOp.op, expected)
+            }
+        }
     }
 
     /**

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -9,6 +9,7 @@ import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.core.ResourceEdge
 import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.StringMatchMode
 
 private const val COUNT_QUERY_CLAUSES = 2
 private const val DISTINCT_LIMIT_QUERY_CLAUSES = 3
@@ -127,6 +128,7 @@ class QueryPipeline private constructor(
         return CypherResult(columns, rows)
     }
 
+    @Suppress("ReturnCount")
     private fun tryElementIdSeek(
         match: CypherClause.Match,
         where: CypherClause.Where,
@@ -159,6 +161,7 @@ class QueryPipeline private constructor(
         return results
     }
 
+    @Suppress("ReturnCount")
     private fun elementIdEquality(expression: CypherExpr, variable: String): String? {
         val comparison = expression as? CypherExpr.Comparison ?: return null
         if (comparison.op != "=") return null
@@ -179,6 +182,7 @@ class QueryPipeline private constructor(
         else -> false
     }
 
+    @Suppress("ReturnCount")
     private fun seekNode(elementId: String): Pair<CypherGraph, Node>? {
         if (!qualified) {
             val nodeId = elementId.toIntOrNull() ?: return null
@@ -390,8 +394,14 @@ class QueryPipeline private constructor(
     ): CypherResult {
         val rows = mutableListOf<Map<String, Any?>>()
         for (source in sources) {
-            for (node in source.graph.nodes(nodeClass)) {
-                if (!filter.matches(node)) continue
+            val indexedNodes = source.graph.nodesByStringProperty(
+                nodeClass,
+                filter.property,
+                filter.mode,
+                filter.expected
+            )
+            val candidates = indexedNodes ?: source.graph.nodes(nodeClass).filter(filter::matches)
+            for (node in candidates) {
 
                 val candidate = nodeValue(source, node)
                 val bindings = mutableMapOf<String, Any?>(variable to candidate)
@@ -405,20 +415,20 @@ class QueryPipeline private constructor(
 
     private data class DirectStringFilter(
         val property: String,
-        val operation: String,
+        val mode: StringMatchMode,
         val expected: String
     ) {
         fun matches(node: Node): Boolean {
             val actual = NodePropertyAccessor.getProperty(node, property) as? String ?: return false
-            return when (operation) {
-                "STARTS WITH" -> actual.startsWith(expected)
-                "ENDS WITH" -> actual.endsWith(expected)
-                "CONTAINS" -> actual.contains(expected)
-                else -> false
+            return when (mode) {
+                StringMatchMode.STARTS_WITH -> actual.startsWith(expected)
+                StringMatchMode.ENDS_WITH -> actual.endsWith(expected)
+                StringMatchMode.CONTAINS -> actual.contains(expected)
             }
         }
 
         companion object {
+            @Suppress("ReturnCount")
             fun compile(expression: CypherExpr, variable: String): DirectStringFilter? {
                 val stringOp = expression as? CypherExpr.StringOp ?: return null
                 val property = stringOp.left as? CypherExpr.Property ?: return null
@@ -426,7 +436,13 @@ class QueryPipeline private constructor(
                 val literal = stringOp.right as? CypherExpr.Literal ?: return null
                 val expected = literal.value as? String ?: return null
                 if (owner.name != variable) return null
-                return DirectStringFilter(property.propertyName, stringOp.op, expected)
+                val mode = when (stringOp.op) {
+                    "STARTS WITH" -> StringMatchMode.STARTS_WITH
+                    "ENDS WITH" -> StringMatchMode.ENDS_WITH
+                    "CONTAINS" -> StringMatchMode.CONTAINS
+                    else -> return null
+                }
+                return DirectStringFilter(property.propertyName, mode, expected)
             }
         }
     }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -68,16 +68,24 @@ class QueryPipeline private constructor(
         // node scan early instead of materialising all candidates first.
         val earlyLimit = computeEarlyLimit(clauses)
 
-        for (clause in clauses) {
+        var consumedWhereIndex = -1
+        for ((clauseIndex, clause) in clauses.withIndex()) {
             when (clause) {
                 is CypherClause.Match -> {
-                    rows = if (clause.optional) {
+                    val pushedWhere = clauses.getOrNull(clauseIndex + 1) as? CypherClause.Where
+                    val soughtRows = pushedWhere?.let { tryElementIdSeek(clause, it, rows) }
+                    rows = if (soughtRows != null) {
+                        consumedWhereIndex = clauseIndex + 1
+                        soughtRows
+                    } else if (clause.optional) {
                         executeOptionalMatch(clause.patterns, rows)
                     } else {
                         executeMatch(clause.patterns, rows, earlyLimit)
                     }
                 }
-                is CypherClause.Where -> rows = executeWhere(clause, rows)
+                is CypherClause.Where -> {
+                    if (clauseIndex != consumedWhereIndex) rows = executeWhere(clause, rows)
+                }
                 is CypherClause.Return -> {
                     val (newRows, newColumns) = projectAndAggregate(clause.items, rows, clause.distinct)
                     rows = newRows
@@ -117,6 +125,72 @@ class QueryPipeline private constructor(
         }
 
         return CypherResult(columns, rows)
+    }
+
+    private fun tryElementIdSeek(
+        match: CypherClause.Match,
+        where: CypherClause.Where,
+        inputRows: List<Map<String, Any?>>
+    ): List<Map<String, Any?>>? {
+        if (match.optional || match.patterns.size != 1) return null
+        val pattern = match.patterns.single()
+        if (pattern.pathVariable != null || pattern.elements.size != 1) return null
+        val nodePattern = pattern.elements.single() as? PatternElement.NodePattern ?: return null
+        val variable = nodePattern.variable ?: return null
+        if (inputRows.any { variable in it }) return null
+
+        val elementId = elementIdEquality(where.condition, variable) ?: return null
+        val sourceAndNode = seekNode(elementId) ?: return emptyList()
+        val (source, node) = sourceAndNode
+        val nodeClass = nodePattern.labels.firstOrNull()
+            ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
+            ?: Node::class.java
+        if (!nodeClass.isInstance(node)) return emptyList()
+
+        val candidate = nodeValue(source, node)
+        val results = mutableListOf<Map<String, Any?>>()
+        for (inputRow in inputRows) {
+            if (!matchesNodeConstraints(candidate, nodePattern, inputRow)) continue
+            val bindings = inputRow.toMutableMap()
+            bindings[variable] = candidate
+            addProvenance(bindings, candidate)
+            if (evaluator.evaluate(where.condition, bindings) == true) results.add(bindings)
+        }
+        return results
+    }
+
+    private fun elementIdEquality(expression: CypherExpr, variable: String): String? {
+        val comparison = expression as? CypherExpr.Comparison ?: return null
+        if (comparison.op != "=") return null
+        return when {
+            isElementIdReference(comparison.left, variable) ->
+                (comparison.right as? CypherExpr.Literal)?.value as? String
+            isElementIdReference(comparison.right, variable) ->
+                (comparison.left as? CypherExpr.Literal)?.value as? String
+            else -> null
+        }
+    }
+
+    private fun isElementIdReference(expression: CypherExpr, variable: String): Boolean = when (expression) {
+        is CypherExpr.FunctionCall -> expression.name.equals("elementId", ignoreCase = true) &&
+            expression.args.singleOrNull() == CypherExpr.Variable(variable)
+        is CypherExpr.Property -> expression.expression == CypherExpr.Variable(variable) &&
+            expression.propertyName in setOf(ELEMENT_ID_PROPERTY, QUALIFIED_ID_PROPERTY)
+        else -> false
+    }
+
+    private fun seekNode(elementId: String): Pair<CypherGraph, Node>? {
+        if (!qualified) {
+            val nodeId = elementId.toIntOrNull() ?: return null
+            return sources.single().let { source -> source.graph.node(NodeId(nodeId))?.let { source to it } }
+        }
+
+        val separator = elementId.lastIndexOf(':')
+        if (separator <= 0 || separator == elementId.lastIndex) return null
+        val graphId = elementId.substring(0, separator)
+        val nodeId = elementId.substring(separator + 1).toIntOrNull() ?: return null
+        val source = sources.firstOrNull { it.id == graphId } ?: return null
+        return source.graph.node(NodeId(nodeId))?.let { source to it }
     }
 
     /**

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -16,7 +16,6 @@ import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.graph.nodesByStringProperty
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 
 private const val COUNT_QUERY_CLAUSES = 2
 private const val DISTINCT_LIMIT_QUERY_CLAUSES = 3
@@ -530,17 +529,26 @@ class QueryPipeline private constructor(
             val candidates = if (accelerated.any { it == null }) {
                 graph.nodes(candidateType).filter(disjunction::matches)
             } else {
-                uniqueNodes(accelerated.filterNotNull())
+                filterOwnedNodes(filters, accelerated.filterNotNull())
             }
             for (node in candidates) yield(node)
         }
     }
 
-    private fun <T : Node> uniqueNodes(sequences: List<Sequence<T>>): Sequence<Node> = sequence {
-        val seen = IntOpenHashSet()
-        for (nodes in sequences) {
+    private fun <T : Node> filterOwnedNodes(
+        filters: List<DirectStringFilter>,
+        sequences: List<Sequence<T>>
+    ): Sequence<Node> = sequence {
+        for ((index, nodes) in sequences.withIndex()) {
             for (node in nodes) {
-                if (seen.add(node.id.value)) yield(node)
+                var ownedByEarlierFilter = false
+                for (earlierIndex in 0 until index) {
+                    if (filters[earlierIndex].matches(node)) {
+                        ownedByEarlierFilter = true
+                        break
+                    }
+                }
+                if (!ownedByEarlierFilter) yield(node)
             }
         }
     }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -16,6 +16,7 @@ import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.graph.nodesByStringProperty
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 
 private const val COUNT_QUERY_CLAUSES = 2
 private const val DISTINCT_LIMIT_QUERY_CLAUSES = 3
@@ -529,31 +530,20 @@ class QueryPipeline private constructor(
             val candidates = if (accelerated.any { it == null }) {
                 graph.nodes(candidateType).filter(disjunction::matches)
             } else {
-                mergeSortedNodes(accelerated.filterNotNull())
+                uniqueNodes(accelerated.filterNotNull())
             }
             for (node in candidates) yield(node)
         }
     }
 
-    private fun <T : Node> mergeSortedNodes(sequences: List<Sequence<T>>): Sequence<Node> = sequence {
-        val iterators = sequences.map { it.iterator() }
-        val heads = iterators.map { iterator -> iterator.nextOrNull() }.toMutableList()
-        while (true) {
-            var next: Node? = null
-            for (head in heads) {
-                if (head != null && (next == null || head.id.value < next.id.value)) next = head
-            }
-            next ?: break
-            yield(next)
-            heads.indices.forEach { index ->
-                while (heads[index]?.id == next.id) {
-                    heads[index] = iterators[index].nextOrNull()
-                }
+    private fun <T : Node> uniqueNodes(sequences: List<Sequence<T>>): Sequence<Node> = sequence {
+        val seen = IntOpenHashSet()
+        for (nodes in sequences) {
+            for (node in nodes) {
+                if (seen.add(node.id.value)) yield(node)
             }
         }
     }
-
-    private fun <T> Iterator<T>.nextOrNull(): T? = if (hasNext()) next() else null
 
     private data class DirectStringFilter(
         val property: String,

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -282,9 +282,9 @@ class QueryPipeline private constructor(
             if (!matchesNodeConstraints(candidate, nodePattern, emptyMap())) continue
 
             val bindings = mutableMapOf<String, Any?>(variable to candidate)
-            addProvenance(bindings, candidate)
             if (evaluator.evaluate(where.condition, bindings) != true) continue
 
+            addProvenance(bindings, candidate)
             rows.add(projectRow(ret.items, columns, bindings))
             if (rows.size >= limitCount) return CypherResult(columns, rows)
         }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -278,12 +278,14 @@ class QueryPipeline private constructor(
             ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
             ?: Node::class.java
         val rows = mutableListOf<Map<String, Any?>>()
+        val predicateBindings = mutableMapOf<String, Any?>(variable to null)
         for (candidate in nodeCandidates(nodeClass)) {
             if (!matchesNodeConstraints(candidate, nodePattern, emptyMap())) continue
 
-            val bindings = mutableMapOf<String, Any?>(variable to candidate)
-            if (evaluator.evaluate(where.condition, bindings) != true) continue
+            predicateBindings[variable] = candidate
+            if (evaluator.evaluate(where.condition, predicateBindings) != true) continue
 
+            val bindings = mutableMapOf<String, Any?>(variable to candidate)
             addProvenance(bindings, candidate)
             rows.add(projectRow(ret.items, columns, bindings))
             if (rows.size >= limitCount) return CypherResult(columns, rows)

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -1,16 +1,20 @@
 package io.johnsonlee.graphite.cypher
 
+import io.johnsonlee.graphite.core.AnnotationNode
 import io.johnsonlee.graphite.core.CallEdge
+import io.johnsonlee.graphite.core.CallSiteNode
 import io.johnsonlee.graphite.core.ControlFlowEdge
 import io.johnsonlee.graphite.core.ControlFlowKind
 import io.johnsonlee.graphite.core.DataFlowEdge
 import io.johnsonlee.graphite.core.DataFlowKind
 import io.johnsonlee.graphite.core.IntConstant
+import io.johnsonlee.graphite.core.MethodDescriptor
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.core.ResourceEdge
 import io.johnsonlee.graphite.core.ResourceRelation
 import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeEdge
+import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.core.TypeRelation
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
@@ -166,6 +170,75 @@ class CrossGraphCypherExecutorTest {
         )
         assertEquals(1, union.rows.size)
         assertEquals(listOf("billing", "orders"), graphIds(union.rows.single()))
+    }
+
+    @Test
+    fun `agent discovery query streams distinct rows and merges provenance`() {
+        val caller = MethodDescriptor(
+            TypeDescriptor("com.example.ThankYouService"),
+            "create",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val callee = MethodDescriptor(
+            TypeDescriptor("com.example.Repository"),
+            "save",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val executor = executor(
+            "orders" to graph(CallSiteNode(NodeId(1), caller, callee, 10, null, emptyList())),
+            "billing" to graph(CallSiteNode(NodeId(1), caller, callee, 20, null, emptyList()))
+        )
+
+        val result = executor.execute(
+            """
+            MATCH (n)
+            WHERE (exists(n.class) AND n.class CONTAINS 'ThankYou')
+               OR (exists(n.name) AND n.name CONTAINS 'ThankYou')
+               OR (exists(n.caller_class) AND n.caller_class CONTAINS 'ThankYou')
+               OR (exists(n.caller_name) AND n.caller_name CONTAINS 'ThankYou')
+               OR (exists(n.callee_class) AND n.callee_class CONTAINS 'ThankYou')
+               OR (exists(n.callee_name) AND n.callee_name CONTAINS 'ThankYou')
+            RETURN DISTINCT n.class AS class, n.name AS name,
+                n.caller_class AS caller, n.caller_name AS callerMethod,
+                n.callee_class AS callee, n.callee_name AS calleeMethod
+            LIMIT 1
+            """.trimIndent()
+        )
+
+        assertEquals(1, result.rows.size)
+        assertEquals("com.example.ThankYouService", result.rows.single()["caller"])
+        assertEquals("create", result.rows.single()["callerMethod"])
+        assertEquals("com.example.Repository", result.rows.single()["callee"])
+        assertEquals("save", result.rows.single()["calleeMethod"])
+        assertEquals(listOf("billing", "orders"), graphIds(result.rows.single()))
+    }
+
+    @Test
+    fun `agent discovery query preserves dynamic annotation properties`() {
+        val annotation = AnnotationNode(
+            NodeId(1),
+            "com.example.Feature",
+            "com.example.Owner",
+            "create",
+            mapOf("caller_class" to "com.example.ThankYouDynamicOwner")
+        )
+        val executor = executor("orders" to graph(annotation))
+
+        val result = executor.execute(
+            "MATCH (n) WHERE " +
+                "(exists(n.class) AND n.class CONTAINS 'ThankYou') OR " +
+                "(exists(n.name) AND n.name CONTAINS 'ThankYou') OR " +
+                "(exists(n.caller_class) AND n.caller_class CONTAINS 'ThankYou') OR " +
+                "(exists(n.caller_name) AND n.caller_name CONTAINS 'ThankYou') OR " +
+                "(exists(n.callee_class) AND n.callee_class CONTAINS 'ThankYou') OR " +
+                "(exists(n.callee_name) AND n.callee_name CONTAINS 'ThankYou') " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 10"
+        )
+
+        assertEquals(listOf("com.example.ThankYouDynamicOwner"), result.rows.map { it["caller"] })
+        assertEquals(listOf("orders"), graphIds(result.rows.single()))
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -206,6 +206,10 @@ class CrossGraphCypherExecutorTest {
             "MATCH (n:StringConstant) WHERE n.value ENDS WITH 'handler' " +
                 "RETURN elementId(n) AS id LIMIT 2"
         )
+        val missing = executor.execute(
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS 'missing' " +
+                "RETURN elementId(n) AS id LIMIT 2"
+        )
 
         assertEquals("billing:1", contains.rows.single()["id"])
         assertEquals("feature-billing-handler", contains.rows.single()["value"])
@@ -213,6 +217,7 @@ class CrossGraphCypherExecutorTest {
         assertEquals("orders:1", startsWith.rows.single()["id"])
         assertEquals(listOf("orders:1", "billing:1"), endsWith.rows.map { it["id"] })
         assertEquals(listOf(listOf("orders"), listOf("billing")), endsWith.rows.map(::graphIds))
+        assertTrue(missing.rows.isEmpty())
     }
 
     @Test
@@ -240,6 +245,9 @@ class CrossGraphCypherExecutorTest {
         val propertySeek = executor.execute(
             "MATCH (a:IntConstant) WHERE 'orders:1' = a.qualifiedId RETURN a.value AS value"
         )
+        val unlabeledSeek = executor.execute(
+            "MATCH (a) WHERE elementId(a) = 'billing:1' RETURN a.value AS value"
+        )
 
         assertEquals(
             listOf(mapOf("source" to "billing:1", "target" to "billing:2", "value" to 40)),
@@ -248,6 +256,8 @@ class CrossGraphCypherExecutorTest {
         assertEquals(listOf("billing"), graphIds(result.rows.single()))
         assertEquals(10, propertySeek.rows.single()["value"])
         assertEquals(listOf("orders"), graphIds(propertySeek.rows.single()))
+        assertEquals(30, unlabeledSeek.rows.single()["value"])
+        assertEquals(listOf("billing"), graphIds(unlabeledSeek.rows.single()))
         assertTrue(missing.rows.isEmpty())
     }
 

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -216,6 +216,42 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `element id seek seeds a qualified call chain without scanning colliding ids`() {
+        val orders = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId(1), 10))
+            .addNode(IntConstant(NodeId(2), 20))
+            .addEdge(DataFlowEdge(NodeId(1), NodeId(2), DataFlowKind.ASSIGN))
+            .build()
+        val billing = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId(1), 30))
+            .addNode(IntConstant(NodeId(2), 40))
+            .addEdge(DataFlowEdge(NodeId(1), NodeId(2), DataFlowKind.ASSIGN))
+            .build()
+        val executor = executor("orders" to orders, "billing" to billing)
+
+        val result = executor.execute(
+            "MATCH (a:IntConstant) WHERE elementId(a) = 'billing:1' " +
+                "WITH a MATCH (a)-[:DATAFLOW*1..2]->(b:IntConstant) " +
+                "RETURN elementId(a) AS source, elementId(b) AS target, b.value AS value LIMIT 2"
+        )
+        val missing = executor.execute(
+            "MATCH (a:IntConstant) WHERE elementId(a) = 'missing:1' RETURN a.value AS value"
+        )
+        val propertySeek = executor.execute(
+            "MATCH (a:IntConstant) WHERE 'orders:1' = a.qualifiedId RETURN a.value AS value"
+        )
+
+        assertEquals(
+            listOf(mapOf("source" to "billing:1", "target" to "billing:2", "value" to 40)),
+            result.rows.map { it.filterKeys { key -> key != RESULT_METADATA_KEY } }
+        )
+        assertEquals(listOf("billing"), graphIds(result.rows.single()))
+        assertEquals(10, propertySeek.rows.single()["value"])
+        assertEquals(listOf("orders"), graphIds(propertySeek.rows.single()))
+        assertTrue(missing.rows.isEmpty())
+    }
+
+    @Test
     fun `supports an empty graph set and rejects duplicate graph namespaces`() {
         val empty = CrossGraphCypherExecutor(emptyList()).execute("MATCH (n) RETURN count(n) AS count")
         assertEquals(0L, empty.rows.single()["count"])

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -221,6 +221,43 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `string filters preserve virtual qualified properties`() {
+        val executor = executor(
+            "orders" to graph(StringConstant(NodeId(1), "order")),
+            "billing" to graph(StringConstant(NodeId(1), "billing"))
+        )
+
+        val graphId = executor.execute(
+            "MATCH (n:StringConstant) WHERE n.graphId STARTS WITH 'ord' " +
+                "RETURN elementId(n) AS id LIMIT 1"
+        )
+        val elementId = executor.execute(
+            "MATCH (n:StringConstant) WHERE n.elementId ENDS WITH ':1' " +
+                "RETURN elementId(n) AS id LIMIT 2"
+        )
+        val qualifiedId = executor.execute(
+            "MATCH (n:StringConstant) WHERE n.qualifiedId CONTAINS 'billing:' " +
+                "RETURN elementId(n) AS id LIMIT 1"
+        )
+
+        assertEquals(listOf("orders:1"), graphId.rows.map { it["id"] })
+        assertEquals(listOf("orders:1", "billing:1"), elementId.rows.map { it["id"] })
+        assertEquals(listOf("billing:1"), qualifiedId.rows.map { it["id"] })
+    }
+
+    @Test
+    fun `element id seek preserves an empty graph namespace`() {
+        val executor = executor("" to graph(IntConstant(NodeId(1), 10)))
+
+        val result = executor.execute(
+            "MATCH (n:IntConstant) WHERE elementId(n) = ':1' RETURN n.value AS value"
+        )
+
+        assertEquals(listOf(10), result.rows.map { it["value"] })
+        assertEquals(listOf(""), graphIds(result.rows.single()))
+    }
+
+    @Test
     fun `element id seek seeds a qualified call chain without scanning colliding ids`() {
         val orders = DefaultGraph.Builder()
             .addNode(IntConstant(NodeId(1), 10))

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -188,6 +188,34 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `fast string filters preserve qualified identity and provenance`() {
+        val executor = executor(
+            "orders" to graph(StringConstant(NodeId(1), "feature-order-handler")),
+            "billing" to graph(StringConstant(NodeId(1), "feature-billing-handler"))
+        )
+
+        val contains = executor.execute(
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS 'billing' " +
+                "RETURN elementId(n) AS id, n.value AS value LIMIT 1"
+        )
+        val startsWith = executor.execute(
+            "MATCH (n:StringConstant) WHERE n.value STARTS WITH 'feature-order' " +
+                "RETURN elementId(n) AS id LIMIT 1"
+        )
+        val endsWith = executor.execute(
+            "MATCH (n:StringConstant) WHERE n.value ENDS WITH 'handler' " +
+                "RETURN elementId(n) AS id LIMIT 2"
+        )
+
+        assertEquals("billing:1", contains.rows.single()["id"])
+        assertEquals("feature-billing-handler", contains.rows.single()["value"])
+        assertEquals(listOf("billing"), graphIds(contains.rows.single()))
+        assertEquals("orders:1", startsWith.rows.single()["id"])
+        assertEquals(listOf("orders:1", "billing:1"), endsWith.rows.map { it["id"] })
+        assertEquals(listOf(listOf("orders"), listOf("billing")), endsWith.rows.map(::graphIds))
+    }
+
+    @Test
     fun `supports an empty graph set and rejects duplicate graph namespaces`() {
         val empty = CrossGraphCypherExecutor(emptyList()).execute("MATCH (n) RETURN count(n) AS count")
         assertEquals(0L, empty.rows.single()["count"])

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -9,6 +9,7 @@ import io.johnsonlee.graphite.core.DataFlowEdge
 import io.johnsonlee.graphite.core.DataFlowKind
 import io.johnsonlee.graphite.core.IntConstant
 import io.johnsonlee.graphite.core.MethodDescriptor
+import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.core.ResourceEdge
 import io.johnsonlee.graphite.core.ResourceRelation
@@ -18,6 +19,8 @@ import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.core.TypeRelation
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.StringPropertyLookup
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -173,7 +176,7 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
-    fun `agent discovery query streams distinct rows and merges provenance`() {
+    fun `broad discovery query streams distinct rows and merges provenance`() {
         val caller = MethodDescriptor(
             TypeDescriptor("com.example.ThankYouService"),
             "create",
@@ -216,7 +219,58 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
-    fun `agent discovery query preserves dynamic annotation properties`() {
+    fun `qualified broad discovery drains large matches with bounded deduplication state`() {
+        val matchCount = 5_000
+        val consumed = mutableMapOf("orders" to 0, "billing" to 0)
+        val caller = MethodDescriptor(
+            TypeDescriptor("com.example.TargetService"),
+            "call",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val callee = MethodDescriptor(
+            TypeDescriptor("com.example.TargetRepository"),
+            "load",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+
+        fun indexedGraph(graphId: String): Graph {
+            val backing = DefaultGraph.Builder().apply {
+                repeat(matchCount) { index ->
+                    addNode(CallSiteNode(NodeId(index), caller, callee, index, null, emptyList()))
+                }
+            }.build()
+            return object : Graph by backing, StringPropertyLookup {
+                override fun <T : Node> nodesByStringProperty(
+                    type: Class<T>,
+                    property: String,
+                    mode: StringMatchMode,
+                    expected: String,
+                    limit: Int
+                ): Sequence<T> = backing.nodes(type).onEach {
+                    consumed[graphId] = consumed.getValue(graphId) + 1
+                }
+            }
+        }
+
+        val result = executor(
+            "orders" to indexedGraph("orders"),
+            "billing" to indexedGraph("billing")
+        ).execute(
+            "MATCH (n:CallSiteNode) WHERE " +
+                "n.caller_class CONTAINS 'Target' OR n.callee_class CONTAINS 'Target' " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 1"
+        )
+
+        assertEquals(listOf("com.example.TargetService"), result.rows.map { it["caller"] })
+        assertEquals(listOf("billing", "orders"), graphIds(result.rows.single()))
+        assertEquals(2 * matchCount, consumed.getValue("orders"))
+        assertEquals(2 * matchCount, consumed.getValue("billing"))
+    }
+
+    @Test
+    fun `broad discovery query preserves dynamic annotation properties`() {
         val annotation = AnnotationNode(
             NodeId(1),
             "com.example.Feature",

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -24,6 +24,7 @@ import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.StringPropertyLookup
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -530,7 +531,7 @@ class QueryPipelineTest {
 
     @Test
     fun `filtered distinct disjunction keeps unbounded storage lookup semantics`() {
-        val unboundedGraph = object : Graph by graph {
+        val unboundedGraph = object : Graph by graph, StringPropertyLookup {
             override fun nodeCount(type: Class<out Node>): Long = Int.MAX_VALUE.toLong()
 
             override fun <T : Node> nodesByStringProperty(

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -556,11 +556,11 @@ class QueryPipelineTest {
         )
 
         assertEquals(listOf("com.example.Service"), result.rows.map { it["caller"] })
-        assertEquals(2, consumed)
+        assertEquals(1, consumed)
     }
 
     @Test
-    fun `filtered distinct string disjunction merges candidates in node order`() {
+    fun `filtered distinct string disjunction deduplicates unordered candidate streams`() {
         val caller = MethodDescriptor(TypeDescriptor("com.example.Service"), "call", emptyList(), stringType)
         val callee = MethodDescriptor(TypeDescriptor("com.example.Repository"), "load", emptyList(), stringType)
         val backing = DefaultGraph.Builder().apply {
@@ -576,10 +576,10 @@ class QueryPipelineTest {
                 expected: String,
                 limit: Int
             ): Sequence<T> {
-                val nodes = backing.nodes(type).toList()
+                val nodes = backing.nodes(type).associateBy { it.id.value }
                 return when (property) {
-                    "caller_class" -> sequenceOf(nodes[0], nodes[2])
-                    "callee_class" -> sequenceOf(nodes[0], nodes[1], nodes[2])
+                    "caller_class" -> sequenceOf(nodes.getValue(1))
+                    "callee_class" -> sequenceOf(nodes.getValue(2), nodes.getValue(1), nodes.getValue(0))
                     else -> emptySequence()
                 }
             }
@@ -591,7 +591,7 @@ class QueryPipelineTest {
                 "RETURN DISTINCT n.id AS id LIMIT 4"
         )
 
-        assertEquals(listOf(0, 1, 2), result.rows.map { it["id"] })
+        assertEquals(listOf(1, 2, 0), result.rows.map { it["id"] })
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -23,6 +23,7 @@ import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.StringMatchMode
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -503,6 +504,77 @@ class QueryPipelineTest {
         val result = pipeline.execute(clauses)
         assertEquals(1, result.rows.size)
         assertEquals(strConstHello.value, result.rows[0]["id"])
+    }
+
+    @Test
+    fun `filtered distinct limit streams generic predicates`() {
+        val result = CypherExecutor(graph).execute(
+            "MATCH (n:IntConstant) WHERE n.value > 0 " +
+                "RETURN DISTINCT n.type AS type LIMIT 1"
+        )
+
+        assertEquals(listOf("IntConstant"), result.rows.map { it["type"] })
+    }
+
+    @Test
+    fun `filtered distinct string disjunction stops after the single graph limit`() {
+        val result = CypherExecutor(graph).execute(
+            "MATCH (n) WHERE " +
+                "(exists(n.caller_class) AND n.caller_class CONTAINS 'Service') OR " +
+                "(exists(n.callee_class) AND n.callee_class CONTAINS 'Service') " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 1"
+        )
+
+        assertEquals(listOf("com.example.Service"), result.rows.map { it["caller"] })
+    }
+
+    @Test
+    fun `filtered distinct disjunction keeps unbounded storage lookup semantics`() {
+        val unboundedGraph = object : Graph by graph {
+            override fun nodeCount(type: Class<out Node>): Long = Int.MAX_VALUE.toLong()
+
+            override fun <T : Node> nodesByStringProperty(
+                type: Class<T>,
+                property: String,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int
+            ): Sequence<T>? {
+                assertEquals(Int.MAX_VALUE, limit)
+                return null
+            }
+        }
+        val result = CypherExecutor(unboundedGraph).execute(
+            "MATCH (n:CallSiteNode) WHERE " +
+                "n.caller_class CONTAINS 'Service' OR n.callee_class CONTAINS 'Service' " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 1"
+        )
+
+        assertEquals(listOf("com.example.Service"), result.rows.map { it["caller"] })
+    }
+
+    @Test
+    fun `filtered distinct disjunction with unsupported properties uses generic evaluation`() {
+        val result = CypherExecutor(graph).execute(
+            "MATCH (n:StringConstant) WHERE " +
+                "(exists(n.value) AND n.value CONTAINS 'hello') OR " +
+                "(exists(n.unknown) AND n.unknown CONTAINS 'hello') " +
+                "RETURN DISTINCT n.value AS value LIMIT 1"
+        )
+
+        assertEquals(listOf("hello"), result.rows.map { it["value"] })
+    }
+
+    @Test
+    fun `filtered distinct disjunction with mismatched existence guard uses generic evaluation`() {
+        val result = CypherExecutor(graph).execute(
+            "MATCH (n:StringConstant) WHERE " +
+                "(exists(n.unknown) AND n.value CONTAINS 'hello') OR " +
+                "(exists(n.name) AND n.name CONTAINS 'missing') " +
+                "RETURN DISTINCT n.value AS value LIMIT 1"
+        )
+
+        assertTrue(result.rows.isEmpty())
     }
 
     // ========================================================================

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -530,6 +530,71 @@ class QueryPipelineTest {
     }
 
     @Test
+    fun `filtered distinct string disjunction consumes candidates lazily`() {
+        val caller = MethodDescriptor(TypeDescriptor("com.example.Service"), "call", emptyList(), stringType)
+        val callee = MethodDescriptor(TypeDescriptor("com.example.Repository"), "load", emptyList(), stringType)
+        val backing = DefaultGraph.Builder().apply {
+            repeat(1_000) { index ->
+                addNode(CallSiteNode(NodeId(index), caller, callee, index, null, emptyList()))
+            }
+        }.build()
+        var consumed = 0
+        val lookupGraph = object : Graph by backing, StringPropertyLookup {
+            override fun <T : Node> nodesByStringProperty(
+                type: Class<T>,
+                property: String,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int
+            ): Sequence<T> = backing.nodes(type).onEach { consumed++ }
+        }
+
+        val result = CypherExecutor(lookupGraph).execute(
+            "MATCH (n:CallSiteNode) WHERE " +
+                "n.caller_class CONTAINS 'example' OR n.callee_class CONTAINS 'example' " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 1"
+        )
+
+        assertEquals(listOf("com.example.Service"), result.rows.map { it["caller"] })
+        assertEquals(2, consumed)
+    }
+
+    @Test
+    fun `filtered distinct string disjunction merges candidates in node order`() {
+        val caller = MethodDescriptor(TypeDescriptor("com.example.Service"), "call", emptyList(), stringType)
+        val callee = MethodDescriptor(TypeDescriptor("com.example.Repository"), "load", emptyList(), stringType)
+        val backing = DefaultGraph.Builder().apply {
+            repeat(3) { index ->
+                addNode(CallSiteNode(NodeId(index), caller, callee, index, null, emptyList()))
+            }
+        }.build()
+        val lookupGraph = object : Graph by backing, StringPropertyLookup {
+            override fun <T : Node> nodesByStringProperty(
+                type: Class<T>,
+                property: String,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int
+            ): Sequence<T> {
+                val nodes = backing.nodes(type).toList()
+                return when (property) {
+                    "caller_class" -> sequenceOf(nodes[0], nodes[2])
+                    "callee_class" -> sequenceOf(nodes[0], nodes[1], nodes[2])
+                    else -> emptySequence()
+                }
+            }
+        }
+
+        val result = CypherExecutor(lookupGraph).execute(
+            "MATCH (n:CallSiteNode) WHERE " +
+                "n.caller_class CONTAINS 'example' OR n.callee_class CONTAINS 'example' " +
+                "RETURN DISTINCT n.id AS id LIMIT 4"
+        )
+
+        assertEquals(listOf(0, 1, 2), result.rows.map { it["id"] })
+    }
+
+    @Test
     fun `filtered distinct disjunction keeps unbounded storage lookup semantics`() {
         val unboundedGraph = object : Graph by graph, StringPropertyLookup {
             override fun nodeCount(type: Class<out Node>): Long = Int.MAX_VALUE.toLong()

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -561,12 +561,13 @@ class QueryPipelineTest {
 
     @Test
     fun `filtered distinct string disjunction deduplicates unordered candidate streams`() {
-        val caller = MethodDescriptor(TypeDescriptor("com.example.Service"), "call", emptyList(), stringType)
-        val callee = MethodDescriptor(TypeDescriptor("com.example.Repository"), "load", emptyList(), stringType)
+        val targetCaller = MethodDescriptor(TypeDescriptor("com.example.TargetService"), "call", emptyList(), stringType)
+        val otherCaller = MethodDescriptor(TypeDescriptor("com.example.OtherService"), "call", emptyList(), stringType)
+        val targetCallee = MethodDescriptor(TypeDescriptor("com.example.TargetRepository"), "load", emptyList(), stringType)
         val backing = DefaultGraph.Builder().apply {
-            repeat(3) { index ->
-                addNode(CallSiteNode(NodeId(index), caller, callee, index, null, emptyList()))
-            }
+            addNode(CallSiteNode(NodeId(0), otherCaller, targetCallee, 0, null, emptyList()))
+            addNode(CallSiteNode(NodeId(1), targetCaller, targetCallee, 1, null, emptyList()))
+            addNode(CallSiteNode(NodeId(2), otherCaller, targetCallee, 2, null, emptyList()))
         }.build()
         val lookupGraph = object : Graph by backing, StringPropertyLookup {
             override fun <T : Node> nodesByStringProperty(
@@ -587,7 +588,7 @@ class QueryPipelineTest {
 
         val result = CypherExecutor(lookupGraph).execute(
             "MATCH (n:CallSiteNode) WHERE " +
-                "n.caller_class CONTAINS 'example' OR n.callee_class CONTAINS 'example' " +
+                "n.caller_class CONTAINS 'Target' OR n.callee_class CONTAINS 'Target' " +
                 "RETURN DISTINCT n.id AS id LIMIT 4"
         )
 

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AgentBroadDiscoveryMappedQueryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AgentBroadDiscoveryMappedQueryBenchmark.kt
@@ -1,0 +1,129 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.core.MethodDescriptor
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.StringConstant
+import io.johnsonlee.graphite.core.TypeDescriptor
+import io.johnsonlee.graphite.cypher.CrossGraphCypherExecutor
+import io.johnsonlee.graphite.cypher.CypherGraph
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.graph.DefaultGraph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+private const val AGENT_GRAPH_COUNT = 16
+private const val AGENT_STRINGS_PER_GRAPH = 5_000
+private const val AGENT_CALL_SITES_PER_GRAPH = 2_000
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1, jvmArgs = ["-Xmx4g"])
+open class AgentBroadDiscoveryMappedQueryBenchmark {
+
+    private lateinit var root: Path
+    private lateinit var executor: CrossGraphCypherExecutor
+    private val loadedGraphs = mutableListOf<MappedWebGraphBackedGraph>()
+
+    @Setup
+    fun setup() {
+        root = Files.createTempDirectory("graphite-agent-discovery")
+        val graphs = (0 until AGENT_GRAPH_COUNT).map { graphIndex ->
+            val builder = DefaultGraph.Builder()
+            repeat(AGENT_STRINGS_PER_GRAPH) { nodeIndex ->
+                builder.addNode(StringConstant(NodeId(nodeIndex), "symbol_${graphIndex}_$nodeIndex"))
+            }
+            repeat(AGENT_CALL_SITES_PER_GRAPH) { callSiteIndex ->
+                val prefix = if (callSiteIndex % 10 == 0) "ThankYou" else "Feature"
+                val caller = MethodDescriptor(
+                    TypeDescriptor("com.example.$prefix${graphIndex}Service$callSiteIndex"),
+                    "create$callSiteIndex",
+                    emptyList(),
+                    TypeDescriptor("void")
+                )
+                val callee = MethodDescriptor(
+                    TypeDescriptor("com.example.Dependency${callSiteIndex % 20}"),
+                    "invoke${callSiteIndex % 100}",
+                    emptyList(),
+                    TypeDescriptor("void")
+                )
+                builder.addNode(
+                    CallSiteNode(
+                        NodeId(AGENT_STRINGS_PER_GRAPH + callSiteIndex),
+                        caller,
+                        callee,
+                        callSiteIndex,
+                        null,
+                        emptyList()
+                    )
+                )
+            }
+
+            val graphDir = root.resolve("graph-$graphIndex")
+            GraphStore.save(builder.build(), graphDir)
+            val graph = GraphStore.loadMapped(graphDir) as MappedWebGraphBackedGraph
+            loadedGraphs += graph
+            CypherGraph("graph-$graphIndex", graph)
+        }
+        executor = CrossGraphCypherExecutor(graphs)
+
+        val result = executor.execute(HIT_QUERY)
+        check(result.rows.size == 120)
+        check(result.rows.all { (it["caller"] as? String)?.contains("ThankYou") == true })
+        check(executor.execute(MISS_QUERY).rows.isEmpty())
+    }
+
+    @TearDown
+    fun tearDown() {
+        loadedGraphs.forEach(Closeable::close)
+        root.toFile().deleteRecursively()
+    }
+
+    @Benchmark
+    fun broadDiscoveryAcrossAllMappedGraphs(): CypherResult = executor.execute(HIT_QUERY)
+
+    @Benchmark
+    fun coldBroadDiscoveryAcrossAllMappedGraphs(): CypherResult {
+        loadedGraphs.forEach(MappedWebGraphBackedGraph::clearStringPropertyIndexes)
+        return executor.execute(HIT_QUERY)
+    }
+
+    @Benchmark
+    fun coldBroadDiscoveryMissAcrossAllMappedGraphs(): CypherResult {
+        loadedGraphs.forEach(MappedWebGraphBackedGraph::clearStringPropertyIndexes)
+        return executor.execute(MISS_QUERY)
+    }
+
+    private companion object {
+        val HIT_QUERY = discoveryQuery("ThankYou")
+        val MISS_QUERY = discoveryQuery("MissingAgentFeature")
+
+        private fun discoveryQuery(keyword: String): String =
+            "MATCH (n) WHERE " +
+                "(exists(n.class) AND n.class CONTAINS '$keyword') OR " +
+                "(exists(n.name) AND n.name CONTAINS '$keyword') OR " +
+                "(exists(n.caller_class) AND n.caller_class CONTAINS '$keyword') OR " +
+                "(exists(n.caller_name) AND n.caller_name CONTAINS '$keyword') OR " +
+                "(exists(n.callee_class) AND n.callee_class CONTAINS '$keyword') OR " +
+                "(exists(n.callee_name) AND n.callee_name CONTAINS '$keyword') " +
+                "RETURN DISTINCT n.class AS class, n.name AS name, " +
+                "n.caller_class AS caller, n.caller_name AS callerMethod, " +
+                "n.callee_class AS callee, n.callee_name AS calleeMethod LIMIT 120"
+    }
+}

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidBroadDiscoveryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidBroadDiscoveryBenchmark.kt
@@ -1,0 +1,72 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.cypher.query
+import io.johnsonlee.graphite.graph.Graph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.io.Closeable
+import java.lang.reflect.Method
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 1, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(1, jvmArgs = ["-Xmx8g"])
+open class AndroidBroadDiscoveryBenchmark {
+    private lateinit var mappedGraph: Graph
+    private var clearStringPropertyIndexes: Method? = null
+
+    @Setup
+    fun setup() {
+        val graphPath = BenchmarkCorpus.persistedGraph(BenchmarkCorpusKind.ANDROID)
+        mappedGraph = GraphStore.loadMapped(graphPath)
+        clearStringPropertyIndexes = mappedGraph.javaClass.declaredMethods
+            .firstOrNull { it.name.startsWith("clearStringPropertyIndexes") }
+            ?.also { it.isAccessible = true }
+        check(execute().rows.size == BROAD_DISCOVERY_LIMIT)
+    }
+
+    @TearDown
+    fun tearDown() {
+        (mappedGraph as? Closeable)?.close()
+    }
+
+    @Benchmark
+    fun coldBroadDiscovery(): CypherResult {
+        clearStringPropertyIndexes?.invoke(mappedGraph)
+        return execute()
+    }
+
+    @Benchmark
+    fun repeatedBroadDiscovery(): CypherResult = execute()
+
+    private fun execute(): CypherResult = mappedGraph.query(ANDROID_BROAD_DISCOVERY_QUERY)
+}
+
+private const val BROAD_DISCOVERY_LIMIT = 120
+
+private const val ANDROID_BROAD_DISCOVERY_QUERY = """
+MATCH (n)
+WHERE (exists(n.class) AND n.class CONTAINS 'android')
+   OR (exists(n.name) AND n.name CONTAINS 'android')
+   OR (exists(n.caller_class) AND n.caller_class CONTAINS 'android')
+   OR (exists(n.caller_name) AND n.caller_name CONTAINS 'android')
+   OR (exists(n.callee_class) AND n.callee_class CONTAINS 'android')
+   OR (exists(n.callee_name) AND n.callee_name CONTAINS 'android')
+RETURN DISTINCT n.class AS class, n.name AS name,
+    n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 120
+"""

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BroadDiscoveryMappedQueryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/BroadDiscoveryMappedQueryBenchmark.kt
@@ -25,9 +25,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
-private const val AGENT_GRAPH_COUNT = 16
-private const val AGENT_STRINGS_PER_GRAPH = 5_000
-private const val AGENT_CALL_SITES_PER_GRAPH = 2_000
+private const val BROAD_DISCOVERY_GRAPH_COUNT = 16
+private const val BROAD_DISCOVERY_STRINGS_PER_GRAPH = 5_000
+private const val BROAD_DISCOVERY_CALL_SITES_PER_GRAPH = 2_000
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
@@ -35,7 +35,7 @@ private const val AGENT_CALL_SITES_PER_GRAPH = 2_000
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(1, jvmArgs = ["-Xmx4g"])
-open class AgentBroadDiscoveryMappedQueryBenchmark {
+open class BroadDiscoveryMappedQueryBenchmark {
 
     private lateinit var root: Path
     private lateinit var executor: CrossGraphCypherExecutor
@@ -43,13 +43,13 @@ open class AgentBroadDiscoveryMappedQueryBenchmark {
 
     @Setup
     fun setup() {
-        root = Files.createTempDirectory("graphite-agent-discovery")
-        val graphs = (0 until AGENT_GRAPH_COUNT).map { graphIndex ->
+        root = Files.createTempDirectory("graphite-broad-discovery")
+        val graphs = (0 until BROAD_DISCOVERY_GRAPH_COUNT).map { graphIndex ->
             val builder = DefaultGraph.Builder()
-            repeat(AGENT_STRINGS_PER_GRAPH) { nodeIndex ->
+            repeat(BROAD_DISCOVERY_STRINGS_PER_GRAPH) { nodeIndex ->
                 builder.addNode(StringConstant(NodeId(nodeIndex), "symbol_${graphIndex}_$nodeIndex"))
             }
-            repeat(AGENT_CALL_SITES_PER_GRAPH) { callSiteIndex ->
+            repeat(BROAD_DISCOVERY_CALL_SITES_PER_GRAPH) { callSiteIndex ->
                 val prefix = if (callSiteIndex % 10 == 0) "ThankYou" else "Feature"
                 val caller = MethodDescriptor(
                     TypeDescriptor("com.example.$prefix${graphIndex}Service$callSiteIndex"),
@@ -65,7 +65,7 @@ open class AgentBroadDiscoveryMappedQueryBenchmark {
                 )
                 builder.addNode(
                     CallSiteNode(
-                        NodeId(AGENT_STRINGS_PER_GRAPH + callSiteIndex),
+                        NodeId(BROAD_DISCOVERY_STRINGS_PER_GRAPH + callSiteIndex),
                         caller,
                         callee,
                         callSiteIndex,
@@ -112,7 +112,7 @@ open class AgentBroadDiscoveryMappedQueryBenchmark {
 
     private companion object {
         val HIT_QUERY = discoveryQuery("ThankYou")
-        val MISS_QUERY = discoveryQuery("MissingAgentFeature")
+        val MISS_QUERY = discoveryQuery("MissingBroadFeature")
 
         private fun discoveryQuery(keyword: String): String =
             "MATCH (n) WHERE " +

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/CrossGraphMappedQueryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/CrossGraphMappedQueryBenchmark.kt
@@ -42,7 +42,8 @@ open class CrossGraphMappedQueryBenchmark {
 
     private lateinit var root: Path
     private lateinit var executor: CrossGraphCypherExecutor
-    private val loadedGraphs = mutableListOf<Closeable>()
+    private val loadedGraphs = mutableListOf<MappedWebGraphBackedGraph>()
+    private var querySequence = 0L
 
     @Setup
     fun setup() {
@@ -72,7 +73,7 @@ open class CrossGraphMappedQueryBenchmark {
             val graphDir = root.resolve("graph-$graphIndex")
             GraphStore.save(builder.build(), graphDir)
             val graph = GraphStore.loadMapped(graphDir)
-            loadedGraphs.add(graph as Closeable)
+            loadedGraphs.add(graph as MappedWebGraphBackedGraph)
             CypherGraph("graph-$graphIndex", graph)
         }
         executor = CrossGraphCypherExecutor(graphs)
@@ -97,6 +98,28 @@ open class CrossGraphMappedQueryBenchmark {
     )
 
     @Benchmark
+    fun uncachedKeywordMissAcrossAllMappedGraphs(): CypherResult {
+        val keyword = "missing_feature_keyword_${querySequence++}"
+        return executor.execute(
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS '$keyword' " +
+                "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+        )
+    }
+
+    @Benchmark
+    fun coldKeywordLateHitAcrossAllMappedGraphs(): CypherResult {
+        loadedGraphs.forEach(MappedWebGraphBackedGraph::clearStringPropertyIndexes)
+        return executor.execute(KEYWORD_QUERY)
+    }
+
+    @Benchmark
+    fun coldTwoKeywordSearchesAcrossAllMappedGraphs(): CypherResult {
+        loadedGraphs.forEach(MappedWebGraphBackedGraph::clearStringPropertyIndexes)
+        executor.execute(KEYWORD_QUERY)
+        return executor.execute(MISSING_KEYWORD_QUERY)
+    }
+
+    @Benchmark
     fun keywordLateHitAcrossAllMappedGraphs(): CypherResult = executor.execute(KEYWORD_QUERY)
 
     @Benchmark
@@ -115,6 +138,9 @@ open class CrossGraphMappedQueryBenchmark {
     private companion object {
         const val KEYWORD_QUERY =
             "MATCH (n:StringConstant) WHERE n.value CONTAINS '$MAPPED_TARGET_VALUE' " +
+                "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+        const val MISSING_KEYWORD_QUERY =
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS 'missing_feature_keyword' " +
                 "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
     }
 }

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/CrossGraphMappedQueryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/CrossGraphMappedQueryBenchmark.kt
@@ -30,6 +30,7 @@ private const val MAPPED_CHAIN_DEPTH = 8
 private const val MAPPED_TARGET_GRAPH_INDEX = MAPPED_GRAPH_COUNT - 1
 private const val MAPPED_TARGET_GRAPH_ID = "graph-$MAPPED_TARGET_GRAPH_INDEX"
 private const val MAPPED_TARGET_VALUE = "needle_feature_entry"
+private const val MAPPED_EARLY_VALUE = "early_feature_entry"
 
 /** Production-path counterpart to the in-memory cross-graph Cypher benchmark. */
 @State(Scope.Benchmark)
@@ -51,10 +52,10 @@ open class CrossGraphMappedQueryBenchmark {
         val graphs = (0 until MAPPED_GRAPH_COUNT).map { graphIndex ->
             val builder = DefaultGraph.Builder()
             for (nodeIndex in 0 until MAPPED_NODES_PER_GRAPH) {
-                val value = if (graphIndex == MAPPED_TARGET_GRAPH_INDEX && nodeIndex == 0) {
-                    MAPPED_TARGET_VALUE
-                } else {
-                    "symbol_${graphIndex}_$nodeIndex"
+                val value = when {
+                    graphIndex == 0 && nodeIndex == 0 -> MAPPED_EARLY_VALUE
+                    graphIndex == MAPPED_TARGET_GRAPH_INDEX && nodeIndex == 0 -> MAPPED_TARGET_VALUE
+                    else -> "symbol_${graphIndex}_$nodeIndex"
                 }
                 builder.addNode(StringConstant(NodeId(nodeIndex), value))
             }
@@ -78,10 +79,13 @@ open class CrossGraphMappedQueryBenchmark {
         }
         executor = CrossGraphCypherExecutor(graphs)
 
+        val earlySearch = executor.execute(EARLY_KEYWORD_QUERY)
+        check(earlySearch.rows.size == 1 && earlySearch.rows.single()["id"] == "graph-0:0")
         val search = executor.execute(KEYWORD_QUERY)
         check(search.rows.size == 1 && search.rows.single()["id"] == "$MAPPED_TARGET_GRAPH_ID:0")
         val chain = executor.execute(callChainQuery(search.rows.single().getValue("id") as String))
         check(chain.rows.size == MAPPED_CHAIN_DEPTH)
+        check(executor.execute(MISSING_KEYWORD_QUERY).rows.isEmpty())
     }
 
     @TearDown
@@ -120,6 +124,13 @@ open class CrossGraphMappedQueryBenchmark {
     }
 
     @Benchmark
+    fun coldTwoEarlyHitKeywordSearchesAcrossAllMappedGraphs(): CypherResult {
+        loadedGraphs.forEach(MappedWebGraphBackedGraph::clearStringPropertyIndexes)
+        executor.execute(EARLY_KEYWORD_QUERY)
+        return executor.execute(EARLY_KEYWORD_QUERY)
+    }
+
+    @Benchmark
     fun keywordLateHitAcrossAllMappedGraphs(): CypherResult = executor.execute(KEYWORD_QUERY)
 
     @Benchmark
@@ -128,6 +139,9 @@ open class CrossGraphMappedQueryBenchmark {
         val seed = search.rows.single().getValue("id") as String
         return executor.execute(callChainQuery(seed))
     }
+
+    @Benchmark
+    fun retainedStringPropertyIndexFootprint(): Int = loadedGraphs.size
 
     private fun callChainQuery(seed: String): String =
         "MATCH (a:StringConstant) WHERE elementId(a) = '$seed' " +
@@ -142,5 +156,8 @@ open class CrossGraphMappedQueryBenchmark {
         const val MISSING_KEYWORD_QUERY =
             "MATCH (n:StringConstant) WHERE n.value CONTAINS 'missing_feature_keyword' " +
                 "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+        const val EARLY_KEYWORD_QUERY =
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS '$MAPPED_EARLY_VALUE' " +
+                "RETURN elementId(n) AS id, n.value AS value LIMIT 1"
     }
 }

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/CrossGraphMappedQueryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/CrossGraphMappedQueryBenchmark.kt
@@ -1,0 +1,120 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.DataFlowEdge
+import io.johnsonlee.graphite.core.DataFlowKind
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.StringConstant
+import io.johnsonlee.graphite.cypher.CrossGraphCypherExecutor
+import io.johnsonlee.graphite.cypher.CypherGraph
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.graph.DefaultGraph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+private const val MAPPED_GRAPH_COUNT = 16
+private const val MAPPED_NODES_PER_GRAPH = 5_000
+private const val MAPPED_CHAIN_DEPTH = 8
+private const val MAPPED_TARGET_GRAPH_INDEX = MAPPED_GRAPH_COUNT - 1
+private const val MAPPED_TARGET_GRAPH_ID = "graph-$MAPPED_TARGET_GRAPH_INDEX"
+private const val MAPPED_TARGET_VALUE = "needle_feature_entry"
+
+/** Production-path counterpart to the in-memory cross-graph Cypher benchmark. */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1, jvmArgs = ["-Xmx4g"])
+open class CrossGraphMappedQueryBenchmark {
+
+    private lateinit var root: Path
+    private lateinit var executor: CrossGraphCypherExecutor
+    private val loadedGraphs = mutableListOf<Closeable>()
+
+    @Setup
+    fun setup() {
+        root = Files.createTempDirectory("graphite-cross-graph-query")
+        val graphs = (0 until MAPPED_GRAPH_COUNT).map { graphIndex ->
+            val builder = DefaultGraph.Builder()
+            for (nodeIndex in 0 until MAPPED_NODES_PER_GRAPH) {
+                val value = if (graphIndex == MAPPED_TARGET_GRAPH_INDEX && nodeIndex == 0) {
+                    MAPPED_TARGET_VALUE
+                } else {
+                    "symbol_${graphIndex}_$nodeIndex"
+                }
+                builder.addNode(StringConstant(NodeId(nodeIndex), value))
+            }
+            if (graphIndex == MAPPED_TARGET_GRAPH_INDEX) {
+                for (nodeIndex in 0 until MAPPED_CHAIN_DEPTH) {
+                    builder.addEdge(
+                        DataFlowEdge(
+                            NodeId(nodeIndex),
+                            NodeId(nodeIndex + 1),
+                            DataFlowKind.PARAMETER_PASS
+                        )
+                    )
+                }
+            }
+
+            val graphDir = root.resolve("graph-$graphIndex")
+            GraphStore.save(builder.build(), graphDir)
+            val graph = GraphStore.loadMapped(graphDir)
+            loadedGraphs.add(graph as Closeable)
+            CypherGraph("graph-$graphIndex", graph)
+        }
+        executor = CrossGraphCypherExecutor(graphs)
+
+        val search = executor.execute(KEYWORD_QUERY)
+        check(search.rows.size == 1 && search.rows.single()["id"] == "$MAPPED_TARGET_GRAPH_ID:0")
+        val chain = executor.execute(callChainQuery(search.rows.single().getValue("id") as String))
+        check(chain.rows.size == MAPPED_CHAIN_DEPTH)
+    }
+
+    @TearDown
+    fun tearDown() {
+        loadedGraphs.forEach(Closeable::close)
+        root.toFile().deleteRecursively()
+    }
+
+    @Benchmark
+    fun keywordMissAcrossAllMappedGraphs(): CypherResult = executor.execute(
+        "MATCH (n:StringConstant) " +
+            "WHERE n.value CONTAINS 'missing_feature_keyword' " +
+            "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+    )
+
+    @Benchmark
+    fun keywordLateHitAcrossAllMappedGraphs(): CypherResult = executor.execute(KEYWORD_QUERY)
+
+    @Benchmark
+    fun keywordThenMappedCallChain(): CypherResult {
+        val search = executor.execute(KEYWORD_QUERY)
+        val seed = search.rows.single().getValue("id") as String
+        return executor.execute(callChainQuery(seed))
+    }
+
+    private fun callChainQuery(seed: String): String =
+        "MATCH (a:StringConstant) WHERE elementId(a) = '$seed' " +
+            "WITH a MATCH (a)-[:DATAFLOW*1..$MAPPED_CHAIN_DEPTH]->(b:StringConstant) " +
+            "RETURN elementId(a) AS source, elementId(b) AS target, b.value AS value " +
+            "LIMIT $MAPPED_CHAIN_DEPTH"
+
+    private companion object {
+        const val KEYWORD_QUERY =
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS '$MAPPED_TARGET_VALUE' " +
+                "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+    }
+}

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
@@ -1,0 +1,131 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.FieldDescriptor
+import io.johnsonlee.graphite.core.FieldNode
+import io.johnsonlee.graphite.core.Node
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.ResourceFileNode
+import io.johnsonlee.graphite.core.TypeDescriptor
+import io.johnsonlee.graphite.cypher.CypherExecutor
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.graph.DefaultGraph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+private const val ADMISSION_RESOURCE_NODES = 50_000
+private const val ADMISSION_FIELD_NODES = 50_000
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@Fork(1, jvmArgs = ["-Xmx4g"])
+open class MappedStringAdmissionBenchmark {
+
+    @Benchmark
+    fun earlyHitAfterAdmittedMiss(state: AdmittedMissBenchmarkState): CypherResult = state.earlyHit()
+
+    @Benchmark
+    fun earlyHitAfterLruEviction(state: EvictedIndexBenchmarkState): CypherResult = state.earlyHit()
+}
+
+@State(Scope.Thread)
+open class AdmittedMissBenchmarkState : MappedStringAdmissionBenchmarkState() {
+    @Setup(Level.Invocation)
+    fun admitMiss() {
+        clearIndexes()
+        check(execute(MISSING_PATH_QUERY).rows.isEmpty())
+    }
+}
+
+@State(Scope.Thread)
+open class EvictedIndexBenchmarkState : MappedStringAdmissionBenchmarkState() {
+    @Setup(Level.Invocation)
+    fun evictFirstIndex() {
+        clearIndexes()
+        INDEX_ADMISSION_QUERIES.forEach { query ->
+            repeat(2) { check(execute(query).rows.isEmpty()) }
+        }
+        check(indexCount() == 4)
+        check(indexCount(ResourceFileNode::class.java, "path") == 0)
+    }
+}
+
+@State(Scope.Thread)
+open class MappedStringAdmissionBenchmarkState {
+    private lateinit var root: Path
+    private lateinit var mapped: MappedWebGraphBackedGraph
+    private lateinit var executor: CypherExecutor
+
+    @Setup(Level.Trial)
+    fun setupGraph() {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(ADMISSION_RESOURCE_NODES) { index ->
+                addNode(ResourceFileNode(NodeId(index), "path-$index", "source-$index", "format-$index"))
+            }
+            repeat(ADMISSION_FIELD_NODES) { index ->
+                addNode(
+                    FieldNode(
+                        NodeId(ADMISSION_RESOURCE_NODES + index),
+                        FieldDescriptor(
+                            TypeDescriptor("example.Owner$index"),
+                            "field-$index",
+                            TypeDescriptor("example.Type$index")
+                        ),
+                        false
+                    )
+                )
+            }
+        }.build()
+        root = Files.createTempDirectory("graphite-string-admission")
+        GraphStore.save(graph, root)
+        mapped = GraphStore.loadMapped(root) as MappedWebGraphBackedGraph
+        executor = CypherExecutor(mapped)
+        check(earlyHit().rows.single()["value"] == "path-0")
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDownGraph() {
+        mapped.close()
+        root.toFile().deleteRecursively()
+    }
+
+    fun earlyHit(): CypherResult = executor.execute(EARLY_PATH_QUERY)
+
+    protected fun clearIndexes() = mapped.clearStringPropertyIndexes()
+
+    protected fun execute(query: String): CypherResult = executor.execute(query)
+
+    protected fun indexCount(type: Class<out Node>? = null, property: String? = null): Int =
+        mapped.stringPropertyIndexCount(type, property)
+
+    private companion object {
+        const val EARLY_PATH_QUERY =
+            "MATCH (n:ResourceFileNode) WHERE n.path CONTAINS 'path-0' " +
+                "RETURN n.path AS value LIMIT 1"
+    }
+}
+
+private const val MISSING_PATH_QUERY =
+    "MATCH (n:ResourceFileNode) WHERE n.path CONTAINS 'missing-path' RETURN n.path AS value LIMIT 1"
+
+private val INDEX_ADMISSION_QUERIES = listOf(
+    MISSING_PATH_QUERY,
+    "MATCH (n:ResourceFileNode) WHERE n.source CONTAINS 'missing-source' RETURN n.source AS value LIMIT 1",
+    "MATCH (n:ResourceFileNode) WHERE n.format CONTAINS 'missing-format' RETURN n.format AS value LIMIT 1",
+    "MATCH (n:FieldNode) WHERE n.class CONTAINS 'missing-class' RETURN n.class AS value LIMIT 1",
+    "MATCH (n:FieldNode) WHERE n.name CONTAINS 'missing-name' RETURN n.name AS value LIMIT 1"
+)

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
@@ -40,6 +40,9 @@ open class MappedStringAdmissionBenchmark {
 
     @Benchmark
     fun earlyHitAfterLruEviction(state: EvictedIndexBenchmarkState): CypherResult = state.earlyHit()
+
+    @Benchmark
+    fun earlyHitAfterLargeLimitScan(state: LargeLimitBenchmarkState): CypherResult = state.earlyHit()
 }
 
 @State(Scope.Thread)
@@ -61,6 +64,15 @@ open class EvictedIndexBenchmarkState : MappedStringAdmissionBenchmarkState() {
         }
         check(indexCount() == 4)
         check(indexCount(ResourceFileNode::class.java, "path") == 0)
+    }
+}
+
+@State(Scope.Thread)
+open class LargeLimitBenchmarkState : MappedStringAdmissionBenchmarkState() {
+    @Setup(Level.Invocation)
+    fun admitLargeLimit() {
+        clearIndexes()
+        check(execute(LARGE_LIMIT_PATH_QUERY).rows.size == ADMISSION_RESOURCE_NODES)
     }
 }
 
@@ -121,6 +133,10 @@ open class MappedStringAdmissionBenchmarkState {
 
 private const val MISSING_PATH_QUERY =
     "MATCH (n:ResourceFileNode) WHERE n.path CONTAINS 'missing-path' RETURN n.path AS value LIMIT 1"
+
+private const val LARGE_LIMIT_PATH_QUERY =
+    "MATCH (n:ResourceFileNode) WHERE n.path CONTAINS 'path-' RETURN n.path AS value " +
+        "LIMIT $ADMISSION_RESOURCE_NODES"
 
 private val INDEX_ADMISSION_QUERIES = listOf(
     MISSING_PATH_QUERY,

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
@@ -42,7 +42,7 @@ open class MappedStringAdmissionBenchmark {
     fun earlyHitAfterLruEviction(state: EvictedIndexBenchmarkState): CypherResult = state.earlyHit()
 
     @Benchmark
-    fun earlyHitAfterLargeLimitScan(state: LargeLimitBenchmarkState): CypherResult = state.earlyHit()
+    fun earlyHitAfterLargeLimitScan(state: LargeLimitBenchmarkState): CypherResult = state.earlyHitWithoutIndexBuild()
 }
 
 @State(Scope.Thread)
@@ -72,8 +72,11 @@ open class LargeLimitBenchmarkState : MappedStringAdmissionBenchmarkState() {
     @Setup(Level.Invocation)
     fun admitLargeLimit() {
         clearIndexes()
-        check(execute(LARGE_LIMIT_PATH_QUERY).rows.size == ADMISSION_RESOURCE_NODES)
+        check(execute(LARGE_LIMIT_PATH_QUERY).rows.single()["value"] == "path-0")
+        check(indexCount() == 0)
     }
+
+    fun earlyHitWithoutIndexBuild(): CypherResult = earlyHit().also { check(indexCount() == 0) }
 }
 
 @State(Scope.Thread)
@@ -135,7 +138,7 @@ private const val MISSING_PATH_QUERY =
     "MATCH (n:ResourceFileNode) WHERE n.path CONTAINS 'missing-path' RETURN n.path AS value LIMIT 1"
 
 private const val LARGE_LIMIT_PATH_QUERY =
-    "MATCH (n:ResourceFileNode) WHERE n.path CONTAINS 'path-' RETURN n.path AS value " +
+    "MATCH (n:ResourceFileNode) WHERE n.path CONTAINS 'path-0' RETURN n.path AS value " +
         "LIMIT $ADMISSION_RESOURCE_NODES"
 
 private val INDEX_ADMISSION_QUERIES = listOf(

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -141,7 +141,7 @@ internal class MappedWebGraphBackedGraph(
             return indexedNodes(index, mode, expected, limit)
         }
 
-        val admission = StringPropertyAdmissionKey(key, mode, expected)
+        val admission = StringPropertyAdmissionKey(key, mode, expected, limit)
         val shouldBuild = synchronized(stringPropertyIndexLock) {
             stringPropertyAdmissions.shouldBuild(admission, limit == Int.MAX_VALUE)
         }
@@ -459,7 +459,8 @@ private data class StringPropertyKey(
 private data class StringPropertyAdmissionKey(
     val property: StringPropertyKey,
     val mode: StringMatchMode,
-    val expected: String
+    val expected: String,
+    val limit: Int
 )
 
 private class StringPropertyAdmissions {

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -2,15 +2,24 @@ package io.johnsonlee.graphite.webgraph
 
 import io.johnsonlee.graphite.core.BranchScope
 import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.core.EnumConstant
 import io.johnsonlee.graphite.core.Edge
+import io.johnsonlee.graphite.core.FieldNode
+import io.johnsonlee.graphite.core.LocalVariable
 import io.johnsonlee.graphite.core.MethodDescriptor
 import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.ParameterNode
+import io.johnsonlee.graphite.core.ResourceFileNode
+import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.input.ResourceAccessor
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
+import it.unimi.dsi.fastutil.ints.IntArrayList
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import it.unimi.dsi.webgraph.ImmutableGraph
 import java.io.BufferedInputStream
@@ -21,6 +30,7 @@ import java.io.EOFException
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.MappedByteBuffer
+import java.util.LinkedHashMap
 
 /**
  * A [Graph] backed by WebGraph compression for edges and memory-mapped I/O for nodes.
@@ -81,6 +91,17 @@ internal class MappedWebGraphBackedGraph(
         }.groupBy { it.conditionNodeId.value }
     }
 
+    private val stringPropertyIndexLock = Any()
+    private val stringPropertyAccesses = LinkedHashMap<StringPropertyKey, Int>()
+    private val stringPropertyIndexes = object : LinkedHashMap<StringPropertyKey, MappedStringPropertyIndex>(
+        MAX_STRING_PROPERTY_INDEXES + 1,
+        STRING_PROPERTY_INDEX_LOAD_FACTOR,
+        true
+    ) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<StringPropertyKey, MappedStringPropertyIndex>?): Boolean =
+            size > MAX_STRING_PROPERTY_INDEXES
+    }
+
     override fun node(id: NodeId): Node? {
         val nodeId = id.value
         if (nodeId < 0 || nodeId >= nodeOffsets.size) return null
@@ -96,6 +117,31 @@ internal class MappedWebGraphBackedGraph(
 
     override fun nodeCount(type: Class<out Node>): Long =
         nodeTypeIndex.count(type)
+
+    @Suppress("UNCHECKED_CAST", "ReturnCount")
+    override fun <T : Node> nodesByStringProperty(
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String
+    ): Sequence<T>? {
+        if (!supportsRawStringProperty(type, property)) return null
+        val key = StringPropertyKey(type, property)
+        val index = synchronized(stringPropertyIndexLock) {
+            stringPropertyIndexes[key] ?: run {
+                val accesses = (stringPropertyAccesses[key] ?: 0) + 1
+                stringPropertyAccesses[key] = accesses
+                trimStringPropertyAccesses()
+                if (accesses < MIN_STRING_PROPERTY_INDEX_ACCESSES) {
+                    null
+                } else {
+                    buildStringPropertyIndex(type, property).also { stringPropertyIndexes[key] = it }
+                }
+            }
+        } ?: return null
+        return index.matchingNodeIds(mode, expected)
+            .mapNotNull { node(NodeId(it)) as? T }
+    }
 
     override fun edgeCount(): Long = edgeCount
 
@@ -192,13 +238,244 @@ internal class MappedWebGraphBackedGraph(
         metadata.value.supertypes.keys + metadata.value.subtypes.keys
 
     override fun close() {
+        clearStringPropertyIndexes()
         // MappedByteBuffer is unmapped by GC; no explicit unmap in standard API
+    }
+
+    internal fun clearStringPropertyIndexes() {
+        synchronized(stringPropertyIndexLock) {
+            stringPropertyIndexes.clear()
+            stringPropertyAccesses.clear()
+        }
+    }
+
+    private fun trimStringPropertyAccesses() {
+        while (stringPropertyAccesses.size > MAX_STRING_PROPERTY_ACCESS_COUNTS) {
+            val oldest = stringPropertyAccesses.entries.iterator()
+            oldest.next()
+            oldest.remove()
+        }
+    }
+
+    private fun buildStringPropertyIndex(
+        type: Class<out Node>,
+        property: String
+    ): MappedStringPropertyIndex {
+        val capacity = nodeTypeIndex.count(type).toInt()
+        val nodeIds = IntArray(capacity)
+        val stringIds = IntArray(capacity)
+        val uniqueStringIds = HashSet<Int>()
+        var size = 0
+        for (nodeId in nodeTypeIndex.ids(type)) {
+            val stringId = rawStringPropertyIndex(nodeId, type, property) ?: continue
+            nodeIds[size] = nodeId
+            stringIds[size] = stringId
+            uniqueStringIds.add(stringId)
+            size++
+        }
+        return MappedStringPropertyIndex(
+            nodeIds.copyOf(size),
+            stringIds.copyOf(size),
+            uniqueStringIds.toIntArray().sortedArray(),
+            stringTable
+        )
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun rawStringPropertyIndex(
+        nodeId: Int,
+        type: Class<out Node>,
+        property: String
+    ): Int? {
+        val offset = nodeOffsets.offset(nodeId)
+        if (offset < 0L) return null
+        val fields = offset.toInt() + NODE_HEADER_BYTES
+        return when (type) {
+            StringConstant::class.java -> mappedNodeData.getInt(fields)
+            EnumConstant::class.java -> when (property) {
+                "enum_type" -> mappedNodeData.getInt(fields)
+                "name" -> mappedNodeData.getInt(fields + Int.SIZE_BYTES)
+                else -> null
+            }
+            LocalVariable::class.java -> when (property) {
+                "name" -> mappedNodeData.getInt(fields)
+                "type" -> mappedNodeData.getInt(fields + Int.SIZE_BYTES)
+                else -> null
+            }
+            FieldNode::class.java -> when (property) {
+                "class" -> mappedNodeData.getInt(fields)
+                "name" -> mappedNodeData.getInt(fields + Int.SIZE_BYTES)
+                "type" -> mappedNodeData.getInt(fields + 2 * Int.SIZE_BYTES)
+                else -> null
+            }
+            ParameterNode::class.java -> if (property == "type") {
+                mappedNodeData.getInt(fields + Int.SIZE_BYTES)
+            } else {
+                null
+            }
+            ResourceFileNode::class.java -> when (property) {
+                "path" -> mappedNodeData.getInt(fields)
+                "source" -> mappedNodeData.getInt(fields + Int.SIZE_BYTES)
+                "format" -> mappedNodeData.getInt(fields + 2 * Int.SIZE_BYTES)
+                else -> null
+            }
+            CallSiteNode::class.java -> rawCallSiteStringProperty(fields, property)
+            else -> null
+        }
+    }
+
+    private fun rawCallSiteStringProperty(fields: Int, property: String): Int? {
+        val callerParameters = mappedNodeData.getInt(fields + 2 * Int.SIZE_BYTES)
+        val calleeFields = fields + (METHOD_DESCRIPTOR_FIXED_INTS + callerParameters) * Int.SIZE_BYTES
+        return when (property) {
+            "caller_class" -> mappedNodeData.getInt(fields)
+            "caller_name" -> mappedNodeData.getInt(fields + Int.SIZE_BYTES)
+            "callee_class" -> mappedNodeData.getInt(calleeFields)
+            "callee_name" -> mappedNodeData.getInt(calleeFields + Int.SIZE_BYTES)
+            else -> null
+        }
     }
 
     private fun readNodeAt(offset: Long): Node {
         val input = ByteBufferDataInput(mappedNodeData, offset.toInt())
         return NodeSerializer.readNode(input, stringTable, nodeDataVersion)
     }
+}
+
+private const val NODE_HEADER_BYTES = Int.SIZE_BYTES + Byte.SIZE_BYTES
+private const val METHOD_DESCRIPTOR_FIXED_INTS = 4
+private const val MAX_STRING_PROPERTY_INDEXES = 4
+private const val MAX_STRING_PROPERTY_ACCESS_COUNTS = 16
+private const val MIN_STRING_PROPERTY_INDEX_ACCESSES = 2
+private const val MAX_STRING_MATCH_CACHE_ENTRIES = 32
+private const val MAX_CACHED_MATCHING_STRINGS = 100_000
+private const val MAX_TRIGRAM_INDEX_STRINGS = 500_000
+private const val MIN_TRIGRAM_LENGTH = 3
+private const val STRING_PROPERTY_INDEX_LOAD_FACTOR = 0.75f
+private const val STRING_HASH_FACTOR = 31
+
+private data class StringPropertyKey(
+    val type: Class<out Node>,
+    val property: String
+)
+
+private data class StringMatchKey(
+    val mode: StringMatchMode,
+    val expected: String
+)
+
+private class MappedStringPropertyIndex(
+    private val nodeIds: IntArray,
+    private val stringIds: IntArray,
+    private val uniqueStringIds: IntArray,
+    private val stringTable: StringTable
+) {
+    private val trigramIndex: Int2ObjectOpenHashMap<IntArray>? by lazy(::buildTrigramIndex)
+    private val matchingStrings = object : LinkedHashMap<StringMatchKey, IntArray>(
+        MAX_STRING_MATCH_CACHE_ENTRIES + 1,
+        STRING_PROPERTY_INDEX_LOAD_FACTOR,
+        true
+    ) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<StringMatchKey, IntArray>?): Boolean =
+            size > MAX_STRING_MATCH_CACHE_ENTRIES
+    }
+
+    fun matchingNodeIds(mode: StringMatchMode, expected: String): Sequence<Int> {
+        val matchedStrings = matchingStringIds(mode, expected)
+        if (matchedStrings.isEmpty()) return emptySequence()
+        return nodeIds.indices.asSequence()
+            .filter { java.util.Arrays.binarySearch(matchedStrings, stringIds[it]) >= 0 }
+            .map { nodeIds[it] }
+    }
+
+    @Synchronized
+    private fun matchingStringIds(mode: StringMatchMode, expected: String): IntArray {
+        val key = StringMatchKey(mode, expected)
+        matchingStrings[key]?.let { return it }
+
+        val result = when {
+            mode == StringMatchMode.CONTAINS && expected.length >= MIN_TRIGRAM_LENGTH ->
+                matchingContainsStringIds(expected)
+            else -> scanMatchingStringIds(mode, expected)
+        }
+        if (result.size <= MAX_CACHED_MATCHING_STRINGS) matchingStrings[key] = result
+        return result
+    }
+
+    @Suppress("ReturnCount")
+    private fun matchingContainsStringIds(expected: String): IntArray {
+        val index = trigramIndex ?: return scanMatchingStringIds(StringMatchMode.CONTAINS, expected)
+        var candidates: IntArray? = null
+        val seenTrigrams = IntOpenHashSet()
+        for (position in 0..expected.length - MIN_TRIGRAM_LENGTH) {
+            val trigram = trigramHash(expected, position)
+            if (!seenTrigrams.add(trigram)) continue
+            val posting = index[trigram] ?: return IntArray(0)
+            if (candidates == null || posting.size < candidates.size) candidates = posting
+        }
+
+        val shortestPosting = candidates ?: return IntArray(0)
+        val matched = IntArray(shortestPosting.size)
+        var size = 0
+        for (stringId in shortestPosting) {
+            if (stringTable.get(stringId).contains(expected)) matched[size++] = stringId
+        }
+        return matched.copyOf(size).also(java.util.Arrays::sort)
+    }
+
+    private fun scanMatchingStringIds(mode: StringMatchMode, expected: String): IntArray {
+        val matched = IntArray(uniqueStringIds.size)
+        var size = 0
+        for (stringId in uniqueStringIds) {
+            val actual = stringTable.get(stringId)
+            val matches = when (mode) {
+                StringMatchMode.STARTS_WITH -> actual.startsWith(expected)
+                StringMatchMode.ENDS_WITH -> actual.endsWith(expected)
+                StringMatchMode.CONTAINS -> actual.contains(expected)
+            }
+            if (matches) matched[size++] = stringId
+        }
+        return matched.copyOf(size)
+    }
+
+    private fun buildTrigramIndex(): Int2ObjectOpenHashMap<IntArray>? {
+        if (uniqueStringIds.size > MAX_TRIGRAM_INDEX_STRINGS) return null
+        val builders = Int2ObjectOpenHashMap<IntArrayList>()
+        val seenTrigrams = IntOpenHashSet()
+        for (stringId in uniqueStringIds) {
+            val value = stringTable.get(stringId)
+            seenTrigrams.clear()
+            for (position in 0..value.length - MIN_TRIGRAM_LENGTH) {
+                val trigram = trigramHash(value, position)
+                if (seenTrigrams.add(trigram)) {
+                    builders.computeIfAbsent(trigram) { IntArrayList() }.add(stringId)
+                }
+            }
+        }
+
+        val result = Int2ObjectOpenHashMap<IntArray>(builders.size)
+        builders.int2ObjectEntrySet().forEach { entry ->
+            result.put(entry.intKey, entry.value.toIntArray())
+        }
+        return result
+    }
+}
+
+private fun trigramHash(value: String, position: Int): Int =
+    (value[position].code * STRING_HASH_FACTOR + value[position + 1].code) * STRING_HASH_FACTOR +
+        value[position + 2].code
+
+@Suppress("CyclomaticComplexMethod")
+private fun supportsRawStringProperty(type: Class<out Node>, property: String): Boolean = when (type) {
+    StringConstant::class.java -> property == "value"
+    EnumConstant::class.java -> property == "enum_type" || property == "name"
+    LocalVariable::class.java -> property == "name" || property == "type"
+    FieldNode::class.java -> property == "class" || property == "name" || property == "type"
+    ParameterNode::class.java -> property == "type"
+    ResourceFileNode::class.java -> property == "path" || property == "source" || property == "format"
+    CallSiteNode::class.java -> property == "caller_class" || property == "caller_name" ||
+        property == "callee_class" || property == "callee_name"
+    else -> false
 }
 
 /**

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -17,6 +17,7 @@ import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.StringPropertyLookup
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.ints.IntArrayList
@@ -56,7 +57,7 @@ import java.util.LinkedHashMap
  *
  * Created by [GraphStore.loadMapped].
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 internal class MappedWebGraphBackedGraph(
     private val forward: ImmutableGraph,
     private val backward: Lazy<ImmutableGraph>,
@@ -74,7 +75,7 @@ internal class MappedWebGraphBackedGraph(
     private val metadata: Lazy<GraphMetadata>,
     private val classOverviewProvider: (Int) -> ClassOverview?,
     private val resourceAccessor: Lazy<ResourceAccessor>
-) : Graph, Closeable {
+) : Graph, StringPropertyLookup, Closeable {
 
     override val resources: ResourceAccessor
         get() = resourceAccessor.value
@@ -92,14 +93,19 @@ internal class MappedWebGraphBackedGraph(
     }
 
     private val stringPropertyIndexLock = Any()
-    private val stringPropertyAccesses = LinkedHashMap<StringPropertyKey, Int>()
+    private val stringPropertyAdmissions = StringPropertyAdmissions()
     private val stringPropertyIndexes = object : LinkedHashMap<StringPropertyKey, MappedStringPropertyIndex>(
         MAX_STRING_PROPERTY_INDEXES + 1,
         STRING_PROPERTY_INDEX_LOAD_FACTOR,
         true
     ) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<StringPropertyKey, MappedStringPropertyIndex>?): Boolean =
-            size > MAX_STRING_PROPERTY_INDEXES
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<StringPropertyKey, MappedStringPropertyIndex>?
+        ): Boolean {
+            val remove = size > MAX_STRING_PROPERTY_INDEXES
+            if (remove && eldest != null) stringPropertyAdmissions.clear(eldest.key)
+            return remove
+        }
     }
 
     override fun node(id: NodeId): Node? {
@@ -135,33 +141,32 @@ internal class MappedWebGraphBackedGraph(
             return indexedNodes(index, mode, expected, limit)
         }
 
-        val previousAccesses = synchronized(stringPropertyIndexLock) {
-            stringPropertyAccesses[key] ?: 0
+        val admission = StringPropertyAdmissionKey(key, mode, expected)
+        val shouldBuild = synchronized(stringPropertyIndexLock) {
+            stringPropertyAdmissions.shouldBuild(admission, limit == Int.MAX_VALUE)
         }
-        if (limit != Int.MAX_VALUE && previousAccesses <= 0) {
-            return rawStringPropertyScan(type, property, mode, expected, limit, key)
+        if (!shouldBuild) {
+            return if (limit == Int.MAX_VALUE) {
+                null
+            } else {
+                rawStringPropertyScan(type, property, mode, expected, limit, admission)
+            }
         }
 
         val index = synchronized(stringPropertyIndexLock) {
             stringPropertyIndexes[key] ?: run {
-                val accesses = stringPropertyAccesses[key] ?: 0
-                if (accesses == REJECTED_STRING_PROPERTY_INDEX) return@synchronized null
-                if (accesses == 0) {
-                    stringPropertyAccesses[key] = 1
+                buildStringPropertyIndex(type, property)?.also {
+                    stringPropertyIndexes[key] = it
+                    stringPropertyAdmissions.clear(key)
+                } ?: run {
+                    stringPropertyAdmissions.reject(key)
                     null
-                } else {
-                    buildStringPropertyIndex(type, property)?.also {
-                        stringPropertyIndexes[key] = it
-                    } ?: run {
-                        stringPropertyAccesses[key] = REJECTED_STRING_PROPERTY_INDEX
-                        null
-                    }
                 }
             }
         } ?: return if (limit == Int.MAX_VALUE) {
             null
         } else {
-            rawStringPropertyScan(type, property, mode, expected, limit, key)
+            rawStringPropertyScan(type, property, mode, expected, limit, admission)
         }
         return indexedNodes(index, mode, expected, limit)
     }
@@ -183,7 +188,7 @@ internal class MappedWebGraphBackedGraph(
         mode: StringMatchMode,
         expected: String,
         limit: Int,
-        key: StringPropertyKey
+        admission: StringPropertyAdmissionKey
     ): Sequence<T> = sequence {
         var inspected = 0
         var yielded = 0
@@ -191,7 +196,11 @@ internal class MappedWebGraphBackedGraph(
         for (nodeId in nodeTypeIndex.ids(type)) {
             inspected++
             if (!admitted && inspected > MAX_STRING_PROPERTY_ADMISSION_NODES) {
-                admitStringPropertyIndex(key)
+                synchronized(stringPropertyIndexLock) {
+                    if (admission.property !in stringPropertyIndexes) {
+                        stringPropertyAdmissions.admit(admission)
+                    }
+                }
                 admitted = true
             }
             val stringId = rawStringPropertyIndex(nodeId, type, property)
@@ -202,14 +211,6 @@ internal class MappedWebGraphBackedGraph(
                     yielded++
                     if (yielded >= limit) break
                 }
-            }
-        }
-    }
-
-    private fun admitStringPropertyIndex(key: StringPropertyKey) {
-        synchronized(stringPropertyIndexLock) {
-            if ((stringPropertyAccesses[key] ?: 0) == 0) {
-                stringPropertyAccesses[key] = 1
             }
         }
     }
@@ -316,12 +317,17 @@ internal class MappedWebGraphBackedGraph(
     internal fun clearStringPropertyIndexes() {
         synchronized(stringPropertyIndexLock) {
             stringPropertyIndexes.clear()
-            stringPropertyAccesses.clear()
+            stringPropertyAdmissions.clear()
         }
     }
 
-    internal fun stringPropertyIndexCount(): Int = synchronized(stringPropertyIndexLock) {
-        stringPropertyIndexes.size
+    internal fun stringPropertyIndexCount(
+        type: Class<out Node>? = null,
+        property: String? = null
+    ): Int = synchronized(stringPropertyIndexLock) {
+        stringPropertyIndexes.keys.count { key ->
+            (type == null || key.type == type) && (property == null || key.property == property)
+        }
     }
 
     private fun buildStringPropertyIndex(
@@ -421,8 +427,10 @@ internal class MappedWebGraphBackedGraph(
 private const val NODE_HEADER_BYTES = Int.SIZE_BYTES + Byte.SIZE_BYTES
 private const val METHOD_DESCRIPTOR_FIXED_INTS = 4
 private const val MAX_STRING_PROPERTY_INDEXES = 4
-private const val REJECTED_STRING_PROPERTY_INDEX = -1
 private const val MAX_STRING_PROPERTY_ADMISSION_NODES = 256
+private const val MAX_STRING_PROPERTY_ADMISSIONS = 32
+private const val MAX_STRING_PROPERTY_ADMISSION_BYTES = 64L * 1024
+private const val STRING_PROPERTY_ADMISSION_ESTIMATED_BYTES = 96L
 private const val MAX_STRING_PROPERTY_INDEX_RETAINED_BYTES = 8L * 1024 * 1024
 private const val STRING_PROPERTY_INDEX_ARRAYS = 3
 private const val PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES = 16L
@@ -447,6 +455,72 @@ private data class StringPropertyKey(
     val type: Class<out Node>,
     val property: String
 )
+
+private data class StringPropertyAdmissionKey(
+    val property: StringPropertyKey,
+    val mode: StringMatchMode,
+    val expected: String
+)
+
+private class StringPropertyAdmissions {
+    private val predicates = LinkedHashMap<StringPropertyAdmissionKey, Unit>(
+        MAX_STRING_PROPERTY_ADMISSIONS + 1,
+        STRING_PROPERTY_INDEX_LOAD_FACTOR,
+        true
+    )
+    private val unboundedProperties = mutableSetOf<StringPropertyKey>()
+    private val rejectedProperties = mutableSetOf<StringPropertyKey>()
+    private var retainedBytes = 0L
+
+    fun shouldBuild(admission: StringPropertyAdmissionKey, unbounded: Boolean): Boolean {
+        if (admission.property in rejectedProperties) return false
+        return if (unbounded) {
+            !unboundedProperties.add(admission.property)
+        } else {
+            predicates[admission] != null
+        }
+    }
+
+    fun admit(admission: StringPropertyAdmissionKey) {
+        if (admission.property in rejectedProperties || predicates[admission] != null) return
+        val bytes = estimatedStringPropertyAdmissionBytes(admission)
+        if (bytes > MAX_STRING_PROPERTY_ADMISSION_BYTES) return
+        predicates[admission] = Unit
+        retainedBytes += bytes
+        while (predicates.size > MAX_STRING_PROPERTY_ADMISSIONS ||
+            retainedBytes > MAX_STRING_PROPERTY_ADMISSION_BYTES
+        ) {
+            val entries = predicates.entries.iterator()
+            val eldest = entries.next().key
+            retainedBytes -= estimatedStringPropertyAdmissionBytes(eldest)
+            entries.remove()
+        }
+    }
+
+    fun reject(property: StringPropertyKey) {
+        clear(property)
+        rejectedProperties.add(property)
+    }
+
+    fun clear(property: StringPropertyKey) {
+        val entries = predicates.entries.iterator()
+        while (entries.hasNext()) {
+            val admission = entries.next().key
+            if (admission.property == property) {
+                retainedBytes -= estimatedStringPropertyAdmissionBytes(admission)
+                entries.remove()
+            }
+        }
+        unboundedProperties.remove(property)
+    }
+
+    fun clear() {
+        predicates.clear()
+        unboundedProperties.clear()
+        rejectedProperties.clear()
+        retainedBytes = 0L
+    }
+}
 
 private data class StringMatchKey(
     val mode: StringMatchMode,
@@ -600,6 +674,11 @@ private fun estimatedMatchingStringCacheBytes(key: StringMatchKey, strings: IntA
     STRING_MATCH_CACHE_ENTRY_ESTIMATED_BYTES + PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES +
         STRING_HEADER_ESTIMATED_BYTES + key.expected.length.toLong() * Char.SIZE_BYTES +
         strings.size.toLong() * Int.SIZE_BYTES
+
+private fun estimatedStringPropertyAdmissionBytes(key: StringPropertyAdmissionKey): Long =
+    STRING_PROPERTY_ADMISSION_ESTIMATED_BYTES +
+        key.property.property.length.toLong() * Char.SIZE_BYTES +
+        key.expected.length.toLong() * Char.SIZE_BYTES
 
 private fun stringMatches(actual: String, mode: StringMatchMode, expected: String): Boolean = when (mode) {
     StringMatchMode.STARTS_WITH -> actual.startsWith(expected)

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -123,24 +123,95 @@ internal class MappedWebGraphBackedGraph(
         type: Class<T>,
         property: String,
         mode: StringMatchMode,
-        expected: String
+        expected: String,
+        limit: Int
     ): Sequence<T>? {
         if (!supportsRawStringProperty(type, property)) return null
+        if (limit <= 0) return emptySequence()
         val key = StringPropertyKey(type, property)
+        synchronized(stringPropertyIndexLock) {
+            stringPropertyIndexes[key]
+        }?.let { index ->
+            return indexedNodes(index, mode, expected, limit)
+        }
+
+        val previousAccesses = synchronized(stringPropertyIndexLock) {
+            stringPropertyAccesses[key] ?: 0
+        }
+        if (limit != Int.MAX_VALUE && previousAccesses <= 0) {
+            return rawStringPropertyScan(type, property, mode, expected, limit, key)
+        }
+
         val index = synchronized(stringPropertyIndexLock) {
             stringPropertyIndexes[key] ?: run {
-                val accesses = (stringPropertyAccesses[key] ?: 0) + 1
-                stringPropertyAccesses[key] = accesses
-                trimStringPropertyAccesses()
-                if (accesses < MIN_STRING_PROPERTY_INDEX_ACCESSES) {
+                val accesses = stringPropertyAccesses[key] ?: 0
+                if (accesses == REJECTED_STRING_PROPERTY_INDEX) return@synchronized null
+                if (accesses == 0) {
+                    stringPropertyAccesses[key] = 1
                     null
                 } else {
-                    buildStringPropertyIndex(type, property).also { stringPropertyIndexes[key] = it }
+                    buildStringPropertyIndex(type, property)?.also {
+                        stringPropertyIndexes[key] = it
+                    } ?: run {
+                        stringPropertyAccesses[key] = REJECTED_STRING_PROPERTY_INDEX
+                        null
+                    }
                 }
             }
-        } ?: return null
-        return index.matchingNodeIds(mode, expected)
-            .mapNotNull { node(NodeId(it)) as? T }
+        } ?: return if (limit == Int.MAX_VALUE) {
+            null
+        } else {
+            rawStringPropertyScan(type, property, mode, expected, limit, key)
+        }
+        return indexedNodes(index, mode, expected, limit)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Node> indexedNodes(
+        index: MappedStringPropertyIndex,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int
+    ): Sequence<T> = index.matchingNodeIds(mode, expected)
+        .take(limit)
+        .mapNotNull { node(NodeId(it)) as? T }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Node> rawStringPropertyScan(
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int,
+        key: StringPropertyKey
+    ): Sequence<T> = sequence {
+        var inspected = 0
+        var yielded = 0
+        var admitted = false
+        for (nodeId in nodeTypeIndex.ids(type)) {
+            inspected++
+            if (!admitted && inspected > MAX_STRING_PROPERTY_ADMISSION_NODES) {
+                admitStringPropertyIndex(key)
+                admitted = true
+            }
+            val stringId = rawStringPropertyIndex(nodeId, type, property)
+            if (stringId != null && stringMatches(stringTable.get(stringId), mode, expected)) {
+                val matchedNode = node(NodeId(nodeId)) as? T
+                if (matchedNode != null) {
+                    yield(matchedNode)
+                    yielded++
+                    if (yielded >= limit) break
+                }
+            }
+        }
+    }
+
+    private fun admitStringPropertyIndex(key: StringPropertyKey) {
+        synchronized(stringPropertyIndexLock) {
+            if ((stringPropertyAccesses[key] ?: 0) == 0) {
+                stringPropertyAccesses[key] = 1
+            }
+        }
     }
 
     override fun edgeCount(): Long = edgeCount
@@ -249,34 +320,39 @@ internal class MappedWebGraphBackedGraph(
         }
     }
 
-    private fun trimStringPropertyAccesses() {
-        while (stringPropertyAccesses.size > MAX_STRING_PROPERTY_ACCESS_COUNTS) {
-            val oldest = stringPropertyAccesses.entries.iterator()
-            oldest.next()
-            oldest.remove()
-        }
+    internal fun stringPropertyIndexCount(): Int = synchronized(stringPropertyIndexLock) {
+        stringPropertyIndexes.size
     }
 
     private fun buildStringPropertyIndex(
         type: Class<out Node>,
         property: String
-    ): MappedStringPropertyIndex {
-        val capacity = nodeTypeIndex.count(type).toInt()
+    ): MappedStringPropertyIndex? {
+        val nodeCount = nodeTypeIndex.count(type)
+        if (estimatedStringPropertyIndexBytes(nodeCount) > MAX_STRING_PROPERTY_INDEX_RETAINED_BYTES) return null
+        val capacity = nodeCount.toInt()
         val nodeIds = IntArray(capacity)
         val stringIds = IntArray(capacity)
-        val uniqueStringIds = HashSet<Int>()
         var size = 0
         for (nodeId in nodeTypeIndex.ids(type)) {
             val stringId = rawStringPropertyIndex(nodeId, type, property) ?: continue
             nodeIds[size] = nodeId
             stringIds[size] = stringId
-            uniqueStringIds.add(stringId)
             size++
         }
+        val indexedNodeIds = if (size == capacity) nodeIds else nodeIds.copyOf(size)
+        val indexedStringIds = if (size == capacity) stringIds else stringIds.copyOf(size)
+        val uniqueStringIds = indexedStringIds.copyOf().apply(java.util.Arrays::sort)
+        var uniqueSize = 0
+        for (stringId in uniqueStringIds) {
+            if (uniqueSize == 0 || uniqueStringIds[uniqueSize - 1] != stringId) {
+                uniqueStringIds[uniqueSize++] = stringId
+            }
+        }
         return MappedStringPropertyIndex(
-            nodeIds.copyOf(size),
-            stringIds.copyOf(size),
-            uniqueStringIds.toIntArray().sortedArray(),
+            indexedNodeIds,
+            indexedStringIds,
+            uniqueStringIds.copyOf(uniqueSize),
             stringTable
         )
     }
@@ -345,14 +421,27 @@ internal class MappedWebGraphBackedGraph(
 private const val NODE_HEADER_BYTES = Int.SIZE_BYTES + Byte.SIZE_BYTES
 private const val METHOD_DESCRIPTOR_FIXED_INTS = 4
 private const val MAX_STRING_PROPERTY_INDEXES = 4
-private const val MAX_STRING_PROPERTY_ACCESS_COUNTS = 16
-private const val MIN_STRING_PROPERTY_INDEX_ACCESSES = 2
+private const val REJECTED_STRING_PROPERTY_INDEX = -1
+private const val MAX_STRING_PROPERTY_ADMISSION_NODES = 256
+private const val MAX_STRING_PROPERTY_INDEX_RETAINED_BYTES = 8L * 1024 * 1024
+private const val STRING_PROPERTY_INDEX_ARRAYS = 3
+private const val PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES = 16L
 private const val MAX_STRING_MATCH_CACHE_ENTRIES = 32
-private const val MAX_CACHED_MATCHING_STRINGS = 100_000
+private const val MAX_STRING_MATCH_CACHE_BYTES = 2L * 1024 * 1024
+private const val STRING_MATCH_CACHE_ENTRY_ESTIMATED_BYTES = 64L
+private const val STRING_HEADER_ESTIMATED_BYTES = 24L
+private const val MAX_TRIGRAM_INDEX_RETAINED_BYTES = 16L * 1024 * 1024
+private const val MAX_TRIGRAM_POSTINGS = 1_000_000
 private const val MAX_TRIGRAM_INDEX_STRINGS = 500_000
+private const val TRIGRAM_ENTRY_ESTIMATED_BYTES = 64L
+private const val TRIGRAM_POSTING_ESTIMATED_BYTES = 12L
 private const val MIN_TRIGRAM_LENGTH = 3
 private const val STRING_PROPERTY_INDEX_LOAD_FACTOR = 0.75f
 private const val STRING_HASH_FACTOR = 31
+
+private fun estimatedStringPropertyIndexBytes(nodeCount: Long): Long =
+    STRING_PROPERTY_INDEX_ARRAYS * PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES +
+        nodeCount * STRING_PROPERTY_INDEX_ARRAYS * Int.SIZE_BYTES
 
 private data class StringPropertyKey(
     val type: Class<out Node>,
@@ -364,21 +453,23 @@ private data class StringMatchKey(
     val expected: String
 )
 
-private class MappedStringPropertyIndex(
+internal class MappedStringPropertyIndex(
     private val nodeIds: IntArray,
     private val stringIds: IntArray,
     private val uniqueStringIds: IntArray,
-    private val stringTable: StringTable
+    private val stringTable: StringTable,
+    private val maxTrigramPostings: Int = MAX_TRIGRAM_POSTINGS,
+    private val maxTrigramBytes: Long = MAX_TRIGRAM_INDEX_RETAINED_BYTES,
+    private val maxMatchingStringCacheEntries: Int = MAX_STRING_MATCH_CACHE_ENTRIES,
+    private val maxMatchingStringCacheBytes: Long = MAX_STRING_MATCH_CACHE_BYTES
 ) {
     private val trigramIndex: Int2ObjectOpenHashMap<IntArray>? by lazy(::buildTrigramIndex)
-    private val matchingStrings = object : LinkedHashMap<StringMatchKey, IntArray>(
+    private val matchingStrings = LinkedHashMap<StringMatchKey, IntArray>(
         MAX_STRING_MATCH_CACHE_ENTRIES + 1,
         STRING_PROPERTY_INDEX_LOAD_FACTOR,
         true
-    ) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<StringMatchKey, IntArray>?): Boolean =
-            size > MAX_STRING_MATCH_CACHE_ENTRIES
-    }
+    )
+    private var matchingStringCacheBytes = 0L
 
     fun matchingNodeIds(mode: StringMatchMode, expected: String): Sequence<Int> {
         val matchedStrings = matchingStringIds(mode, expected)
@@ -398,9 +489,27 @@ private class MappedStringPropertyIndex(
                 matchingContainsStringIds(expected)
             else -> scanMatchingStringIds(mode, expected)
         }
-        if (result.size <= MAX_CACHED_MATCHING_STRINGS) matchingStrings[key] = result
+        cacheMatchingStrings(key, result)
         return result
     }
+
+    private fun cacheMatchingStrings(key: StringMatchKey, result: IntArray) {
+        val resultBytes = estimatedMatchingStringCacheBytes(key, result)
+        if (resultBytes > maxMatchingStringCacheBytes) return
+        matchingStrings[key] = result
+        matchingStringCacheBytes += resultBytes
+        while (matchingStrings.size > maxMatchingStringCacheEntries ||
+            matchingStringCacheBytes > maxMatchingStringCacheBytes
+        ) {
+            val entries = matchingStrings.entries.iterator()
+            val eldest = entries.next()
+            matchingStringCacheBytes -= estimatedMatchingStringCacheBytes(eldest.key, eldest.value)
+            entries.remove()
+        }
+    }
+
+    @Synchronized
+    internal fun matchingStringCacheSize(): Int = matchingStrings.size
 
     @Suppress("ReturnCount")
     private fun matchingContainsStringIds(expected: String): IntArray {
@@ -440,25 +549,62 @@ private class MappedStringPropertyIndex(
 
     private fun buildTrigramIndex(): Int2ObjectOpenHashMap<IntArray>? {
         if (uniqueStringIds.size > MAX_TRIGRAM_INDEX_STRINGS) return null
-        val builders = Int2ObjectOpenHashMap<IntArrayList>()
-        val seenTrigrams = IntOpenHashSet()
-        for (stringId in uniqueStringIds) {
-            val value = stringTable.get(stringId)
-            seenTrigrams.clear()
-            for (position in 0..value.length - MIN_TRIGRAM_LENGTH) {
-                val trigram = trigramHash(value, position)
-                if (seenTrigrams.add(trigram)) {
-                    builders.computeIfAbsent(trigram) { IntArrayList() }.add(stringId)
-                }
-            }
-        }
+        val builder = TrigramIndexBuilder(maxTrigramPostings, maxTrigramBytes)
+        return if (populateTrigramIndex(builder)) builder.build() else null
+    }
 
+    private fun populateTrigramIndex(builder: TrigramIndexBuilder): Boolean {
+        for (stringId in uniqueStringIds) {
+            if (!builder.add(stringId, stringTable.get(stringId))) return false
+        }
+        return true
+    }
+}
+
+private class TrigramIndexBuilder(
+    private val maxPostings: Int,
+    private val maxBytes: Long
+) {
+    private val builders = Int2ObjectOpenHashMap<IntArrayList>()
+    private val seenTrigrams = IntOpenHashSet()
+    private var postings = 0
+    private var estimatedBytes = 0L
+
+    fun add(stringId: Int, value: String): Boolean {
+        seenTrigrams.clear()
+        for (position in 0..value.length - MIN_TRIGRAM_LENGTH) {
+            val trigram = trigramHash(value, position)
+            if (!seenTrigrams.add(trigram)) continue
+            val posting = builders[trigram]
+            val addedBytes = TRIGRAM_POSTING_ESTIMATED_BYTES +
+                if (posting == null) TRIGRAM_ENTRY_ESTIMATED_BYTES else 0L
+            if (postings >= maxPostings || estimatedBytes + addedBytes > maxBytes) return false
+            val target = posting ?: IntArrayList().also { builders.put(trigram, it) }
+            target.add(stringId)
+            postings++
+            estimatedBytes += addedBytes
+        }
+        return true
+    }
+
+    fun build(): Int2ObjectOpenHashMap<IntArray> {
         val result = Int2ObjectOpenHashMap<IntArray>(builders.size)
         builders.int2ObjectEntrySet().forEach { entry ->
             result.put(entry.intKey, entry.value.toIntArray())
         }
         return result
     }
+}
+
+private fun estimatedMatchingStringCacheBytes(key: StringMatchKey, strings: IntArray): Long =
+    STRING_MATCH_CACHE_ENTRY_ESTIMATED_BYTES + PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES +
+        STRING_HEADER_ESTIMATED_BYTES + key.expected.length.toLong() * Char.SIZE_BYTES +
+        strings.size.toLong() * Int.SIZE_BYTES
+
+private fun stringMatches(actual: String, mode: StringMatchMode, expected: String): Boolean = when (mode) {
+    StringMatchMode.STARTS_WITH -> actual.startsWith(expected)
+    StringMatchMode.ENDS_WITH -> actual.endsWith(expected)
+    StringMatchMode.CONTAINS -> actual.contains(expected)
 }
 
 private fun trigramHash(value: String, position: Int): Int =

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -45,6 +45,7 @@ import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.graph.MmapGraphBuilder
 import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.nodesByStringProperty
 import io.johnsonlee.graphite.input.ResourceAccessor
 import io.johnsonlee.graphite.input.ResourceEntry
 import it.unimi.dsi.fastutil.io.BinIO
@@ -289,6 +290,18 @@ class GraphStoreTest {
                 )
                 assertEquals(0, loaded.stringPropertyIndexCount())
 
+                assertEquals(
+                    listOf("symbol-0"),
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.STARTS_WITH,
+                        "symbol-0",
+                        limit = 1
+                    ).orEmpty().map { it.value }.toList()
+                )
+                assertEquals(0, loaded.stringPropertyIndexCount())
+
                 assertTrue(
                     loaded.nodesByStringProperty(
                         StringConstant::class.java,
@@ -299,6 +312,16 @@ class GraphStoreTest {
                     ).orEmpty().none()
                 )
                 assertEquals(1, loaded.stringPropertyIndexCount())
+                assertEquals(
+                    listOf("symbol-0"),
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.STARTS_WITH,
+                        "symbol-0",
+                        limit = 1
+                    ).orEmpty().map { it.value }.toList()
+                )
                 assertTrue(
                     loaded.nodesByStringProperty(
                         StringConstant::class.java,
@@ -315,6 +338,171 @@ class GraphStoreTest {
             dir.toFile().deleteRecursively()
         }
     }
+
+    @Test
+    fun `mapped string lookup resets predicate admission after LRU eviction`() {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(300) { index ->
+                addNode(ResourceFileNode(NodeId(index), "path-$index", "source-$index", "format-$index"))
+                addNode(
+                    FieldNode(
+                        NodeId(300 + index),
+                        FieldDescriptor(
+                            TypeDescriptor("example.Owner$index"),
+                            "field-$index",
+                            TypeDescriptor("example.Type$index")
+                        ),
+                        false
+                    )
+                )
+            }
+        }.build()
+        val dir = Files.createTempDirectory("webgraph-string-property-eviction")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.loadMapped(dir) as MappedWebGraphBackedGraph
+            try {
+                listOf(
+                    Triple(ResourceFileNode::class.java, "path", "missing-path"),
+                    Triple(ResourceFileNode::class.java, "source", "missing-source"),
+                    Triple(ResourceFileNode::class.java, "format", "missing-format"),
+                    Triple(FieldNode::class.java, "class", "missing-class"),
+                    Triple(FieldNode::class.java, "name", "missing-name")
+                ).forEach { (type, property, expected) ->
+                    repeat(2) {
+                        assertTrue(
+                            loaded.nodesByStringProperty(
+                                type,
+                                property,
+                                StringMatchMode.CONTAINS,
+                                expected,
+                                limit = 1
+                            ).orEmpty().none()
+                        )
+                    }
+                }
+
+                assertEquals(4, loaded.stringPropertyIndexCount())
+                assertEquals(0, loaded.stringPropertyIndexCount(ResourceFileNode::class.java, "path"))
+                assertTrue(
+                    loaded.nodesByStringProperty(
+                        ResourceFileNode::class.java,
+                        "path",
+                        StringMatchMode.CONTAINS,
+                        "missing-path",
+                        limit = 1
+                    ).orEmpty().none()
+                )
+                assertEquals(0, loaded.stringPropertyIndexCount(ResourceFileNode::class.java, "path"))
+                assertEquals(
+                    listOf("path-0"),
+                    loaded.nodesByStringProperty(
+                        ResourceFileNode::class.java,
+                        "path",
+                        StringMatchMode.STARTS_WITH,
+                        "path-0",
+                        limit = 1
+                    ).orEmpty().map { it.path }.toList()
+                )
+                assertEquals(0, loaded.stringPropertyIndexCount(ResourceFileNode::class.java, "path"))
+            } finally {
+                loaded.close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `mapped string lookup bounds predicate admission state`() {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(300) { index ->
+                addNode(StringConstant(NodeId(index), "symbol-$index"))
+            }
+        }.build()
+        val dir = Files.createTempDirectory("webgraph-string-property-admission-bounds")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.loadMapped(dir) as MappedWebGraphBackedGraph
+            try {
+                repeat(33) { index ->
+                    assertTrue(loaded.stringConstantsMissing("short-missing-$index"))
+                }
+                assertTrue(loaded.stringConstantsMissing("short-missing-0"))
+                assertEquals(0, loaded.stringPropertyIndexCount())
+                assertTrue(loaded.stringConstantsMissing("short-missing-32"))
+                assertEquals(1, loaded.stringPropertyIndexCount())
+
+                loaded.clearStringPropertyIndexes()
+                val largePredicates = List(24) { index -> "large-missing-$index-${"x".repeat(1_500)}" }
+                largePredicates.forEach { expected ->
+                    assertTrue(loaded.stringConstantsMissing(expected))
+                }
+                assertTrue(loaded.stringConstantsMissing(largePredicates.first()))
+                assertEquals(0, loaded.stringPropertyIndexCount())
+                assertTrue(loaded.stringConstantsMissing(largePredicates.last()))
+                assertEquals(1, loaded.stringPropertyIndexCount())
+
+                loaded.clearStringPropertyIndexes()
+                val oversized = "oversized-${"x".repeat(32_768)}"
+                repeat(2) {
+                    assertTrue(loaded.stringConstantsMissing(oversized))
+                }
+                assertEquals(0, loaded.stringPropertyIndexCount())
+            } finally {
+                loaded.close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `clearing mapped string indexes resets unbounded admission`() {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(300) { index ->
+                addNode(StringConstant(NodeId(index), "symbol-$index"))
+            }
+        }.build()
+        val dir = Files.createTempDirectory("webgraph-string-property-admission-clear")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.loadMapped(dir) as MappedWebGraphBackedGraph
+            try {
+                assertNull(loaded.unboundedStringConstants("symbol"))
+                assertEquals(300, loaded.unboundedStringConstants("symbol")?.count())
+                assertEquals(1, loaded.stringPropertyIndexCount())
+
+                loaded.clearStringPropertyIndexes()
+
+                assertEquals(0, loaded.stringPropertyIndexCount())
+                assertNull(loaded.unboundedStringConstants("symbol"))
+                assertEquals(300, loaded.unboundedStringConstants("symbol")?.count())
+                assertEquals(1, loaded.stringPropertyIndexCount())
+            } finally {
+                loaded.close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun MappedWebGraphBackedGraph.stringConstantsMissing(expected: String): Boolean =
+        nodesByStringProperty(
+            StringConstant::class.java,
+            "value",
+            StringMatchMode.CONTAINS,
+            expected,
+            limit = 1
+        ).orEmpty().none()
+
+    private fun MappedWebGraphBackedGraph.unboundedStringConstants(expected: String): Sequence<StringConstant>? =
+        nodesByStringProperty(
+            StringConstant::class.java,
+            "value",
+            StringMatchMode.CONTAINS,
+            expected
+        )
 
     private fun assertRawStringPropertyLookups(graph: Graph) {
         assertEquals(

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -108,6 +108,7 @@ class GraphStoreTest {
             try {
                 val mapped = loaded as MappedWebGraphBackedGraph
                 assertEarlyLimitedLookupsDoNotBuildIndex(mapped)
+                assertAgentDiscoveryQuery(loaded)
                 assertNull(
                     loaded.nodesByStringProperty(
                         StringConstant::class.java,
@@ -199,6 +200,31 @@ class GraphStoreTest {
             assertEquals(listOf("feature-alpha"), early)
         }
         assertEquals(0, graph.stringPropertyIndexCount())
+    }
+
+    private fun assertAgentDiscoveryQuery(graph: Graph) {
+        val rows = graph.query(
+            """
+            MATCH (n)
+            WHERE (exists(n.class) AND n.class CONTAINS 'Owner')
+               OR (exists(n.name) AND n.name CONTAINS 'Owner')
+               OR (exists(n.caller_class) AND n.caller_class CONTAINS 'Owner')
+               OR (exists(n.caller_name) AND n.caller_name CONTAINS 'Owner')
+               OR (exists(n.callee_class) AND n.callee_class CONTAINS 'Owner')
+               OR (exists(n.callee_name) AND n.callee_name CONTAINS 'Owner')
+            RETURN DISTINCT n.class AS class, n.name AS name,
+                n.caller_class AS caller, n.caller_name AS callerMethod,
+                n.callee_class AS callee, n.callee_name AS calleeMethod
+            LIMIT 120
+            """.trimIndent()
+        ).rows
+
+        assertEquals(2, rows.size)
+        assertEquals("token", rows.single { it["class"] == "example.Owner" }["name"])
+        val callSite = rows.single { it["caller"] == "example.Owner" }
+        assertEquals("callerFeature", callSite["callerMethod"])
+        assertEquals("example.Target", callSite["callee"])
+        assertEquals("billingFeature", callSite["calleeMethod"])
     }
 
     @Test

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -340,6 +340,61 @@ class GraphStoreTest {
     }
 
     @Test
+    fun `mapped string lookup keeps admission specific to the query limit`() {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(300) { index ->
+                addNode(StringConstant(NodeId(index), "symbol-$index"))
+            }
+        }.build()
+        val dir = Files.createTempDirectory("webgraph-string-property-limit-admission")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.loadMapped(dir) as MappedWebGraphBackedGraph
+            try {
+                assertEquals(
+                    300,
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.CONTAINS,
+                        "symbol-",
+                        limit = 300
+                    ).orEmpty().count()
+                )
+                assertEquals(0, loaded.stringPropertyIndexCount())
+
+                assertEquals(
+                    listOf("symbol-0"),
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.CONTAINS,
+                        "symbol-",
+                        limit = 1
+                    ).orEmpty().map { it.value }.toList()
+                )
+                assertEquals(0, loaded.stringPropertyIndexCount())
+
+                assertEquals(
+                    300,
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.CONTAINS,
+                        "symbol-",
+                        limit = 300
+                    ).orEmpty().count()
+                )
+                assertEquals(1, loaded.stringPropertyIndexCount())
+            } finally {
+                loaded.close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `mapped string lookup resets predicate admission after LRU eviction`() {
         val graph = DefaultGraph.Builder().apply {
             repeat(300) { index ->

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -109,7 +109,7 @@ class GraphStoreTest {
             try {
                 val mapped = loaded as MappedWebGraphBackedGraph
                 assertEarlyLimitedLookupsDoNotBuildIndex(mapped)
-                assertAgentDiscoveryQuery(loaded)
+                assertBroadDiscoveryQuery(loaded)
                 assertNull(
                     loaded.nodesByStringProperty(
                         StringConstant::class.java,
@@ -186,6 +186,55 @@ class GraphStoreTest {
         }
     }
 
+    @Test
+    fun `mapped broad disjunction deduplicates unordered property streams`() {
+        val nodeIds = listOf(1, 30, 70, 2, 90, 4, 5, 50, 40, 3)
+        val returnType = TypeDescriptor("void")
+        val graph = DefaultGraph.Builder().apply {
+            nodeIds.forEach { nodeId ->
+                val callerClass = if (nodeId == 4) "example.TargetCaller" else "example.OtherCaller$nodeId"
+                val calleeClass = if (nodeId == 90 || nodeId == 4) {
+                    "example.TargetCallee"
+                } else {
+                    "example.OtherCallee$nodeId"
+                }
+                addNode(
+                    CallSiteNode(
+                        NodeId(nodeId),
+                        MethodDescriptor(TypeDescriptor(callerClass), "call$nodeId", emptyList(), returnType),
+                        MethodDescriptor(TypeDescriptor(calleeClass), "load$nodeId", emptyList(), returnType),
+                        nodeId,
+                        null,
+                        emptyList()
+                    )
+                )
+            }
+        }.build()
+        val dir = Files.createTempDirectory("webgraph-unordered-string-candidates")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.loadMapped(dir) as MappedWebGraphBackedGraph
+            try {
+                val storedOrder = loaded.nodes(CallSiteNode::class.java).map { it.id.value }.toList()
+                assertTrue(storedOrder.indexOf(90) < storedOrder.indexOf(4), "Mapped fixture must be unordered")
+
+                val rows = loaded.query(
+                    "MATCH (n:CallSiteNode) WHERE " +
+                        "n.caller_class CONTAINS 'Target' OR n.callee_class CONTAINS 'Target' " +
+                        "RETURN DISTINCT n.id AS id, rand() AS nonce LIMIT 3"
+                ).rows
+                val resultIds = rows.map { it["id"] }
+
+                assertEquals(listOf(4, 90), resultIds)
+                assertEquals(resultIds.size, resultIds.distinct().size)
+            } finally {
+                loaded.close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
     private fun assertEarlyLimitedLookupsDoNotBuildIndex(graph: MappedWebGraphBackedGraph) {
         listOf(
             StringMatchMode.CONTAINS to "alpha",
@@ -203,7 +252,7 @@ class GraphStoreTest {
         assertEquals(0, graph.stringPropertyIndexCount())
     }
 
-    private fun assertAgentDiscoveryQuery(graph: Graph) {
+    private fun assertBroadDiscoveryQuery(graph: Graph) {
         val rows = graph.query(
             """
             MATCH (n)

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -88,6 +88,18 @@ class GraphStoreTest {
             .addNode(StringConstant(NodeId(0), "feature-alpha"))
             .addNode(StringConstant(NodeId(1), "feature-beta"))
             .addNode(CallSiteNode(NodeId(2), caller, callee, 10, null, emptyList()))
+            .addNode(EnumConstant(NodeId(3), TypeDescriptor("example.State"), "READY"))
+            .addNode(LocalVariable(NodeId(4), "request", TypeDescriptor("java.lang.String"), caller))
+            .addNode(
+                FieldNode(
+                    NodeId(5),
+                    FieldDescriptor(owner, "token", TypeDescriptor("java.lang.String")),
+                    false
+                )
+            )
+            .addNode(ParameterNode(NodeId(6), 0, TypeDescriptor("java.lang.String"), caller))
+            .addNode(ResourceFileNode(NodeId(7), "config/app.yml", "resources", "yaml"))
+            .addNode(IntConstant(NodeId(8), 42))
             .build()
         val dir = Files.createTempDirectory("webgraph-string-property-index")
         try {
@@ -140,6 +152,7 @@ class GraphStoreTest {
                 assertEquals(listOf("callerFeature"), startsWith)
                 assertEquals(listOf("billingFeature"), endsWith)
                 assertEquals(listOf("feature-beta"), cypherValues)
+                assertRawStringPropertyLookups(loaded)
                 assertNull(
                     loaded.nodesByStringProperty(
                         StringConstant::class.java,
@@ -148,12 +161,125 @@ class GraphStoreTest {
                         "feature"
                     )
                 )
+                assertNull(
+                    loaded.nodesByStringProperty(
+                        IntConstant::class.java,
+                        "value",
+                        StringMatchMode.CONTAINS,
+                        "42"
+                    )
+                )
+                assertTrue(loaded.memberAnnotationIndex().orEmpty().isEmpty())
+                assertNull(loaded.classOrigin("example.Owner"))
+                assertTrue(loaded.classOrigins().isEmpty())
+                assertTrue(loaded.artifactDependencies().isEmpty())
             } finally {
                 (loaded as Closeable).close()
             }
         } finally {
             dir.toFile().deleteRecursively()
         }
+    }
+
+    private fun assertRawStringPropertyLookups(graph: Graph) {
+        assertEquals(
+            listOf("example.State"),
+            indexedValues(graph, EnumConstant::class.java, "enum_type", StringMatchMode.ENDS_WITH, "State") {
+                it.enumType.className
+            }
+        )
+        assertEquals(
+            listOf("READY"),
+            indexedValues(graph, EnumConstant::class.java, "name", StringMatchMode.STARTS_WITH, "REA") {
+                it.enumName
+            }
+        )
+        assertEquals(
+            listOf("request"),
+            indexedValues(graph, LocalVariable::class.java, "name", StringMatchMode.CONTAINS, "que") { it.name }
+        )
+        assertEquals(
+            listOf("java.lang.String"),
+            indexedValues(graph, LocalVariable::class.java, "type", StringMatchMode.ENDS_WITH, "String") {
+                it.type.className
+            }
+        )
+        assertEquals(
+            listOf("example.Owner"),
+            indexedValues(graph, FieldNode::class.java, "class", StringMatchMode.CONTAINS, "Owner") {
+                it.descriptor.declaringClass.className
+            }
+        )
+        assertEquals(
+            listOf("token"),
+            indexedValues(graph, FieldNode::class.java, "name", StringMatchMode.CONTAINS, "oke") {
+                it.descriptor.name
+            }
+        )
+        assertEquals(
+            listOf("java.lang.String"),
+            indexedValues(graph, FieldNode::class.java, "type", StringMatchMode.ENDS_WITH, "String") {
+                it.descriptor.type.className
+            }
+        )
+        assertEquals(
+            listOf("java.lang.String"),
+            indexedValues(graph, ParameterNode::class.java, "type", StringMatchMode.CONTAINS, "lang") {
+                it.type.className
+            }
+        )
+        assertResourceStringPropertyLookups(graph)
+    }
+
+    private fun assertResourceStringPropertyLookups(graph: Graph) {
+        assertEquals(
+            listOf("config/app.yml"),
+            indexedValues(graph, ResourceFileNode::class.java, "path", StringMatchMode.STARTS_WITH, "config") {
+                it.path
+            }
+        )
+        assertEquals(
+            listOf("resources"),
+            indexedValues(graph, ResourceFileNode::class.java, "source", StringMatchMode.CONTAINS, "source") {
+                it.source
+            }
+        )
+        assertEquals(
+            listOf("yaml"),
+            indexedValues(graph, ResourceFileNode::class.java, "format", StringMatchMode.ENDS_WITH, "yaml") {
+                it.format
+            }
+        )
+        assertEquals(
+            listOf("example.Owner"),
+            indexedValues(graph, CallSiteNode::class.java, "caller_class", StringMatchMode.CONTAINS, "Owner") {
+                it.caller.declaringClass.className
+            }
+        )
+        assertEquals(
+            listOf("example.Target"),
+            indexedValues(graph, CallSiteNode::class.java, "callee_class", StringMatchMode.CONTAINS, "Target") {
+                it.callee.declaringClass.className
+            }
+        )
+        assertEquals(
+            listOf("feature-alpha", "feature-beta"),
+            indexedValues(graph, StringConstant::class.java, "value", StringMatchMode.CONTAINS, "a") { it.value }
+        )
+    }
+
+    private fun <T : Node, R> indexedValues(
+        graph: Graph,
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String,
+        transform: (T) -> R
+    ): List<R> {
+        graph.nodesByStringProperty(type, property, mode, expected)
+        return assertNotNull(graph.nodesByStringProperty(type, property, mode, expected))
+            .map(transform)
+            .toList()
     }
 
     @Test
@@ -1588,6 +1714,7 @@ class GraphStoreTest {
         DataOutputStream(utfOut).use { it.writeUTF("ok") }
         val utfInput = inputCtor.newInstance(ByteBuffer.wrap(utfOut.toByteArray()), 0) as DataInput
         assertEquals("ok", utfInput.readUTF())
+        assertFailsWith<UnsupportedOperationException> { utfInput.readLine() }
 
         val flushed = mutableListOf<Boolean>()
         val delegate = object : OutputStream() {

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -37,12 +37,14 @@ import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.core.TypeRelation
 import io.johnsonlee.graphite.core.ValueNode
+import io.johnsonlee.graphite.cypher.query
 import io.johnsonlee.graphite.graph.ClassDependency
 import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.graph.MmapGraphBuilder
+import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.input.ResourceAccessor
 import io.johnsonlee.graphite.input.ResourceEntry
 import it.unimi.dsi.fastutil.io.BinIO
@@ -66,6 +68,93 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class GraphStoreTest {
+
+    @Test
+    fun `mapped string property lookup uses raw node fields and falls back when unsupported`() {
+        val owner = TypeDescriptor("example.Owner")
+        val caller = MethodDescriptor(
+            owner,
+            "callerFeature",
+            listOf(TypeDescriptor("java.lang.String"), TypeDescriptor("int")),
+            TypeDescriptor("void")
+        )
+        val callee = MethodDescriptor(
+            TypeDescriptor("example.Target"),
+            "billingFeature",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val graph = DefaultGraph.Builder()
+            .addNode(StringConstant(NodeId(0), "feature-alpha"))
+            .addNode(StringConstant(NodeId(1), "feature-beta"))
+            .addNode(CallSiteNode(NodeId(2), caller, callee, 10, null, emptyList()))
+            .build()
+        val dir = Files.createTempDirectory("webgraph-string-property-index")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.loadMapped(dir)
+            try {
+                assertNull(
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.CONTAINS,
+                        "alpha"
+                    )
+                )
+                val contains = loaded.nodesByStringProperty(
+                    StringConstant::class.java,
+                    "value",
+                    StringMatchMode.CONTAINS,
+                    "alpha"
+                )?.map { it.value }?.toList()
+                loaded.nodesByStringProperty(
+                    CallSiteNode::class.java,
+                    "caller_name",
+                    StringMatchMode.STARTS_WITH,
+                    "caller"
+                )
+                val startsWith = loaded.nodesByStringProperty(
+                    CallSiteNode::class.java,
+                    "caller_name",
+                    StringMatchMode.STARTS_WITH,
+                    "caller"
+                )?.map { it.caller.name }?.toList()
+                loaded.nodesByStringProperty(
+                    CallSiteNode::class.java,
+                    "callee_name",
+                    StringMatchMode.ENDS_WITH,
+                    "Feature"
+                )
+                val endsWith = loaded.nodesByStringProperty(
+                    CallSiteNode::class.java,
+                    "callee_name",
+                    StringMatchMode.ENDS_WITH,
+                    "Feature"
+                )?.map { it.callee.name }?.toList()
+                val cypherValues = loaded.query(
+                    "MATCH (n:StringConstant) WHERE n.value CONTAINS 'beta' RETURN n.value AS value"
+                ).rows.map { it["value"] }
+
+                assertEquals(listOf("feature-alpha"), contains)
+                assertEquals(listOf("callerFeature"), startsWith)
+                assertEquals(listOf("billingFeature"), endsWith)
+                assertEquals(listOf("feature-beta"), cypherValues)
+                assertNull(
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "unknown",
+                        StringMatchMode.CONTAINS,
+                        "feature"
+                    )
+                )
+            } finally {
+                (loaded as Closeable).close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
 
     @Test
     fun `round-trip save and load preserves nodes`() {

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -106,6 +106,8 @@ class GraphStoreTest {
             GraphStore.save(graph, dir)
             val loaded = GraphStore.loadMapped(dir)
             try {
+                val mapped = loaded as MappedWebGraphBackedGraph
+                assertEarlyLimitedLookupsDoNotBuildIndex(mapped)
                 assertNull(
                     loaded.nodesByStringProperty(
                         StringConstant::class.java,
@@ -120,6 +122,7 @@ class GraphStoreTest {
                     StringMatchMode.CONTAINS,
                     "alpha"
                 )?.map { it.value }?.toList()
+                assertEquals(1, mapped.stringPropertyIndexCount())
                 loaded.nodesByStringProperty(
                     CallSiteNode::class.java,
                     "caller_name",
@@ -175,6 +178,112 @@ class GraphStoreTest {
                 assertTrue(loaded.artifactDependencies().isEmpty())
             } finally {
                 (loaded as Closeable).close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun assertEarlyLimitedLookupsDoNotBuildIndex(graph: MappedWebGraphBackedGraph) {
+        listOf(
+            StringMatchMode.CONTAINS to "alpha",
+            StringMatchMode.STARTS_WITH to "feature"
+        ).forEach { (mode, expected) ->
+            val early = graph.nodesByStringProperty(
+                StringConstant::class.java,
+                "value",
+                mode,
+                expected,
+                limit = 1
+            )?.map { it.value }?.toList()
+            assertEquals(listOf("feature-alpha"), early)
+        }
+        assertEquals(0, graph.stringPropertyIndexCount())
+    }
+
+    @Test
+    fun `trigram budget exhaustion falls back to dictionary scan`() {
+        val dir = Files.createTempDirectory("webgraph-trigram-budget")
+        try {
+            val values = listOf("alpha-feature", "beta-feature")
+            val strings = StringTable.build(values, dir)
+            val index = MappedStringPropertyIndex(
+                nodeIds = intArrayOf(10, 11),
+                stringIds = values.map(strings::indexOf).toIntArray(),
+                uniqueStringIds = values.map(strings::indexOf).sorted().toIntArray(),
+                stringTable = strings,
+                maxTrigramPostings = 0,
+                maxTrigramBytes = 0,
+                maxMatchingStringCacheEntries = 1,
+                maxMatchingStringCacheBytes = 128
+            )
+
+            assertEquals(
+                listOf(10),
+                index.matchingNodeIds(StringMatchMode.CONTAINS, "alpha").toList()
+            )
+            assertEquals(1, index.matchingStringCacheSize())
+            assertTrue(index.matchingNodeIds(StringMatchMode.CONTAINS, "missing").none())
+            assertEquals(1, index.matchingStringCacheSize())
+
+            val uncached = MappedStringPropertyIndex(
+                nodeIds = intArrayOf(10, 11),
+                stringIds = values.map(strings::indexOf).toIntArray(),
+                uniqueStringIds = values.map(strings::indexOf).sorted().toIntArray(),
+                stringTable = strings,
+                maxMatchingStringCacheBytes = 0
+            )
+            assertEquals(listOf(11), uncached.matchingNodeIds(StringMatchMode.STARTS_WITH, "beta").toList())
+            assertEquals(0, uncached.matchingStringCacheSize())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `mapped string lookup admits an index only after a long raw scan`() {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(300) { index ->
+                addNode(StringConstant(NodeId(index), "symbol-$index"))
+            }
+        }.build()
+        val dir = Files.createTempDirectory("webgraph-string-property-admission")
+        try {
+            GraphStore.save(graph, dir)
+            val loaded = GraphStore.loadMapped(dir) as MappedWebGraphBackedGraph
+            try {
+                assertTrue(
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.ENDS_WITH,
+                        "missing",
+                        limit = 1
+                    ).orEmpty().none()
+                )
+                assertEquals(0, loaded.stringPropertyIndexCount())
+
+                assertTrue(
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.ENDS_WITH,
+                        "missing",
+                        limit = 1
+                    ).orEmpty().none()
+                )
+                assertEquals(1, loaded.stringPropertyIndexCount())
+                assertTrue(
+                    loaded.nodesByStringProperty(
+                        StringConstant::class.java,
+                        "value",
+                        StringMatchMode.CONTAINS,
+                        "symbol",
+                        limit = 0
+                    ).orEmpty().none()
+                )
+            } finally {
+                loaded.close()
             }
         } finally {
             dir.toFile().deleteRecursively()
@@ -1904,7 +2013,7 @@ class GraphStoreTest {
         val dir = Files.createTempDirectory("webgraph-oob-test")
         try {
             GraphStore.save(graph, dir)
-            val loaded = GraphStore.load(dir)
+            val loaded = GraphStore.loadMapped(dir)
 
             // NodeId with value >= numNodes should return empty
             val bigId = NodeId(999999)


### PR DESCRIPTION
## Summary

- optimize the exact six-property broad-discovery Cypher query observed on Graphite 2.2.2
- stream filtered `DISTINCT ... LIMIT` rows and route guarded string disjunctions through mapped raw-field/index lookups
- deduplicate unordered property streams by filter ownership, with memory independent of match count
- preserve cross-graph provenance, old mapped graph behavior, generic fallback, and the JVM contract of existing `Graph` implementations
- make mapped-index admission predicate-and-limit-specific, bounded, and reset on LRU eviction
- document `/api/cypher` as the aggregate endpoint so clients do not enumerate graphs and fan out themselves

## Reported workload

```cypher
MATCH (n)
WHERE (exists(n.class) AND n.class CONTAINS 'ThankYou')
   OR (exists(n.name) AND n.name CONTAINS 'ThankYou')
   OR (exists(n.caller_class) AND n.caller_class CONTAINS 'ThankYou')
   OR (exists(n.caller_name) AND n.caller_name CONTAINS 'ThankYou')
   OR (exists(n.callee_class) AND n.callee_class CONTAINS 'ThankYou')
   OR (exists(n.callee_name) AND n.callee_name CONTAINS 'ThankYou')
RETURN DISTINCT n.class AS class, n.name AS name,
    n.caller_class AS caller, n.caller_name AS callerMethod,
    n.callee_class AS callee, n.callee_name AS calleeMethod
LIMIT 120
```

`RETURN DISTINCT` excluded the old filtered-node fast path, and the guarded six-way `OR` could not compile as a direct string filter. The generic path deserialized every unlabeled node, evaluated the full predicate per node, projected all matches, deduplicated them, and applied `LIMIT` last.

The client also enumerated `/api/graphs` and called graph-scoped Cypher routes. That is client-side fan-out. `/api/cypher` already executes one server-side cross-graph query. `/api/graphs` reads cached descriptors, so its timeout during this workload points to server saturation rather than expensive graph-list generation.

## Implementation

- filtered single-node `DISTINCT ... LIMIT` execution retains at most the requested distinct rows while still scanning later graphs to merge complete provenance
- guarded `STARTS WITH`, `ENDS WITH`, and `CONTAINS` disjunctions narrow unlabeled scans to relevant node types and use mapped raw string fields or indexes
- each mapped candidate stream belongs to one filter; later streams suppress nodes matching an earlier filter, so unordered streams are deduplicated without retaining node IDs
- dynamic annotation properties and unsupported/complex expressions remain on the generic evaluator
- storage lookup is an optional `StringPropertyLookup` capability plus a safe `Graph` extension; `Graph.class` does not gain a JVM method, preserving compatibility with implementations compiled against 2.2.2
- finite index admission is keyed by node type, property, match mode, expected string, and lookup limit; a costly large-page scan cannot make a later `LIMIT 1` request build an index
- admission retains at most 32 predicates / 64 KiB and is cleared when a property index leaves the four-entry LRU

## Benchmark environment

Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK 17.0.18, JMH 1.37, one benchmark thread and one fork. Baseline and branch runs used the same machine and dependency caches. `main` was commit `e4d1c6a`.

## Android-scale benchmark

The primary pressure benchmark uses the Android fixture JAR: 5.9 million nodes and about 6.5 million edges. `AndroidBroadDiscoveryBenchmark` runs the six-property query shape with the common term `android` and validates all 120 rows. Its name describes the workload, not its original caller. The identical benchmark source was run on `main` and this branch.

```shell
./gradlew :webgraph:jmh \
  -Pjmh.filter='AndroidBroadDiscoveryBenchmark.*' \
  --no-daemon
```

| Exact benchmark | `main` | branch | speedup |
|---|---:|---:|---:|
| `AndroidBroadDiscoveryBenchmark.coldBroadDiscovery` | 7,426.015 ms/op | 207.392 ms/op | 35.81x |
| `AndroidBroadDiscoveryBenchmark.repeatedBroadDiscovery` | 7,433.167 ms/op | 204.300 ms/op | 36.38x |

The final memory fix preserves the Android-scale speedup. The deterministic 16-graph `BroadDiscoveryMappedQueryBenchmark` is supporting evidence: repeated `2.861 ms/op`, cold hit `11.661 ms/op`, and cold miss `7.949 ms/op`. The earlier cold profiler measured allocation falling from 137.930 to 25.203 MB/op.

## Review fixes

| Admission control | `main` | branch |
|---|---:|---:|
| different predicate after an admitted full miss | 0.555 ms/op | 0.390 ms/op |
| same predicate after a large-limit scan | 0.518 ms/op | 0.463 ms/op |
| lookup after four-entry LRU eviction | 0.189 ms/op | 0.263 ms/op |

The earlier branch spikes were 25.074 ms, 21.339 ms, and 9.810 ms respectively. Admission now isolates both predicate and lookup budget; all three controls are at `main` latency. The same-predicate JMH uses `CONTAINS 'path-0'` on both sides, changes only `LIMIT 50000` to `LIMIT 1`, and asserts the index remains absent after setup and measurement.

The eager candidate union originally retained and sorted every match. A later primitive-ID-set version fixed lazy single-graph limits but could retain every match during qualified cross-graph provenance scans. The final filter-owned merge retains no node IDs. Its regressions prove:

- a single-graph `LIMIT 1` consumes one candidate rather than all 1,000
- explicitly unordered streams produce IDs `[1, 2, 0]` exactly once each
- a real `save -> loadMapped` unordered type index returns `[4, 90]`, not `[4, 90, 4]`, for `RETURN DISTINCT n.id, rand()`
- two qualified graphs with 5,000 nodes each drain all 20,000 indexed candidates, return one row, merge both graph IDs, and use no match-sized deduplication state

An ABI regression asserts that `Graph.class` has no `nodesByStringProperty` method and that graphs without the optional capability use the generic fallback rather than throwing `AbstractMethodError`.

## Method-level regression

```shell
./gradlew :cypher:jmh \
  -Pjmh.filter='io.johnsonlee.graphite.cypher.CypherBenchmark.*' \
  --no-daemon
```

| Exact `CypherBenchmark` method | `main` | branch |
|---|---:|---:|
| `aggregationCountGroupBy` | 34.443 us/op | 34.449 us/op |
| `countStar` | 2.263 us/op | 2.284 us/op |
| `functionCalls` | 24.868 us/op | 24.683 us/op |
| `nodeMatchWithWhere` | 58.748 us/op | 57.674 us/op |
| `regexFilter` | 23.571 us/op | 24.045 us/op |
| `returnDistinct` | 103.294 us/op | 102.030 us/op |
| `simpleNodeMatch` | 20.418 us/op | 20.417 us/op |
| `singleHopRelationship` | 30.085 us/op | 29.920 us/op |
| `variableLengthPath` | 26.093 us/op | 26.071 us/op |
| `withPipeline` | 76.079 us/op | 76.587 us/op |

The confidence intervals overlap, so there is no measured method-level regression.

## End-to-end and ordinary-query regression

```shell
./gradlew :webgraph:jmh \
  -Pjmh.filter='GraphEndToEndBenchmark.android_build_save_load_query' \
  --no-daemon
```

| Exact benchmark | `main` | branch |
|---|---:|---:|
| `GraphEndToEndBenchmark.android_build_save_load_query` | 30,182.415 ms/op | 23,877.213 ms/op |

This single shot covers Android JAR -> build -> save -> mapped load -> Cypher query and shows no end-to-end regression.

Ordinary `AndroidQueryBenchmark` mapped queries remain in the same sub-millisecond range; all branch and `main` confidence intervals overlap.

| Android mapped query | `main` | branch |
|---|---:|---:|
| count | 0.003 ms/op | 0.002 ms/op |
| int filter | 0.172 ms/op | 0.182 ms/op |
| distinct | 0.171 ms/op | 0.209 ms/op |
| limited node match | 0.070 ms/op | 0.087 ms/op |
| single hop | 0.651 ms/op | 0.653 ms/op |

## Limits

This is query planning and allocation control, not a hard CPU budget. Arbitrary Cypher can still request a large scan. Request deadlines, cooperative cancellation, query cost limits, and a Cypher concurrency bulkhead remain separate availability work.

## Verification

```shell
./gradlew check -S --no-daemon
./gradlew koverLog --rerun-tasks --no-daemon
./gradlew :cypher:test :cypher:detekt :webgraph:test :webgraph:detekt :webgraph:jmhJar --no-daemon
```

All module tests, baseline-aware detekt tasks, JMH compilation, and Kover verification pass. Application line coverage is Core 98.3471%, Cypher 98.0897%, and WebGraph 98.0072%.

Regression tests cover the exact broad query, cross-graph provenance and full-source consumption, unordered mapped candidate deduplication, dynamic-property fallback, ABI fallback, predicate/limit admission bounds, clear/reset behavior, and LRU eviction.
