### PR TITLE
Add PR benchmark regression gate

### DIFF
--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -185,20 +185,56 @@ export function compareJmh(baseResults, candidateResults, threshold = 15) {
     };
 }
 
+export function confirmJmh(initial, confirmation) {
+    const errors = [
+        ...initial.errors,
+        ...confirmation.errors.map((error) => `confirmation: ${error}`)
+    ];
+    const confirmationRows = new Map(confirmation.rows.map((row) => [row.key, row]));
+    const rows = initial.rows.map((row) => {
+        if (!row.blocked) return row;
+        const retry = confirmationRows.get(row.key);
+        if (retry === undefined) {
+            errors.push(`${row.key}: missing from confirmation results`);
+            return row;
+        }
+        return {
+            ...row,
+            confirmation: {
+                baseScore: retry.baseScore,
+                candidateScore: retry.candidateScore,
+                delta: retry.delta,
+                blocked: retry.blocked
+            },
+            blocked: retry.blocked
+        };
+    });
+    return {
+        passed: errors.length === 0 && rows.every((row) => !row.blocked),
+        errors,
+        rows
+    };
+}
+
 export function renderJmhReport(comparison) {
     const lines = [
         "### Method-level JMH",
         "",
-        "A row blocks only when it exceeds the 15% limit and the 99.9% confidence intervals do not overlap.",
+        "A row blocks only when it exceeds the 15% limit, the 99.9% confidence intervals do not overlap,",
+        "and a reverse-order confirmation run fails the same benchmark.",
         "",
-        "| Benchmark | Base | PR | Regression | Limit | Gate |",
-        "|---|---:|---:|---:|---:|:---:|"
+        "| Benchmark | Base | PR | Regression | Confirmation (base -> PR) | Limit | Gate |",
+        "|---|---:|---:|---:|---:|---:|:---:|"
     ];
     for (const row of comparison.rows) {
+        const confirmation = row.confirmation === undefined
+            ? "-"
+            : `${formatScore(row.confirmation.baseScore)} -> ${formatScore(row.confirmation.candidateScore)} ` +
+                `${row.unit} (${formatDelta(row.confirmation.delta)})`;
         lines.push(
             `| \`${shortBenchmarkName(row.key)}\` | ${formatScore(row.baseScore)} ${row.unit} | ` +
             `${formatScore(row.candidateScore)} ${row.unit} | ${formatDelta(row.delta)} | ` +
-            `${row.threshold.toFixed(0)}% | **${statusLabel(row)}** |`
+            `${confirmation} | ${row.threshold.toFixed(0)}% | **${statusLabel(row)}** |`
         );
     }
     if (comparison.errors.length > 0) {
@@ -367,6 +403,19 @@ function compareLargeCorpusCommand(args) {
     if (!comparison.passed) process.exitCode = 1;
 }
 
+function confirmJmhCommand(args) {
+    const initial = readJson(requireArg(args, "initial"));
+    const confirmation = compareJmh(
+        readJson(requireArg(args, "base")),
+        readJson(requireArg(args, "candidate")),
+        Number(args.threshold ?? 15)
+    );
+    const comparison = confirmJmh(initial, confirmation);
+    writeFile(requireArg(args, "report"), renderJmhReport(comparison));
+    writeJson(requireArg(args, "status"), comparison);
+    if (!comparison.passed) process.exitCode = 1;
+}
+
 function aggregateCommand(args) {
     const aggregated = aggregateReports(requireArg(args, "directory"), {
         baseSha: requireArg(args, "base-sha"),
@@ -382,6 +431,7 @@ function main(argv) {
     const args = parseArgs(argv);
     const command = args._[0];
     if (command === "compare-jmh") compareJmhCommand(args);
+    else if (command === "confirm-jmh") confirmJmhCommand(args);
     else if (command === "compare-large-corpus") compareLargeCorpusCommand(args);
     else if (command === "aggregate") aggregateCommand(args);
     else throw new Error(`Unknown command: ${command ?? "<missing>"}`);

--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -14,7 +14,7 @@ const LARGE_CORPUS_METRICS = [
     { key: "mappedLoadMs", label: "mapped load", threshold: 30, minimum: 50, unit: "ms" },
     { key: "queryMs", label: "query", threshold: 25, minimum: 250, unit: "ms" },
     { key: "pipelineMs", label: "pipeline", threshold: 20, minimum: 1_000, unit: "ms" },
-    { key: "peakHeapBytes", label: "peak heap", threshold: 10, minimum: 128 * MIB, unit: "bytes" }
+    { key: "peakHeapBytes", label: "peak heap", unit: "bytes", advisory: true }
 ];
 
 function finiteNumber(value) {
@@ -116,6 +116,7 @@ function formatDelta(delta) {
 }
 
 function statusLabel(row) {
+    if (row.advisory) return "INFO";
     if (row.blocked) return "FAIL";
     if (row.aboveThreshold) return "NOISE";
     return "PASS";
@@ -250,7 +251,9 @@ export function compareLargeCorpus(baseLog, candidateLog) {
             }
             const absoluteIncrease = candidateValue - baseValue;
             const delta = regressionPercent(baseValue, candidateValue, true);
-            const blocked = delta > metric.threshold && absoluteIncrease > metric.minimum;
+            const advisory = metric.advisory === true;
+            const aboveThreshold = !advisory && delta > metric.threshold;
+            const blocked = aboveThreshold && absoluteIncrease > metric.minimum;
             rows.push({
                 corpus,
                 metric: metric.label,
@@ -260,7 +263,8 @@ export function compareLargeCorpus(baseLog, candidateLog) {
                 delta,
                 threshold: metric.threshold,
                 minimum: metric.minimum,
-                aboveThreshold: delta > metric.threshold,
+                advisory,
+                aboveThreshold,
                 blocked
             });
         }
@@ -285,6 +289,7 @@ export function renderLargeCorpusReport(comparison) {
         "",
         "Each corpus runs `JAR -> build -> save -> mapped load -> Cypher` in an isolated 4 GiB JVM.",
         "Small absolute changes below the noise floor do not block.",
+        "Sampled peak heap is informational because its single-run value depends on GC timing; OOM still blocks.",
         "",
         "| Corpus | Metric | Base | PR | Regression | Limit | Gate |",
         "|---|---|---:|---:|---:|---:|:---:|"
@@ -293,7 +298,7 @@ export function renderLargeCorpusReport(comparison) {
         lines.push(
             `| ${row.corpus} | ${row.metric} | ${formatMeasurement(row.baseValue, row.unit)} | ` +
             `${formatMeasurement(row.candidateValue, row.unit)} | ${formatDelta(row.delta)} | ` +
-            `${row.threshold.toFixed(0)}% | **${statusLabel(row)}** |`
+            `${row.advisory ? "4 GiB cap" : `${row.threshold.toFixed(0)}%`} | **${statusLabel(row)}** |`
         );
     }
     if (comparison.errors.length > 0) {

--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -314,6 +314,40 @@ export function compareLargeCorpus(baseLog, candidateLog) {
     };
 }
 
+export function confirmLargeCorpus(initial, confirmation) {
+    const errors = [
+        ...initial.errors,
+        ...confirmation.errors.map((error) => `confirmation: ${error}`)
+    ];
+    const confirmationRows = new Map(
+        confirmation.rows.map((row) => [`${row.corpus}/${row.metric}`, row])
+    );
+    const rows = initial.rows.map((row) => {
+        if (!row.blocked) return row;
+        const key = `${row.corpus}/${row.metric}`;
+        const retry = confirmationRows.get(key);
+        if (retry === undefined) {
+            errors.push(`${key}: missing from confirmation results`);
+            return row;
+        }
+        return {
+            ...row,
+            confirmation: {
+                baseValue: retry.baseValue,
+                candidateValue: retry.candidateValue,
+                delta: retry.delta,
+                blocked: retry.blocked
+            },
+            blocked: retry.blocked
+        };
+    });
+    return {
+        passed: errors.length === 0 && rows.every((row) => !row.blocked),
+        errors,
+        rows
+    };
+}
+
 function formatMeasurement(value, unit) {
     if (unit === "bytes") return `${(value / MIB).toFixed(0)} MiB`;
     return `${Math.round(value).toLocaleString("en-US")} ms`;
@@ -325,16 +359,23 @@ export function renderLargeCorpusReport(comparison) {
         "",
         "Each corpus runs `JAR -> build -> save -> mapped load -> Cypher` in an isolated 4 GiB JVM.",
         "Small absolute changes below the noise floor do not block.",
+        "Suspected timing regressions must repeat in a reverse-order confirmation run.",
         "Sampled peak heap is informational because its single-run value depends on GC timing; OOM still blocks.",
         "",
-        "| Corpus | Metric | Base | PR | Regression | Limit | Gate |",
-        "|---|---|---:|---:|---:|---:|:---:|"
+        "| Corpus | Metric | Base | PR | Regression | Confirmation (base -> PR) | Limit | Gate |",
+        "|---|---|---:|---:|---:|---:|---:|:---:|"
     ];
     for (const row of comparison.rows) {
+        const confirmation = row.confirmation === undefined
+            ? "-"
+            : `${formatMeasurement(row.confirmation.baseValue, row.unit)} -> ` +
+                `${formatMeasurement(row.confirmation.candidateValue, row.unit)} ` +
+                `(${formatDelta(row.confirmation.delta)})`;
         lines.push(
             `| ${row.corpus} | ${row.metric} | ${formatMeasurement(row.baseValue, row.unit)} | ` +
             `${formatMeasurement(row.candidateValue, row.unit)} | ${formatDelta(row.delta)} | ` +
-            `${row.advisory ? "4 GiB cap" : `${row.threshold.toFixed(0)}%`} | **${statusLabel(row)}** |`
+            `${confirmation} | ${row.advisory ? "4 GiB cap" : `${row.threshold.toFixed(0)}%`} | ` +
+            `**${statusLabel(row)}** |`
         );
     }
     if (comparison.errors.length > 0) {
@@ -416,6 +457,18 @@ function confirmJmhCommand(args) {
     if (!comparison.passed) process.exitCode = 1;
 }
 
+function confirmLargeCorpusCommand(args) {
+    const initial = readJson(requireArg(args, "initial"));
+    const confirmation = compareLargeCorpus(
+        fs.readFileSync(requireArg(args, "base"), "utf8"),
+        fs.readFileSync(requireArg(args, "candidate"), "utf8")
+    );
+    const comparison = confirmLargeCorpus(initial, confirmation);
+    writeFile(requireArg(args, "report"), renderLargeCorpusReport(comparison));
+    writeJson(requireArg(args, "status"), comparison);
+    if (!comparison.passed) process.exitCode = 1;
+}
+
 function aggregateCommand(args) {
     const aggregated = aggregateReports(requireArg(args, "directory"), {
         baseSha: requireArg(args, "base-sha"),
@@ -433,6 +486,7 @@ function main(argv) {
     if (command === "compare-jmh") compareJmhCommand(args);
     else if (command === "confirm-jmh") confirmJmhCommand(args);
     else if (command === "compare-large-corpus") compareLargeCorpusCommand(args);
+    else if (command === "confirm-large-corpus") confirmLargeCorpusCommand(args);
     else if (command === "aggregate") aggregateCommand(args);
     else throw new Error(`Unknown command: ${command ?? "<missing>"}`);
 }

--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+export const COMMENT_MARKER = "<!-- graphite-benchmark-regression-gate -->";
+
+const MIB = 1024 * 1024;
+const LARGE_CORPUS_METRICS = [
+    { key: "buildMs", label: "build", threshold: 20, minimum: 500, unit: "ms" },
+    { key: "saveMs", label: "save", threshold: 25, minimum: 250, unit: "ms" },
+    { key: "mappedLoadMs", label: "mapped load", threshold: 30, minimum: 50, unit: "ms" },
+    { key: "queryMs", label: "query", threshold: 25, minimum: 250, unit: "ms" },
+    { key: "pipelineMs", label: "pipeline", threshold: 20, minimum: 1_000, unit: "ms" },
+    { key: "peakHeapBytes", label: "peak heap", threshold: 10, minimum: 128 * MIB, unit: "bytes" }
+];
+
+function finiteNumber(value) {
+    if (value === null || value === undefined || value === "") return null;
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+}
+
+function parseArgs(argv) {
+    const args = { _: [] };
+    for (let index = 0; index < argv.length; index++) {
+        const argument = argv[index];
+        if (!argument.startsWith("--")) {
+            args._.push(argument);
+            continue;
+        }
+        const name = argument.slice(2);
+        const value = argv[index + 1];
+        if (value === undefined || value.startsWith("--")) {
+            args[name] = true;
+        } else {
+            args[name] = value;
+            index++;
+        }
+    }
+    return args;
+}
+
+function requireArg(args, name) {
+    const value = args[name];
+    if (typeof value !== "string" || value.length === 0) {
+        throw new Error(`Missing --${name}`);
+    }
+    return value;
+}
+
+function readJson(file) {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeFile(file, contents) {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+}
+
+function writeJson(file, value) {
+    writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function benchmarkKey(result) {
+    const parameters = Object.entries(result.params ?? {})
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, value]) => `${name}=${value}`)
+        .join(",");
+    return parameters.length === 0 ? result.benchmark : `${result.benchmark}[${parameters}]`;
+}
+
+function shortBenchmarkName(name) {
+    return name
+        .replace(/^io\.johnsonlee\.graphite\./, "")
+        .replace(/\|/g, "\\|");
+}
+
+function confidenceBounds(metric) {
+    if (!Array.isArray(metric.scoreConfidence) || metric.scoreConfidence.length !== 2) return null;
+    const lower = finiteNumber(metric.scoreConfidence[0]);
+    const upper = finiteNumber(metric.scoreConfidence[1]);
+    return lower !== null && upper !== null && lower <= upper ? [lower, upper] : null;
+}
+
+function isLowerBetter(mode) {
+    return ["avgt", "sample", "ss"].includes(String(mode).toLowerCase());
+}
+
+function regressionPercent(baseScore, candidateScore, lowerIsBetter) {
+    if (baseScore <= 0) return Number.POSITIVE_INFINITY;
+    return lowerIsBetter
+        ? ((candidateScore / baseScore) - 1) * 100
+        : (1 - (candidateScore / baseScore)) * 100;
+}
+
+function confidenceSeparates(baseBounds, candidateBounds, lowerIsBetter) {
+    if (baseBounds === null || candidateBounds === null) return true;
+    return lowerIsBetter
+        ? candidateBounds[0] > baseBounds[1]
+        : candidateBounds[1] < baseBounds[0];
+}
+
+function formatScore(score) {
+    if (!Number.isFinite(score)) return "n/a";
+    if (Math.abs(score) >= 1_000) return score.toFixed(1);
+    if (Math.abs(score) >= 1) return score.toFixed(3);
+    return score.toFixed(4);
+}
+
+function formatDelta(delta) {
+    if (!Number.isFinite(delta)) return "n/a";
+    return `${delta >= 0 ? "+" : ""}${delta.toFixed(1)}%`;
+}
+
+function statusLabel(row) {
+    if (row.blocked) return "FAIL";
+    if (row.aboveThreshold) return "NOISE";
+    return "PASS";
+}
+
+export function compareJmh(baseResults, candidateResults, threshold = 15) {
+    const errors = [];
+    const base = new Map();
+    const candidate = new Map();
+    for (const result of baseResults) base.set(benchmarkKey(result), result);
+    for (const result of candidateResults) candidate.set(benchmarkKey(result), result);
+
+    const allKeys = [...new Set([...base.keys(), ...candidate.keys()])].sort();
+    const rows = [];
+    for (const key of allKeys) {
+        const baseline = base.get(key);
+        const current = candidate.get(key);
+        if (baseline === undefined || current === undefined) {
+            errors.push(`${key}: missing from ${baseline === undefined ? "base" : "candidate"} results`);
+            continue;
+        }
+
+        const baseMetric = baseline.primaryMetric ?? {};
+        const candidateMetric = current.primaryMetric ?? {};
+        const baseScore = finiteNumber(baseMetric.score);
+        const candidateScore = finiteNumber(candidateMetric.score);
+        if (baseScore === null || candidateScore === null || baseScore <= 0 || candidateScore < 0) {
+            errors.push(`${key}: invalid score`);
+            continue;
+        }
+        if (baseline.mode !== current.mode || baseMetric.scoreUnit !== candidateMetric.scoreUnit) {
+            errors.push(`${key}: base and candidate use different mode or unit`);
+            continue;
+        }
+
+        const lowerBetter = isLowerBetter(baseline.mode);
+        if (!lowerBetter && String(baseline.mode).toLowerCase() !== "thrpt") {
+            errors.push(`${key}: unsupported JMH mode ${baseline.mode}`);
+            continue;
+        }
+        const delta = regressionPercent(baseScore, candidateScore, lowerBetter);
+        const aboveThreshold = delta > threshold;
+        const separated = confidenceSeparates(
+            confidenceBounds(baseMetric),
+            confidenceBounds(candidateMetric),
+            lowerBetter
+        );
+        rows.push({
+            key,
+            baseScore,
+            candidateScore,
+            unit: baseMetric.scoreUnit,
+            delta,
+            threshold,
+            aboveThreshold,
+            confidenceSeparated: separated,
+            blocked: aboveThreshold && separated
+        });
+    }
+
+    if (rows.length === 0) errors.push("No comparable JMH benchmarks were found");
+    return {
+        passed: errors.length === 0 && rows.every((row) => !row.blocked),
+        errors,
+        rows
+    };
+}
+
+export function renderJmhReport(comparison) {
+    const lines = [
+        "### Method-level JMH",
+        "",
+        "A row blocks only when it exceeds the 15% limit and the 99.9% confidence intervals do not overlap.",
+        "",
+        "| Benchmark | Base | PR | Regression | Limit | Gate |",
+        "|---|---:|---:|---:|---:|:---:|"
+    ];
+    for (const row of comparison.rows) {
+        lines.push(
+            `| \`${shortBenchmarkName(row.key)}\` | ${formatScore(row.baseScore)} ${row.unit} | ` +
+            `${formatScore(row.candidateScore)} ${row.unit} | ${formatDelta(row.delta)} | ` +
+            `${row.threshold.toFixed(0)}% | **${statusLabel(row)}** |`
+        );
+    }
+    if (comparison.errors.length > 0) {
+        lines.push("", "Errors:", ...comparison.errors.map((error) => `- ${error}`));
+    }
+    return `${lines.join("\n")}\n`;
+}
+
+export function parseLargeCorpusLog(contents) {
+    const results = new Map();
+    for (const line of contents.split(/\r?\n/)) {
+        const marker = line.indexOf("LARGE_CORPUS_BASELINE");
+        if (marker < 0) continue;
+        const tokens = line.slice(marker).trim().split(/\s+/);
+        if (tokens.length < 3) continue;
+        const corpus = tokens[1];
+        const measurement = { corpus };
+        for (const token of tokens.slice(2)) {
+            const separator = token.indexOf("=");
+            if (separator < 1) continue;
+            const name = token.slice(0, separator);
+            const value = finiteNumber(token.slice(separator + 1));
+            if (value !== null) measurement[name] = value;
+        }
+        results.set(corpus, measurement);
+    }
+    return results;
+}
+
+export function compareLargeCorpus(baseLog, candidateLog) {
+    const base = parseLargeCorpusLog(baseLog);
+    const candidate = parseLargeCorpusLog(candidateLog);
+    const errors = [];
+    const rows = [];
+    const corpora = [...new Set([...base.keys(), ...candidate.keys()])].sort();
+
+    for (const corpus of corpora) {
+        const baseline = base.get(corpus);
+        const current = candidate.get(corpus);
+        if (baseline === undefined || current === undefined) {
+            errors.push(`${corpus}: missing from ${baseline === undefined ? "base" : "candidate"} results`);
+            continue;
+        }
+        for (const metric of LARGE_CORPUS_METRICS) {
+            const baseValue = finiteNumber(baseline[metric.key]);
+            const candidateValue = finiteNumber(current[metric.key]);
+            if (baseValue === null || candidateValue === null || baseValue <= 0 || candidateValue < 0) {
+                errors.push(`${corpus}/${metric.label}: invalid measurement`);
+                continue;
+            }
+            const absoluteIncrease = candidateValue - baseValue;
+            const delta = regressionPercent(baseValue, candidateValue, true);
+            const blocked = delta > metric.threshold && absoluteIncrease > metric.minimum;
+            rows.push({
+                corpus,
+                metric: metric.label,
+                baseValue,
+                candidateValue,
+                unit: metric.unit,
+                delta,
+                threshold: metric.threshold,
+                minimum: metric.minimum,
+                aboveThreshold: delta > metric.threshold,
+                blocked
+            });
+        }
+    }
+
+    if (corpora.length === 0) errors.push("No large-corpus measurements were found");
+    return {
+        passed: errors.length === 0 && rows.every((row) => !row.blocked),
+        errors,
+        rows
+    };
+}
+
+function formatMeasurement(value, unit) {
+    if (unit === "bytes") return `${(value / MIB).toFixed(0)} MiB`;
+    return `${Math.round(value).toLocaleString("en-US")} ms`;
+}
+
+export function renderLargeCorpusReport(comparison) {
+    const lines = [
+        "### Real-corpus end to end",
+        "",
+        "Each corpus runs `JAR -> build -> save -> mapped load -> Cypher` in an isolated 4 GiB JVM.",
+        "Small absolute changes below the noise floor do not block.",
+        "",
+        "| Corpus | Metric | Base | PR | Regression | Limit | Gate |",
+        "|---|---|---:|---:|---:|---:|:---:|"
+    ];
+    for (const row of comparison.rows) {
+        lines.push(
+            `| ${row.corpus} | ${row.metric} | ${formatMeasurement(row.baseValue, row.unit)} | ` +
+            `${formatMeasurement(row.candidateValue, row.unit)} | ${formatDelta(row.delta)} | ` +
+            `${row.threshold.toFixed(0)}% | **${statusLabel(row)}** |`
+        );
+    }
+    if (comparison.errors.length > 0) {
+        lines.push("", "Errors:", ...comparison.errors.map((error) => `- ${error}`));
+    }
+    return `${lines.join("\n")}\n`;
+}
+
+export function aggregateReports(directory, metadata) {
+    const components = [
+        { name: "method-level", report: "method-report.md", status: "method-status.json" },
+        { name: "large-corpus", report: "large-corpus-report.md", status: "large-corpus-status.json" }
+    ];
+    const errors = [];
+    const reports = [];
+    let passed = true;
+    for (const component of components) {
+        const reportFile = path.join(directory, component.report);
+        const statusFile = path.join(directory, component.status);
+        if (!fs.existsSync(reportFile) || !fs.existsSync(statusFile)) {
+            errors.push(`${component.name}: result artifact is missing`);
+            passed = false;
+            continue;
+        }
+        reports.push(fs.readFileSync(reportFile, "utf8").trim());
+        const status = readJson(statusFile);
+        if (status.passed !== true) passed = false;
+    }
+
+    const result = passed && errors.length === 0 ? "PASS" : "FAIL";
+    const body = [
+        COMMENT_MARKER,
+        "## Benchmark Regression Gate",
+        "",
+        `**${result}**`,
+        "",
+        `Base: \`${metadata.baseSha.slice(0, 12)}\`  `,
+        `PR: \`${metadata.candidateSha.slice(0, 12)}\`  `,
+        `Runner: \`${metadata.runner}\``,
+        "",
+        ...reports.flatMap((report) => [report, ""]),
+        ...(errors.length > 0 ? ["### Infrastructure errors", "", ...errors.map((error) => `- ${error}`), ""] : []),
+        `[View benchmark logs and artifacts](${metadata.runUrl})`
+    ].join("\n");
+    return { passed: result === "PASS", errors, body: `${body}\n` };
+}
+
+function compareJmhCommand(args) {
+    const comparison = compareJmh(
+        readJson(requireArg(args, "base")),
+        readJson(requireArg(args, "candidate")),
+        Number(args.threshold ?? 15)
+    );
+    writeFile(requireArg(args, "report"), renderJmhReport(comparison));
+    writeJson(requireArg(args, "status"), comparison);
+    if (!comparison.passed) process.exitCode = 1;
+}
+
+function compareLargeCorpusCommand(args) {
+    const comparison = compareLargeCorpus(
+        fs.readFileSync(requireArg(args, "base"), "utf8"),
+        fs.readFileSync(requireArg(args, "candidate"), "utf8")
+    );
+    writeFile(requireArg(args, "report"), renderLargeCorpusReport(comparison));
+    writeJson(requireArg(args, "status"), comparison);
+    if (!comparison.passed) process.exitCode = 1;
+}
+
+function aggregateCommand(args) {
+    const aggregated = aggregateReports(requireArg(args, "directory"), {
+        baseSha: requireArg(args, "base-sha"),
+        candidateSha: requireArg(args, "candidate-sha"),
+        runner: requireArg(args, "runner"),
+        runUrl: requireArg(args, "run-url")
+    });
+    writeFile(requireArg(args, "report"), aggregated.body);
+    writeJson(requireArg(args, "status"), aggregated);
+}
+
+function main(argv) {
+    const args = parseArgs(argv);
+    const command = args._[0];
+    if (command === "compare-jmh") compareJmhCommand(args);
+    else if (command === "compare-large-corpus") compareLargeCorpusCommand(args);
+    else if (command === "aggregate") aggregateCommand(args);
+    else throw new Error(`Unknown command: ${command ?? "<missing>"}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        main(process.argv.slice(2));
+    } catch (error) {
+        console.error(error instanceof Error ? error.stack : String(error));
+        process.exitCode = 1;
+    }
+}

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
     COMMENT_MARKER,
     aggregateReports,
+    confirmLargeCorpus,
     confirmJmh,
     compareJmh,
     compareLargeCorpus,
@@ -165,6 +166,30 @@ test("large-corpus comparison reports sampled heap without blocking on GC noise"
     assert.equal(heap.advisory, true);
     assert.equal(heap.blocked, false);
     assert.match(renderLargeCorpusReport(comparison), /4 GiB cap \| \*\*INFO\*\*/);
+});
+
+test("large-corpus reverse-order confirmation rejects a one-round false positive", () => {
+    const initialCandidate = baseCorpusLine.replace("saveMs=2000", "saveMs=3000");
+    const initial = compareLargeCorpus(baseCorpusLine, initialCandidate);
+    const retryCandidate = baseCorpusLine.replace("saveMs=2000", "saveMs=2100");
+    const retry = compareLargeCorpus(baseCorpusLine, retryCandidate);
+    const confirmed = confirmLargeCorpus(initial, retry);
+
+    assert.equal(initial.passed, false);
+    assert.equal(confirmed.passed, true);
+    assert.equal(confirmed.rows.find((row) => row.metric === "save").blocked, false);
+    assert.match(renderLargeCorpusReport(confirmed), /\*\*NOISE\*\*/);
+});
+
+test("large-corpus reverse-order confirmation blocks a repeated regression", () => {
+    const candidate = baseCorpusLine.replace("saveMs=2000", "saveMs=3000");
+    const initial = compareLargeCorpus(baseCorpusLine, candidate);
+    const retry = compareLargeCorpus(baseCorpusLine, candidate);
+    const confirmed = confirmLargeCorpus(initial, retry);
+
+    assert.equal(confirmed.passed, false);
+    assert.equal(confirmed.rows.find((row) => row.metric === "save").blocked, true);
+    assert.match(renderLargeCorpusReport(confirmed), /\*\*FAIL\*\*/);
 });
 
 test("aggregate report fails closed when an artifact is missing", () => {

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -116,6 +116,20 @@ test("large-corpus comparison ignores changes below the absolute noise floor", (
     assert.equal(comparison.rows.find((row) => row.metric === "mapped load").blocked, false);
 });
 
+test("large-corpus comparison reports sampled heap without blocking on GC noise", () => {
+    const candidate = baseCorpusLine.replace(
+        `peakHeapBytes=${2_000 * 1024 * 1024}`,
+        `peakHeapBytes=${3_500 * 1024 * 1024}`
+    );
+    const comparison = compareLargeCorpus(baseCorpusLine, candidate);
+    const heap = comparison.rows.find((row) => row.metric === "peak heap");
+
+    assert.equal(comparison.passed, true);
+    assert.equal(heap.advisory, true);
+    assert.equal(heap.blocked, false);
+    assert.match(renderLargeCorpusReport(comparison), /4 GiB cap \| \*\*INFO\*\*/);
+});
+
 test("aggregate report fails closed when an artifact is missing", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "benchmark-gate-test-"));
     try {

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+    COMMENT_MARKER,
+    aggregateReports,
+    compareJmh,
+    compareLargeCorpus,
+    parseLargeCorpusLog,
+    renderJmhReport,
+    renderLargeCorpusReport
+} from "./benchmark-gate.mjs";
+
+function jmhResult({
+    benchmark = "io.johnsonlee.graphite.cypher.CypherBenchmark.query",
+    mode = "avgt",
+    score,
+    confidence,
+    unit = "us/op"
+}) {
+    return {
+        benchmark,
+        mode,
+        primaryMetric: {
+            score,
+            scoreConfidence: confidence,
+            scoreUnit: unit
+        }
+    };
+}
+
+test("JMH comparison blocks a separated latency regression", () => {
+    const comparison = compareJmh(
+        [jmhResult({ score: 100, confidence: [95, 105] })],
+        [jmhResult({ score: 125, confidence: [120, 130] })],
+        15
+    );
+
+    assert.equal(comparison.passed, false);
+    assert.equal(comparison.rows[0].blocked, true);
+    assert.match(renderJmhReport(comparison), /\*\*FAIL\*\*/);
+});
+
+test("JMH comparison does not block overlapping confidence intervals", () => {
+    const comparison = compareJmh(
+        [jmhResult({ score: 100, confidence: [80, 120] })],
+        [jmhResult({ score: 125, confidence: [110, 140] })],
+        15
+    );
+
+    assert.equal(comparison.passed, true);
+    assert.equal(comparison.rows[0].aboveThreshold, true);
+    assert.equal(comparison.rows[0].blocked, false);
+    assert.match(renderJmhReport(comparison), /\*\*NOISE\*\*/);
+});
+
+test("JMH throughput regression uses higher-is-better semantics", () => {
+    const comparison = compareJmh(
+        [jmhResult({ mode: "thrpt", score: 1_000, confidence: [980, 1_020], unit: "ops/s" })],
+        [jmhResult({ mode: "thrpt", score: 700, confidence: [680, 720], unit: "ops/s" })],
+        15
+    );
+
+    assert.equal(comparison.passed, false);
+    assert.equal(Math.round(comparison.rows[0].delta), 30);
+});
+
+test("JMH comparison fails when a benchmark is missing", () => {
+    const comparison = compareJmh(
+        [jmhResult({ score: 100, confidence: [95, 105] })],
+        [],
+        15
+    );
+
+    assert.equal(comparison.passed, false);
+    assert.match(comparison.errors[0], /missing from candidate/);
+});
+
+const baseCorpusLine = [
+    "LARGE_CORPUS_BASELINE",
+    "hive",
+    "nodes=100",
+    "buildMs=10000",
+    "saveMs=2000",
+    "mappedLoadMs=200",
+    "queryMs=1000",
+    "pipelineMs=13200",
+    `peakHeapBytes=${2_000 * 1024 * 1024}`
+].join("\t");
+
+test("large-corpus parser accepts Gradle-prefixed output", () => {
+    const parsed = parseLargeCorpusLog(`runner prefix ${baseCorpusLine}\n`);
+
+    assert.equal(parsed.get("hive").buildMs, 10_000);
+    assert.equal(parsed.get("hive").nodes, 100);
+});
+
+test("large-corpus comparison blocks a material pipeline regression", () => {
+    const candidate = baseCorpusLine
+        .replace("pipelineMs=13200", "pipelineMs=17000")
+        .replace("buildMs=10000", "buildMs=13000");
+    const comparison = compareLargeCorpus(baseCorpusLine, candidate);
+
+    assert.equal(comparison.passed, false);
+    assert.equal(comparison.rows.find((row) => row.metric === "pipeline").blocked, true);
+    assert.match(renderLargeCorpusReport(comparison), /\*\*FAIL\*\*/);
+});
+
+test("large-corpus comparison ignores changes below the absolute noise floor", () => {
+    const candidate = baseCorpusLine.replace("mappedLoadMs=200", "mappedLoadMs=250");
+    const comparison = compareLargeCorpus(baseCorpusLine, candidate);
+
+    assert.equal(comparison.passed, true);
+    assert.equal(comparison.rows.find((row) => row.metric === "mapped load").blocked, false);
+});
+
+test("aggregate report fails closed when an artifact is missing", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "benchmark-gate-test-"));
+    try {
+        fs.writeFileSync(path.join(directory, "method-report.md"), "method report\n");
+        fs.writeFileSync(path.join(directory, "method-status.json"), JSON.stringify({ passed: true }));
+        const aggregate = aggregateReports(directory, {
+            baseSha: "a".repeat(40),
+            candidateSha: "b".repeat(40),
+            runner: "test-runner",
+            runUrl: "https://example.invalid/run"
+        });
+
+        assert.equal(aggregate.passed, false);
+        assert.match(aggregate.body, new RegExp(COMMENT_MARKER));
+        assert.match(aggregate.body, /large-corpus: result artifact is missing/);
+    } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+});

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
     COMMENT_MARKER,
     aggregateReports,
+    confirmJmh,
     compareJmh,
     compareLargeCorpus,
     parseLargeCorpusLog,
@@ -76,6 +77,42 @@ test("JMH comparison fails when a benchmark is missing", () => {
 
     assert.equal(comparison.passed, false);
     assert.match(comparison.errors[0], /missing from candidate/);
+});
+
+test("JMH reverse-order confirmation rejects a one-round false positive", () => {
+    const initial = compareJmh(
+        [jmhResult({ score: 100, confidence: [98, 102] })],
+        [jmhResult({ score: 125, confidence: [123, 127] })],
+        15
+    );
+    const retry = compareJmh(
+        [jmhResult({ score: 110, confidence: [108, 112] })],
+        [jmhResult({ score: 111, confidence: [109, 113] })],
+        15
+    );
+    const confirmed = confirmJmh(initial, retry);
+
+    assert.equal(confirmed.passed, true);
+    assert.equal(confirmed.rows[0].blocked, false);
+    assert.match(renderJmhReport(confirmed), /\*\*NOISE\*\*/);
+});
+
+test("JMH reverse-order confirmation blocks a repeated regression", () => {
+    const initial = compareJmh(
+        [jmhResult({ score: 100, confidence: [98, 102] })],
+        [jmhResult({ score: 125, confidence: [123, 127] })],
+        15
+    );
+    const retry = compareJmh(
+        [jmhResult({ score: 102, confidence: [100, 104] })],
+        [jmhResult({ score: 128, confidence: [126, 130] })],
+        15
+    );
+    const confirmed = confirmJmh(initial, retry);
+
+    assert.equal(confirmed.passed, false);
+    assert.equal(confirmed.rows[0].blocked, true);
+    assert.match(renderJmhReport(confirmed), /\*\*FAIL\*\*/);
 });
 
 const baseCorpusLine = [

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,12 +73,31 @@ jobs:
 
     - name: Compare method-level results
       run: |
-        node candidate/.github/scripts/benchmark-gate.mjs compare-jmh \
+        if node candidate/.github/scripts/benchmark-gate.mjs compare-jmh \
           --base benchmark-results/base-jmh.json \
           --candidate benchmark-results/candidate-jmh.json \
           --threshold 15 \
-          --report benchmark-results/method-report.md \
-          --status benchmark-results/method-status.json
+          --report benchmark-results/initial-method-report.md \
+          --status benchmark-results/initial-method-status.json; then
+          mv benchmark-results/initial-method-report.md benchmark-results/method-report.md
+          mv benchmark-results/initial-method-status.json benchmark-results/method-status.json
+        else
+          CANDIDATE_JAR=$(find candidate/graphite-cypher/build/libs -name '*-jmh.jar' -print -quit)
+          BASE_JAR=$(find base/graphite-cypher/build/libs -name '*-jmh.jar' -print -quit)
+          java -jar "${CANDIDATE_JAR}" \
+            'io.johnsonlee.graphite.cypher.CypherBenchmark.*' \
+            -foe true -rf json -rff "${PWD}/benchmark-results/candidate-jmh-confirmation.json"
+          java -jar "${BASE_JAR}" \
+            'io.johnsonlee.graphite.cypher.CypherBenchmark.*' \
+            -foe true -rf json -rff "${PWD}/benchmark-results/base-jmh-confirmation.json"
+          node candidate/.github/scripts/benchmark-gate.mjs confirm-jmh \
+            --initial benchmark-results/initial-method-status.json \
+            --base benchmark-results/base-jmh-confirmation.json \
+            --candidate benchmark-results/candidate-jmh-confirmation.json \
+            --threshold 15 \
+            --report benchmark-results/method-report.md \
+            --status benchmark-results/method-status.json
+        fi
 
     - name: Upload method-level results
       if: always()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,231 @@
+name: Benchmark regression
+
+on:
+  pull_request:
+    branches: ['*']
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  JAVA_OPTS: -Xmx2g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
+  JVM_OPTS: -Xmx2g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
+
+jobs:
+  method-level:
+    name: method-level-benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - name: Checkout base
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+
+    - name: Checkout PR
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: candidate
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Test benchmark gate logic
+      run: node --test candidate/.github/scripts/benchmark-gate.test.mjs
+
+    - name: Build JMH jars
+      run: |
+        base/gradlew -p base :cypher:jmhJar --no-daemon
+        candidate/gradlew -p candidate :cypher:jmhJar --no-daemon
+
+    - name: Benchmark base
+      run: |
+        mkdir -p benchmark-results
+        JMH_JAR=$(find base/graphite-cypher/build/libs -name '*-jmh.jar' -print -quit)
+        test -n "${JMH_JAR}"
+        java -jar "${JMH_JAR}" \
+          'io.johnsonlee.graphite.cypher.CypherBenchmark.*' \
+          -foe true -rf json -rff "${PWD}/benchmark-results/base-jmh.json"
+
+    - name: Benchmark PR
+      run: |
+        JMH_JAR=$(find candidate/graphite-cypher/build/libs -name '*-jmh.jar' -print -quit)
+        test -n "${JMH_JAR}"
+        java -jar "${JMH_JAR}" \
+          'io.johnsonlee.graphite.cypher.CypherBenchmark.*' \
+          -foe true -rf json -rff "${PWD}/benchmark-results/candidate-jmh.json"
+
+    - name: Compare method-level results
+      run: |
+        node candidate/.github/scripts/benchmark-gate.mjs compare-jmh \
+          --base benchmark-results/base-jmh.json \
+          --candidate benchmark-results/candidate-jmh.json \
+          --threshold 15 \
+          --report benchmark-results/method-report.md \
+          --status benchmark-results/method-status.json
+
+    - name: Upload method-level results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-method-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        path: benchmark-results/
+        if-no-files-found: warn
+        retention-days: 14
+
+  large-corpus:
+    name: large-corpus-benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout base
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+
+    - name: Checkout PR
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: candidate
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Benchmark PR large corpora
+      run: |
+        set -o pipefail
+        mkdir -p benchmark-results
+        candidate/gradlew -p candidate :webgraph:largeCorpusTest \
+          -Dlarge.corpus.record=true --no-daemon 2>&1 \
+          | tee benchmark-results/candidate-large-corpus.log
+
+    - name: Benchmark base large corpora
+      run: |
+        set -o pipefail
+        base/gradlew -p base :webgraph:largeCorpusTest \
+          -Dlarge.corpus.record=true --no-daemon 2>&1 \
+          | tee benchmark-results/base-large-corpus.log
+
+    - name: Compare large-corpus results
+      run: |
+        node candidate/.github/scripts/benchmark-gate.mjs compare-large-corpus \
+          --base benchmark-results/base-large-corpus.log \
+          --candidate benchmark-results/candidate-large-corpus.log \
+          --report benchmark-results/large-corpus-report.md \
+          --status benchmark-results/large-corpus-status.json
+
+    - name: Upload large-corpus results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-large-corpus-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        path: benchmark-results/
+        if-no-files-found: warn
+        retention-days: 14
+
+  benchmark-regression-gate:
+    name: benchmark-regression-gate
+    if: always()
+    needs: [method-level, large-corpus]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout PR reporting code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Download benchmark results
+      continue-on-error: true
+      uses: actions/download-artifact@v4
+      with:
+        pattern: benchmark-*-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        path: benchmark-results
+        merge-multiple: true
+
+    - name: Build benchmark report
+      if: always()
+      run: |
+        mkdir -p benchmark-results
+        node .github/scripts/benchmark-gate.mjs aggregate \
+          --directory benchmark-results \
+          --base-sha '${{ github.event.pull_request.base.sha }}' \
+          --candidate-sha '${{ github.event.pull_request.head.sha }}' \
+          --runner '${{ runner.os }}-${{ runner.arch }}' \
+          --run-url '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+          --report benchmark-results/benchmark-report.md \
+          --status benchmark-results/benchmark-status.json
+
+    - name: Attach benchmark report to PR
+      if: always()
+      continue-on-error: true
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const marker = '<!-- graphite-benchmark-regression-gate -->';
+          let body;
+          try {
+            body = fs.readFileSync('benchmark-results/benchmark-report.md', 'utf8');
+          } catch (error) {
+            body = `${marker}\n## Benchmark Regression Gate\n\n**FAIL**\n\nReport generation failed. ` +
+              `[View logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+          }
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            per_page: 100
+          });
+          const existing = comments.find((comment) => comment.body.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });
+          }
+
+    - name: Enforce benchmark gate
+      if: always()
+      env:
+        METHOD_JOB: ${{ needs.method-level.result }}
+        LARGE_CORPUS_JOB: ${{ needs.large-corpus.result }}
+      run: |
+        if [ "${METHOD_JOB}" != success ] || [ "${LARGE_CORPUS_JOB}" != success ]; then
+          echo "::error::Benchmark execution or comparison failed"
+          exit 1
+        fi
+        node -e "const s=require('./benchmark-results/benchmark-status.json'); if(!s.passed) process.exit(1)"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,25 +24,27 @@ jobs:
 
     steps:
     - name: Checkout base
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.base.sha }}
         path: base
 
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: candidate
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: '17'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-read-only: true
 
     - name: Test benchmark gate logic
       run: node --test candidate/.github/scripts/benchmark-gate.test.mjs
@@ -80,7 +82,7 @@ jobs:
 
     - name: Upload method-level results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: benchmark-method-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
         path: benchmark-results/
@@ -94,25 +96,27 @@ jobs:
 
     steps:
     - name: Checkout base
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.base.sha }}
         path: base
 
     - name: Checkout PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: candidate
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: '17'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-read-only: true
 
     - name: Benchmark PR large corpora
       run: |
@@ -139,7 +143,7 @@ jobs:
 
     - name: Upload large-corpus results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: benchmark-large-corpus-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
         path: benchmark-results/
@@ -154,13 +158,13 @@ jobs:
 
     steps:
     - name: Checkout PR reporting code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Download benchmark results
       continue-on-error: true
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: benchmark-*-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
         path: benchmark-results
@@ -182,7 +186,7 @@ jobs:
     - name: Attach benchmark report to PR
       if: always()
       continue-on-error: true
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -154,11 +154,28 @@ jobs:
 
     - name: Compare large-corpus results
       run: |
-        node candidate/.github/scripts/benchmark-gate.mjs compare-large-corpus \
+        if node candidate/.github/scripts/benchmark-gate.mjs compare-large-corpus \
           --base benchmark-results/base-large-corpus.log \
           --candidate benchmark-results/candidate-large-corpus.log \
-          --report benchmark-results/large-corpus-report.md \
-          --status benchmark-results/large-corpus-status.json
+          --report benchmark-results/initial-large-corpus-report.md \
+          --status benchmark-results/initial-large-corpus-status.json; then
+          mv benchmark-results/initial-large-corpus-report.md benchmark-results/large-corpus-report.md
+          mv benchmark-results/initial-large-corpus-status.json benchmark-results/large-corpus-status.json
+        else
+          set -o pipefail
+          base/gradlew -p base :webgraph:largeCorpusTest \
+            -Dlarge.corpus.record=true --no-daemon 2>&1 \
+            | tee benchmark-results/base-large-corpus-confirmation.log
+          candidate/gradlew -p candidate :webgraph:largeCorpusTest \
+            -Dlarge.corpus.record=true --no-daemon 2>&1 \
+            | tee benchmark-results/candidate-large-corpus-confirmation.log
+          node candidate/.github/scripts/benchmark-gate.mjs confirm-large-corpus \
+            --initial benchmark-results/initial-large-corpus-status.json \
+            --base benchmark-results/base-large-corpus-confirmation.log \
+            --candidate benchmark-results/candidate-large-corpus-confirmation.log \
+            --report benchmark-results/large-corpus-report.md \
+            --status benchmark-results/large-corpus-status.json
+        fi
 
     - name: Upload large-corpus results
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,16 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
         java-version: '17'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build
       run: |
@@ -43,7 +46,7 @@ jobs:
 
     - name: Comment coverage on PR
       if: success() && github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');
@@ -112,10 +115,12 @@ jobs:
         MODULE=""
         while IFS= read -r line; do
           if [[ "$line" == *":koverPrintCoverage"* ]]; then
-            MODULE=$(echo "$line" | sed 's/.*> Task :\(.*\):koverPrintCoverage.*/\1/')
+            MODULE=${line#*> Task :}
+            MODULE=${MODULE%:koverPrintCoverage*}
           fi
           if [[ "$line" == *"application line coverage:"* ]]; then
-            PCT=$(echo "$line" | sed 's/.*coverage: \([0-9.]*\)%.*/\1/')
+            PCT=${line#*coverage: }
+            PCT=${PCT%%\%*}
             if awk "BEGIN{exit !($PCT < 98)}"; then
               echo "::error::Module $MODULE coverage is ${PCT}%, below 98% threshold"
               FAILED=true
@@ -129,7 +134,7 @@ jobs:
 
     - name: Comment build failure on PR
       if: failure() && github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -10,11 +10,11 @@
 ## Verification and Benchmarks
 
 - After fixing or tightening unit tests for a performance-sensitive path, rerun the relevant module tests and lint gate.
-- Every PR body must include benchmark testing results.
-- Benchmark evidence in the PR body must include the benchmark command, environment summary, exact benchmark names, result table, and a comparison against `main`.
-- The PR body must include both method-level and end-to-end benchmark data.
+- Every PR must pass the required `benchmark-regression-gate` check. The check runs the base and PR revisions on the same GitHub runner and updates a benchmark result comment on the PR.
+- The benchmark comment is the standard method-level and end-to-end evidence. A PR body may link to it instead of copying the same tables.
+- Additional benchmark evidence in a PR body must include the benchmark command, environment summary, exact benchmark names, result table, and a comparison against `main`.
 - Method-level benchmark data must come from the most relevant JMH class for the touched code. For Cypher query changes, include `CypherBenchmark`.
-- End-to-end benchmark data must include `GraphEndToEndBenchmark`, which covers `JAR -> build -> save -> mapped load -> Cypher query`.
+- Automated end-to-end data comes from `LargeCorpusPerformanceGateTest`, which covers `JAR -> build -> save -> mapped load -> Cypher query`; targeted manual investigations may add `GraphEndToEndBenchmark` data.
 - If a change touches persisted graph loading or large-corpus query behavior, also include the relevant load/query benchmark class, such as `AndroidQueryBenchmark`, `AndroidLoadBenchmark`, `LargeCorpusQueryBenchmark`, or `LargeCorpusLoadBenchmark`.
 - The PR body must explicitly state whether the benchmark comparison indicates a performance regression, including separate conclusions for method-level and end-to-end results.
 - If benchmark results cannot be produced, state the blocker in the PR description rather than leaving performance unaddressed.

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -47,11 +47,12 @@ or failure to finish still blocks the pull request.
 | Full pipeline | 20% | 1,000 ms |
 | Sampled peak heap | Report only | 4 GiB process cap |
 
-Both the relative limit and the minimum increase must be exceeded to block. The absolute floor
-prevents a small, noisy phase from failing a pull request on an insignificant millisecond change.
-Sampled peak heap is informational because a single high-water sample varies with GC timing; the
-isolated 4 GiB process cap is the hard memory gate. Missing corpus output or a benchmark process
-failure blocks the gate.
+Both the relative limit and the minimum increase must be exceeded to trigger a reverse-order
+confirmation run. The same corpus and phase must exceed both limits again to block. This keeps a
+single GC, CPU, or filesystem stall from becoming a required-check failure while preserving a gate
+for repeatable phase regressions. Sampled peak heap is informational because a single high-water
+sample varies with GC timing; the isolated 4 GiB process cap is the hard memory gate. Missing corpus
+output or a benchmark process failure blocks the gate.
 
 ## Gradle caching
 

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -16,10 +16,13 @@ The method-level job runs every `CypherBenchmark` method from both revisions wit
 warmup and measurement protocol. Lower latency is better. A row blocks the pull request only when:
 
 1. candidate latency is more than 15% above the base latency; and
-2. the two JMH 99.9% confidence intervals do not overlap.
+2. the two JMH 99.9% confidence intervals do not overlap; and
+3. the same benchmark fails both the initial base-first run and a PR-first confirmation run.
 
-If JMH cannot produce finite confidence intervals, the 15% threshold is enforced directly. Missing
-benchmarks, invalid scores, changed units, and execution errors fail closed.
+The reverse-order confirmation only runs after a suspected regression. It prevents CPU frequency,
+host contention, or execution order from turning a one-round process-level drift into a required
+check failure. If JMH cannot produce finite confidence intervals, the 15% threshold is enforced
+directly. Missing benchmarks, invalid scores, changed units, and execution errors fail closed.
 
 ## Real-corpus end-to-end gate
 

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -1,0 +1,68 @@
+# Benchmark regression gate
+
+Every pull request runs `.github/workflows/benchmark.yml` as a required status check named
+`benchmark-regression-gate`. It compares the pull request with its exact base commit on the same
+GitHub-hosted runner. A committed score from a different machine is not used as the comparison
+baseline.
+
+The workflow updates one `Benchmark Regression Gate` comment on the pull request. The comment
+contains the base and candidate SHAs, runner architecture, every measured score, delta, threshold,
+and gate decision. Raw JMH JSON and large-corpus logs are retained as workflow artifacts for 14
+days.
+
+## Method-level gate
+
+The method-level job runs every `CypherBenchmark` method from both revisions with its normal JMH
+warmup and measurement protocol. Lower latency is better. A row blocks the pull request only when:
+
+1. candidate latency is more than 15% above the base latency; and
+2. the two JMH 99.9% confidence intervals do not overlap.
+
+If JMH cannot produce finite confidence intervals, the 15% threshold is enforced directly. Missing
+benchmarks, invalid scores, changed units, and execution errors fail closed.
+
+## Real-corpus end-to-end gate
+
+The end-to-end job uses the large-corpus harness introduced in PR #92. Tika, Hive, and the Kotlin
+compiler each run in an isolated 4 GiB JVM through:
+
+```text
+JAR -> graph build -> save -> mapped load -> Cypher queries
+```
+
+The candidate runs before the base so it does not receive a systematic filesystem-cache advantage.
+The semantic and fixture assertions still run in record mode; record mode only disables the
+machine-specific absolute timing ceiling.
+
+| Metric | Relative limit | Minimum absolute increase |
+|---|---:|---:|
+| Build | 20% | 500 ms |
+| Save | 25% | 250 ms |
+| Mapped load | 30% | 50 ms |
+| Query | 25% | 250 ms |
+| Full pipeline | 20% | 1,000 ms |
+| Sampled peak heap | 10% | 128 MiB |
+
+Both the relative limit and the minimum increase must be exceeded to block. The absolute floor
+prevents a small, noisy phase from failing a pull request on an insignificant millisecond change.
+Missing corpus output or a benchmark process failure blocks the gate.
+
+## Local verification
+
+Test the comparison and report generation logic:
+
+```bash
+node --test .github/scripts/benchmark-gate.test.mjs
+actionlint .github/workflows/benchmark.yml
+```
+
+Run the two benchmark sources directly:
+
+```bash
+./gradlew :cypher:jmhJar --no-daemon
+./gradlew :webgraph:largeCorpusTest -Dlarge.corpus.record=true --no-daemon
+```
+
+The workflow deliberately keeps benchmark execution separate from unit-test coverage. Coverage
+answers whether behavior was exercised; the benchmark gate answers whether the same behavior became
+materially slower or more memory intensive.

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -32,7 +32,8 @@ JAR -> graph build -> save -> mapped load -> Cypher queries
 
 The candidate runs before the base so it does not receive a systematic filesystem-cache advantage.
 The semantic and fixture assertions still run in record mode; record mode only disables the
-machine-specific absolute timing ceiling.
+machine-specific absolute timing ceiling. Each corpus process is capped at a 4 GiB heap, so an OOM
+or failure to finish still blocks the pull request.
 
 | Metric | Relative limit | Minimum absolute increase |
 |---|---:|---:|
@@ -41,11 +42,23 @@ machine-specific absolute timing ceiling.
 | Mapped load | 30% | 50 ms |
 | Query | 25% | 250 ms |
 | Full pipeline | 20% | 1,000 ms |
-| Sampled peak heap | 10% | 128 MiB |
+| Sampled peak heap | Report only | 4 GiB process cap |
 
 Both the relative limit and the minimum increase must be exceeded to block. The absolute floor
 prevents a small, noisy phase from failing a pull request on an insignificant millisecond change.
-Missing corpus output or a benchmark process failure blocks the gate.
+Sampled peak heap is informational because a single high-water sample varies with GC timing; the
+isolated 4 GiB process cap is the hard memory gate. Missing corpus output or a benchmark process
+failure blocks the gate.
+
+## Gradle caching
+
+`gradle/actions/setup-gradle` caches the wrapper distribution, downloaded dependencies, compiled
+build scripts, artifact transforms, and other reusable Gradle User Home state. The unit-test
+workflow writes this cache on the default branch. Pull-request benchmark jobs use it read-only, so
+they can reuse trusted main-branch state without creating a cache entry for every PR.
+
+Generated graphs and project `build/` directories are deliberately excluded. The end-to-end gate
+must measure graph construction and persistence rather than restore those outputs from a cache.
 
 ## Local verification
 


### PR DESCRIPTION
## Summary

- add a required `Benchmark regression` pull-request workflow that compares the exact base and PR commits on the same GitHub runner
- run every `CypherBenchmark` method and the Tika, Hive, and Kotlin compiler end-to-end corpus gates
- rerun suspected regressions in the opposite order and block only when the same method or corpus phase fails both rounds
- update one benchmark report comment on the PR and retain raw JMH JSON / large-corpus logs for 14 days
- cache reusable Gradle User Home state from the default branch while forcing benchmark measurements and generated graphs to execute normally

## Gate behavior

The required status is `benchmark-regression-gate`. Its two benchmark jobs run in parallel:

| Suite | Blocking policy |
|---|---|
| Method-level JMH | latency regression above 15%, non-overlapping 99.9% confidence intervals, and the same failure in a reverse-order confirmation run |
| Real-corpus end to end | phase-specific 20-30% relative limit, absolute noise floor, and the same failure in a reverse-order confirmation run |

The real-corpus suite covers `JAR -> build -> save -> mapped load -> Cypher` in isolated 4 GiB JVMs. Sampled peak heap remains visible in the report but is informational because it varies with GC timing; the 4 GiB process limit and OOM are the hard memory gate.

Missing benchmarks, invalid scores, changed units, benchmark crashes, or missing result artifacts fail closed. The final job always attempts to attach a report before enforcing the result.

## Gradle cache

`gradle/actions/setup-gradle@v6` caches wrapper distributions, dependencies, compiled build scripts, artifact transforms, and other reusable Gradle User Home state. The unit-test workflow writes trusted cache state on the default branch; benchmark jobs read it without writing per-PR cache entries.

Generated graph data and project `build/` outputs are not used as benchmark results. `largeCorpusTest` remains untracked and JMH always executes, so caching shortens setup without bypassing the measured work.

## Reporting

One marked `Benchmark Regression Gate` comment is updated on every push with:

- exact base and candidate SHAs
- runner OS and architecture
- every base score, PR score, delta, threshold, confirmation score when needed, and decision
- a link to raw logs and JSON artifacts

## Verification

- GitHub Actions run `33037429774`: `method-level-benchmarks`, `large-corpus-benchmarks`, and `benchmark-regression-gate` all passed
- existing `run-unit-test` check passed on the same PR head
- generated PR comment reports PASS for 10 JMH methods and all 18 real-corpus phase/heap rows
- all 13 comparison/reporting tests pass, including one-round-noise and repeated-regression cases for both suites
- `actionlint` passes for `benchmark.yml` and `build.yml`; all three successful check runs have no annotations
- local `./gradlew check -S --no-daemon` passed and executed all three large-corpus gates

The active default-branch ruleset now requires both `run-unit-test` and `benchmark-regression-gate`.
