### PR TITLE
Prevent topology UNION queries from exhausting heap

### DIFF
--- a/docs/topology-graph.md
+++ b/docs/topology-graph.md
@@ -141,3 +141,51 @@ benchmark with:
 ./gradlew :explore:jmh \
   -Pjmh.filter='TopologyHeapBenchmark.android_buildTopologyHeap'
 ```
+
+## Forty-graph UNION budget regression
+
+The startup regression uses one independently persisted Android-scale graph as
+the fixture and opens 40 mapped instances. Keeping fixture construction outside
+the benchmark fork matters: building the Android graph itself exceeds a 3 GiB
+heap, while opening 40 persisted instances is the behavior under test.
+
+The valid shape has eight `UNION ALL` branches and exactly 100,000 combined
+rows. The oversized shape lets every branch produce 100,000 rows. Before the
+global budget fix, the oversized query retained every branch result and failed
+with `OutOfMemoryError` from `QueryPipeline.copyProvenance` before the topology
+row guard could run. The fixed executor applies the remaining global budget to
+each `UNION ALL` branch and stops executing branches when it is exhausted. A
+distinct `UNION` still scans later branches so duplicate rows retain complete
+cross-graph provenance, but stores at most the configured number of distinct
+rows.
+
+These are one-fork, one-iteration smoke measurements on macOS, OpenJDK 17,
+`-Xmx3g`, using the same persisted fixture for both revisions:
+
+| Scenario | `main` | Fixed | Result |
+|---|---:|---:|---|
+| Valid 40-graph, 100,000-row UNION topology | 6,084.735 ms, 2,754,952,520 B allocated | 6,068.351 ms, 2,762,024,360 B allocated | Completed; time -0.27%, allocation +0.26% |
+| Oversized 40-graph UNION topology | `OutOfMemoryError` | 6,192.009 ms | Rejected with the explicit 100,000-row limit |
+
+The valid-shape timing and allocation deltas are too small to claim a speedup
+or regression from a single observation. The material result is that the legal
+40-graph topology completes within 3 GiB and an oversized query reaches the
+documented row-limit error instead of exhausting the JVM heap.
+
+After preparing a persisted fixture, reproduce both fixed-revision checks with:
+
+```bash
+java -jar graphite-explore/build/libs/*-jmh.jar \
+  'TopologyStartupBenchmark.android_loadAndBuildTopology' \
+  -p graphCount=40 -p topologyShape=union-broad \
+  -wi 0 -i 1 -f 1 \
+  -jvmArgs '-Xmx3g -Dandroid.graph.path=/path/to/persisted-android-graph' \
+  -prof gc -foe true
+
+java -jar graphite-explore/build/libs/*-jmh.jar \
+  'TopologyStartupBenchmark.android_rejectOversizedUnionTopology' \
+  -p graphCount=40 -p topologyShape=bounded \
+  -wi 0 -i 1 -f 1 \
+  -jvmArgs '-Xmx3g -Dandroid.graph.path=/path/to/persisted-android-graph' \
+  -foe true
+```

--- a/docs/topology-graph.md
+++ b/docs/topology-graph.md
@@ -149,6 +149,14 @@ the fixture and opens 40 mapped instances. Keeping fixture construction outside
 the benchmark fork matters: building the Android graph itself exceeds a 3 GiB
 heap, while opening 40 persisted instances is the behavior under test.
 
+The persisted fixture contains 5,938,827 nodes and 6,675,058 edges, so the 40
+mapped graph instances expose 237,553,080 logical nodes and 267,002,320 logical
+edges to the query layer. That is nearly three times the reported production
+cardinality of 80,158,209 nodes and 91,565,639 edges. The instances map the same
+fixture files, however, so this is a conservative JVM heap and query-cardinality
+regression, not a substitute for measuring RSS with 42 distinct production
+graph directories.
+
 The valid shape has eight `UNION ALL` branches and exactly 100,000 combined
 rows. The oversized shape lets every branch produce 100,000 rows. Before the
 global budget fix, the oversized query retained every branch result and failed

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
@@ -56,7 +56,7 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
     fun execute(cypher: String, maxRows: Int): CypherResult {
         require(maxRows >= 0) { "maxRows must be non-negative" }
         val clauses = CypherDslAdapter.parse(cypher)
-        return executeClauses(applyMaxRows(clauses, maxRows), maxRows)
+        return executeClauses(clauses, maxRows)
     }
 
     private fun executeClauses(clauses: List<CypherClause>, maxRows: Int?): CypherResult {
@@ -67,7 +67,8 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
         }
 
         // Execute via pipeline
-        val raw = pipeline.execute(clauses)
+        val boundedClauses = maxRows?.let { applyMaxRows(clauses, it) } ?: clauses
+        val raw = pipeline.execute(boundedClauses)
 
         // Post-process: convert Node values to property maps
         return materializeResult(raw)
@@ -101,12 +102,14 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
         } else {
             val limit = segment[limitIndex] as CypherClause.Limit
             val literalLimit = literalLimitCount(limit.count)
-            if (literalLimit != null && literalLimit > maxRows) {
-                segment.toMutableList().apply {
+            when {
+                literalLimit == null -> segment.toMutableList().apply {
+                    add(limitIndex, CypherClause.Limit(CypherExpr.Literal(maxRows)))
+                }
+                literalLimit > maxRows -> segment.toMutableList().apply {
                     this[limitIndex] = CypherClause.Limit(CypherExpr.Literal(maxRows))
                 }
-            } else {
-                segment
+                else -> segment
             }
         }
     }
@@ -140,16 +143,54 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
         }
         segments.add(current)
 
-        val results = segments.map { segment -> pipeline.execute(segment) }
+        return if (unionAll) {
+            executeUnionAll(segments, maxRows)
+        } else {
+            executeUnionDistinct(segments, maxRows)
+        }
+    }
 
-        if (results.isEmpty()) return CypherResult(emptyList(), emptyList())
+    private fun executeUnionAll(segments: List<List<CypherClause>>, maxRows: Int?): CypherResult {
+        var columns = emptyList<String>()
+        val rows = mutableListOf<Map<String, Any?>>()
+        for (segment in segments) {
+            val remaining = maxRows?.minus(rows.size)
+            if (remaining != null && remaining <= 0) {
+                if (columns.isEmpty()) {
+                    columns = pipeline.execute(applyMaxRowsToSegment(segment, 0)).columns
+                }
+                break
+            }
 
-        val columns = results.first().columns
-        val combinedRows = results.flatMap { it.rows }
-        val finalRows = if (unionAll) combinedRows else distinctRows(combinedRows)
-        val limitedRows = maxRows?.let { finalRows.take(it) } ?: finalRows
+            val boundedSegment = remaining?.let { applyMaxRowsToSegment(segment, it) } ?: segment
+            val result = pipeline.execute(boundedSegment)
+            if (columns.isEmpty()) columns = result.columns
+            if (remaining == null) {
+                rows.addAll(result.rows)
+            } else {
+                rows.addAll(result.rows.take(remaining))
+            }
+        }
+        return materializeResult(CypherResult(columns, rows))
+    }
 
-        return materializeResult(CypherResult(columns, limitedRows))
+    private fun executeUnionDistinct(segments: List<List<CypherClause>>, maxRows: Int?): CypherResult {
+        if (maxRows == 0) {
+            val columns = segments.firstOrNull()
+                ?.let { pipeline.execute(applyMaxRowsToSegment(it, 0)).columns }
+                .orEmpty()
+            return CypherResult(columns, emptyList())
+        }
+        var columns = emptyList<String>()
+        val rows = LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>()
+        // Later segments can still add provenance to a retained duplicate row.
+        for (segment in segments) {
+            val boundedSegment = maxRows?.let { applyMaxRowsToSegment(segment, it) } ?: segment
+            val result = pipeline.execute(boundedSegment)
+            if (columns.isEmpty()) columns = result.columns
+            result.rows.forEach { row -> addDistinctRow(rows, row, maxRows) }
+        }
+        return materializeResult(CypherResult(columns, rows.values.toList()))
     }
 
     /**
@@ -175,20 +216,20 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun distinctRows(rows: List<Map<String, Any?>>): List<Map<String, Any?>> {
-        val byVisibleValues = LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>()
-        for (row in rows) {
-            val visible = row.filterKeys { it != INTERNAL_PROVENANCE_KEY }
-            val existing = byVisibleValues[visible]
-            if (existing == null) {
-                byVisibleValues[visible] = row.toMutableMap()
-            } else {
-                val graphIds = (existing[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty() +
-                    (row[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty()
-                if (graphIds.isNotEmpty()) existing[INTERNAL_PROVENANCE_KEY] = graphIds
-            }
+    private fun addDistinctRow(
+        rows: MutableMap<Map<String, Any?>, MutableMap<String, Any?>>,
+        row: Map<String, Any?>,
+        maxRows: Int?
+    ) {
+        val visible = row.filterKeys { it != INTERNAL_PROVENANCE_KEY }
+        val existing = rows[visible]
+        if (existing != null) {
+            val graphIds = (existing[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty() +
+                (row[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty()
+            if (graphIds.isNotEmpty()) existing[INTERNAL_PROVENANCE_KEY] = graphIds
+        } else if (maxRows == null || rows.size < maxRows) {
+            rows[visible] = row.toMutableMap()
         }
-        return byVisibleValues.values.toList()
     }
 
     private fun materializeValue(value: Any?): Any? = when (value) {

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -173,6 +173,14 @@ class CrossGraphCypherExecutorTest {
         )
         assertEquals(1, union.rows.size)
         assertEquals(listOf("billing", "orders"), graphIds(union.rows.single()))
+
+        val boundedUnion = executor.execute(
+            "MATCH (n:StringConstant) WHERE graphId(n) = 'orders' RETURN n.value AS value " +
+                "UNION MATCH (n:StringConstant) WHERE graphId(n) = 'billing' RETURN n.value AS value",
+            maxRows = 1
+        )
+        assertEquals(listOf("shared"), boundedUnion.rows.map { it["value"] })
+        assertEquals(listOf("billing", "orders"), graphIds(boundedUnion.rows.single()))
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -29,6 +29,7 @@ import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.core.ValueNode
 import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.Graph
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertNotNull
@@ -216,12 +217,82 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `execute with maxRows caps expression limit`() {
+        var consumed = 0
+        val counting = object : Graph by graph {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                graph.nodes(type).onEach { consumed++ }
+        }
+
+        val result = CypherExecutor(counting).execute(
+            "MATCH (n:IntConstant) RETURN n.id LIMIT 50 + 50",
+            maxRows = 1
+        )
+
+        assertEquals(1, result.rows.size)
+        assertEquals(1, consumed)
+    }
+
+    @Test
     fun `execute with maxRows applies to union queries`() {
         val result = executor.execute(
             "MATCH (n:IntConstant) RETURN n.value AS v UNION ALL MATCH (m:StringConstant) RETURN m.value AS v",
             maxRows = 1
         )
         assertEquals(1, result.rows.size)
+    }
+
+    @Test
+    fun `execute with maxRows stops union all before later branches`() {
+        val visitedTypes = mutableListOf<Class<out Node>>()
+        val guarded = object : Graph by graph {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> {
+                visitedTypes.add(type)
+                check(type != StringConstant::class.java) { "Later UNION ALL branch must not execute" }
+                return graph.nodes(type)
+            }
+        }
+
+        val result = CypherExecutor(guarded).execute(
+            "MATCH (n:IntConstant) RETURN n.value AS v UNION ALL " +
+                "MATCH (m:StringConstant) RETURN m.value AS v",
+            maxRows = 1
+        )
+
+        assertEquals(listOf(7), result.rows.map { it["v"] })
+        assertEquals(listOf<Class<out Node>>(IntConstant::class.java), visitedTypes)
+    }
+
+    @Test
+    fun `execute with maxRows pushes remaining budget through expression limit in union`() {
+        var consumedIntConstants = 0
+        val counting = object : Graph by graph {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                graph.nodes(type).onEach {
+                    if (type == IntConstant::class.java) consumedIntConstants++
+                }
+        }
+
+        val result = CypherExecutor(counting).execute(
+            "MATCH (n:StringConstant) WHERE n.value = 'missing' RETURN n.value AS v UNION ALL " +
+                "MATCH (m:IntConstant) RETURN m.value AS v LIMIT 50 + 50",
+            maxRows = 1
+        )
+
+        assertEquals(listOf(7), result.rows.map { it["v"] })
+        assertEquals(1, consumedIntConstants)
+    }
+
+    @Test
+    fun `execute with zero maxRows preserves union columns`() {
+        val result = executor.execute(
+            "MATCH (n:IntConstant) RETURN n.value AS v UNION ALL " +
+                "MATCH (m:StringConstant) RETURN m.value AS v",
+            maxRows = 0
+        )
+
+        assertEquals(listOf("v"), result.columns)
+        assertTrue(result.rows.isEmpty())
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -217,6 +217,12 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `execute with maxRows preserves non numeric literal limit semantics`() {
+        val result = executor.execute("MATCH (n) RETURN n.id LIMIT true", maxRows = 2)
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
     fun `execute with maxRows caps expression limit`() {
         var consumed = 0
         val counting = object : Graph by graph {
@@ -287,6 +293,18 @@ class CypherExecutorTest {
     fun `execute with zero maxRows preserves union columns`() {
         val result = executor.execute(
             "MATCH (n:IntConstant) RETURN n.value AS v UNION ALL " +
+                "MATCH (m:StringConstant) RETURN m.value AS v",
+            maxRows = 0
+        )
+
+        assertEquals(listOf("v"), result.columns)
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `execute with zero maxRows preserves distinct union columns`() {
+        val result = executor.execute(
+            "MATCH (n:IntConstant) RETURN n.value AS v UNION " +
                 "MATCH (m:StringConstant) RETURN m.value AS v",
             maxRows = 0
         )

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
@@ -516,7 +516,8 @@ open class MultiGraphExplorerBenchmark {
 
 /**
  * Measures the real multi-graph startup path with and without topology materialization.
- * Both variants load the same Android-scale mapped graph instances through GraphRegistry.
+ * Both variants load mapped instances of the same Android-scale graph through GraphRegistry.
+ * This stresses per-graph heap and logical query cardinality, but mapped file pages may be shared.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.SingleShotTime)

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
@@ -529,6 +529,9 @@ open class TopologyStartupBenchmark {
     @Param("3")
     var graphCount: Int = 0
 
+    @Param("bounded")
+    lateinit var topologyShape: String
+
     private lateinit var graphPath: Path
 
     @Setup(Level.Trial)
@@ -542,7 +545,18 @@ open class TopologyStartupBenchmark {
     @Benchmark
     fun android_loadAndBuildTopology(): Long = runStartup(buildTopology = true)
 
-    private fun runStartup(buildTopology: Boolean): Long {
+    @Benchmark
+    fun android_rejectOversizedUnionTopology(): Long = runStartup(
+        buildTopology = true,
+        queryOverride = topologyStartupQuery("union-over-budget"),
+        expectRowLimit = true
+    )
+
+    private fun runStartup(
+        buildTopology: Boolean,
+        queryOverride: TopologyQuery? = null,
+        expectRowLimit: Boolean = false
+    ): Long {
         val root = Files.createTempDirectory("graphite-topology-startup")
         val registry = GraphRegistry(root, GraphStore.LoadMode.MAPPED)
         var topology: TopologyService? = null
@@ -552,11 +566,17 @@ open class TopologyStartupBenchmark {
             }
             topology = TopologyService(
                 registry,
-                if (buildTopology) listOf(TOPOLOGY_BENCHMARK_QUERY) else emptyList(),
+                if (buildTopology) listOf(queryOverride ?: topologyStartupQuery(topologyShape)) else emptyList(),
                 root
             )
-            val summary = topology.rebuild()
-            summary.graphCount.toLong() + summary.relationCount + summary.matchedRows
+            try {
+                val summary = topology.rebuild()
+                check(!expectRowLimit) { "Expected the oversized topology query to be rejected" }
+                summary.graphCount.toLong() + summary.relationCount + summary.matchedRows
+            } catch (error: IllegalArgumentException) {
+                check(expectRowLimit && error.message.orEmpty().contains("100000 row limit")) { throw error }
+                graphCount.toLong()
+            }
         } finally {
             topology?.close()
             registry.close()
@@ -586,7 +606,7 @@ open class TopologyApiBenchmark {
         registry = GraphRegistry(root, GraphStore.LoadMode.MAPPED)
         val graphPath = ExplorerBenchmarkCorpus.persistedAndroidGraph()
         repeat(3) { index -> registry.load("service-$index", graphPath, GraphStore.LoadMode.MAPPED) }
-        topology = TopologyService(registry, listOf(TOPOLOGY_BENCHMARK_QUERY), root).also { it.rebuild() }
+        topology = TopologyService(registry, listOf(topologyStartupQuery("bounded")), root).also { it.rebuild() }
         app = Javalin.create { config ->
             config.jsonMapper(JavalinGson(GsonBuilder().create()))
         }.start(0)
@@ -893,18 +913,45 @@ private const val TOPOLOGY_HEAP_GC_PAUSE_MS = 100L
 private const val TOPOLOGY_HEAP_SAMPLE_INTERVAL_NS = 1_000_000L
 private const val TOPOLOGY_HEAP_SAMPLER_JOIN_MS = 5_000L
 
-private val TOPOLOGY_BENCHMARK_QUERY = TopologyQuery(
-    "android-topology.cypher",
-    """
-    MATCH (call:CallSiteNode)
-    WHERE graphId(call) = 'service-0'
-    RETURN 'service-0' AS source,
-           'service-1' AS target,
-           'benchmark-rpc' AS protocol,
-           call.callee_name AS operation
-    LIMIT 100
-    """.trimIndent()
-)
+private fun topologyStartupQuery(shape: String): TopologyQuery = when (shape) {
+    "bounded" -> TopologyQuery(
+        "android-topology.cypher",
+        """
+        MATCH (call:CallSiteNode)
+        WHERE graphId(call) = 'service-0'
+        RETURN 'service-0' AS source,
+               'service-1' AS target,
+               'benchmark-rpc' AS protocol,
+               call.callee_name AS operation
+        LIMIT 100
+        """.trimIndent()
+    )
+    "union-broad" -> TopologyQuery(
+        "android-topology-union.cypher",
+        topologyUnionQuery(MAX_TOPOLOGY_BENCHMARK_ROWS / TOPOLOGY_UNION_BRANCHES)
+    )
+    "union-over-budget" -> TopologyQuery(
+        "android-topology-union-over-budget.cypher",
+        topologyUnionQuery(MAX_TOPOLOGY_BENCHMARK_ROWS)
+    )
+    else -> error("Unknown topology startup shape: $shape")
+}
+
+private fun topologyUnionQuery(rowsPerBranch: Int): String =
+    List(TOPOLOGY_UNION_BRANCHES) { branch ->
+        """
+        MATCH (call:CallSiteNode)
+        RETURN graphId(call) AS source,
+               CASE graphId(call) WHEN 'service-0' THEN 'service-1' ELSE 'service-0' END AS target,
+               'benchmark-rpc-$branch' AS protocol,
+               call.callee_name AS operation,
+               call.callee_class AS evidence
+        LIMIT $rowsPerBranch
+        """.trimIndent()
+    }.joinToString("\nUNION ALL\n")
+
+private const val TOPOLOGY_UNION_BRANCHES = 8
+private const val MAX_TOPOLOGY_BENCHMARK_ROWS = 100_000
 
 private data class MemorySample(
     val usedHeapBytes: Long,


### PR DESCRIPTION
## Summary

- enforce `maxRows` as one global budget across `UNION ALL` branches and stop once exhausted
- bound distinct `UNION` storage while preserving provenance contributed by later duplicate rows
- apply the server limit ahead of expression-based `LIMIT` clauses so the cap can be pushed into execution
- add Android-scale 40-graph JMH coverage for valid and oversized topology UNION queries

## Root cause

`CypherExecutor.executeUnion()` executed every branch with the full 100,001-row topology allowance, retained every branch result, flattened them, and only then applied the global limit. An eight-branch topology rule could therefore retain about 800,000 projected rows plus per-row provenance before `TopologyGraphBuilder` had a chance to enforce its documented 100,000-row limit. On 40 loaded Android-scale graphs under `-Xmx3g`, this failed with `OutOfMemoryError` in `QueryPipeline.copyProvenance`.

## Verification

- `./gradlew check --no-daemon` passed, including all module tests and the Tika/Hive/Kotlin Compiler 4 GiB large-corpus gates.
- `:cypher:koverPrintCoverage` reports 98.0682%, above the repository 98% threshold.
- Repository method-level comparator: 10/10 `CypherBenchmark` methods passed the 15% gate. Largest observed regression was `regexFilter` at +4.4%; method-level conclusion: no performance regression.
- End-to-end conclusion: no regression. All three `JAR -> build -> save -> mapped load -> Cypher` gates passed; observed peak heaps remained below 4 GiB.

Targeted smoke setup: macOS, OpenJDK 17, `-Xmx3g`, one fork and one measured iteration. The persisted Android fixture has 5,938,827 nodes and 6,675,058 edges. Opening 40 mapped instances exposes 237,553,080 logical nodes and 267,002,320 logical edges, nearly three times the reported production cardinality of 80,158,209 nodes and 91,565,639 edges. Because the instances map the same files, this is a conservative JVM heap and query-cardinality regression, not a 42-directory RSS benchmark.

| Scenario | `main` | PR | Conclusion |
|---|---:|---:|---|
| Valid 8-branch UNION, 100,000 rows | 6,084.735 ms / 2,754,952,520 B alloc | 6,068.351 ms / 2,762,024,360 B alloc | Completed; -0.27% time, +0.26% allocation, no identifiable regression |
| Oversized 8-branch UNION | `OutOfMemoryError` | 6,192.009 ms | Controlled 100,000-row-limit rejection instead of OOM |

Commands and full setup notes are recorded in `docs/topology-graph.md`. The required GitHub `benchmark-regression-gate` reruns method-level and end-to-end comparisons on the shared runner.