### PR TITLE
Protect broad Cypher discovery queries on large graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ graphite serve --data /data/graphs \
   --graph orders:orders-graph \
   --graph billing:/data/billing-graph \
   --topology /rules/company-topology.cypher \
+  --max-concurrent-cypher 2 \
+  --cypher-work-budget 250000 \
   --port 8080
 
 # Hot-load or replace a graph without restarting the server
@@ -263,6 +265,24 @@ root-all and graph-scoped REST surface, including the two explicit modes of
 A global discovery query belongs on `/api/cypher`. Enumerating `/api/graphs`
 and then calling `/api/graphs/{graphId}/cypher` for each entry performs
 client-side fan-out and repeats HTTP and Cypher parsing overhead.
+
+Cypher endpoints admit at most two executing queries by default and stop a
+query after 250,000 node or relationship visits. Configure these bounds with
+`--max-concurrent-cypher` and `--cypher-work-budget`. A rejected request returns
+HTTP 429 with `code` set to `cypher_concurrency_limit` or
+`cypher_work_budget_exceeded`. Result `LIMIT` controls returned rows; it does not
+replace this execution budget for aggregations that must scan before limiting.
+
+For label discovery, use the metadata-backed histogram shape below. Graphite
+answers it from node type counts without visiting graph nodes:
+
+```cypher
+MATCH (n)
+UNWIND labels(n) AS label
+RETURN label, count(*) AS count
+ORDER BY count DESC
+LIMIT 50
+```
 
 For multi-graph startup, `--topology` accepts one Cypher file (or a directory
 of `.cypher` files). The configured `--graph` entries are the catalog: Graphite

--- a/README.md
+++ b/README.md
@@ -267,8 +267,9 @@ and then calling `/api/graphs/{graphId}/cypher` for each entry performs
 client-side fan-out and repeats HTTP and Cypher parsing overhead.
 
 Cypher endpoints admit at most two executing queries by default and stop a
-query after 250,000 node or relationship visits. Configure these bounds with
-`--max-concurrent-cypher` and `--cypher-work-budget`. A rejected request returns
+query after 250,000 node, relationship, or storage-index candidate inspections.
+Configure these bounds with `--max-concurrent-cypher` and
+`--cypher-work-budget`. A rejected request returns
 HTTP 429 with `code` set to `cypher_concurrency_limit` or
 `cypher_work_budget_exceeded`. Result `LIMIT` controls returned rows; it does not
 replace this execution budget for aggregations that must scan before limiting.

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ and then calling `/api/graphs/{graphId}/cypher` for each entry performs
 client-side fan-out and repeats HTTP and Cypher parsing overhead.
 
 Cypher endpoints admit at most two executing queries by default and stop a
-query after 250,000 node, relationship, or storage-index candidate inspections.
-Configure these bounds with `--max-concurrent-cypher` and
-`--cypher-work-budget`. A rejected request returns
+query after 250,000 graph work units. Candidate inspections and materialized
+path elements consume work units. Configure these bounds with
+`--max-concurrent-cypher` and `--cypher-work-budget`. A rejected request returns
 HTTP 429 with `code` set to `cypher_concurrency_limit` or
 `cypher_work_budget_exceeded`. Result `LIMIT` controls returned rows; it does not
 replace this execution budget for aggregations that must scan before limiting.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -667,7 +667,7 @@ limit through `UNWIND`, aggregation, and ordering, so it materializes and
 expands every matched node before retaining the top 50 result rows.
 
 **Benchmark:** `AndroidSchemaDiscoveryBenchmark` runs both unmodified queries
-against the persisted 5,938,827-node Android graph. The benchmark name describes
+against the persisted 5,938,826-node Android graph. The benchmark name describes
 the workload rather than the client that generated it, so it remains usable for
 CLI, HTTP, and agent callers.
 
@@ -735,11 +735,10 @@ match rows.
 
 **Design:** HTTP Cypher endpoints now share a non-queuing semaphore with a
 default of two active queries. Each admitted request also receives a 250,000
-work-unit budget, where one node candidate or relationship candidate is one
-unit. Generic node scans, direct string-filter candidates, relationship scans,
-path reconstruction, UNION segments, and cross-graph sources share the request
-budget. Metadata fast paths consume no units. Fanout divides the request budget
-across selected graphs so its maximum aggregate work stays bounded.
+work-unit budget. The intended accounting covers generic node scans, direct
+string-filter candidates, relationship scans, path reconstruction, UNION
+segments, and cross-graph sources. Metadata fast paths consume no units. This
+attempt divides the request budget evenly across fanout graphs.
 
 The limits are configurable with `--max-concurrent-cypher` and
 `--cypher-work-budget`. Concurrency and work-budget rejections return HTTP 429
@@ -757,11 +756,12 @@ pipeline.
 
 **Android budget benchmark:** the new SingleShot benchmark runs the unoptimized
 `MATCH (n) UNWIND keys(n) ... count(*) ... LIMIT 50` shape on the persisted
-5,938,827-node Android graph. With a 250,000-unit budget, all three measured
-invocations reject at exactly the configured limit in `109.710 ms/op` and
-allocate `259,665,267 B/op`; no measured invocation triggers GC. The query is
-stopped during `MATCH`, before 5.9 million bindings can be materialized or keys
-expanded.
+5,938,826-node Android graph. The original run reported `109.710 ms/op` and
+`259,665,267 B/op`, but did not retain enough fixture evidence to support its
+node-count and GC claims. An independent harness run measured `108.846 ms/op`,
+`298,504,171 B/op`, and one or two collections per measured invocation. Attempt
+018 reruns the final implementation against the fixture-validated corpus and
+replaces these resource conclusions.
 
 ```shell
 java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
@@ -792,10 +792,100 @@ semantics; HTTP tests verify 429 work rejection, immediate concurrent rejection,
 permit release, and recovery. `:cypher:check` and `:explore:check` pass. Explicit
 application line coverage is `98.108%` for Cypher and `98.0857%` for Explore.
 
-**Conclusion:** retained. Known schema discovery uses an O(type-count) fast
-path, while unknown full-graph shapes now fail within a configurable work and
-concurrency envelope instead of consuming every graph node or every Jetty
-worker. Default non-budgeted Cypher execution shows no measured regression.
+**Conclusion:** superseded by Attempt 018. Review found uncharged variable-length
+path traversal and storage-internal string scans, fanout could exceed or reject
+before the request-level budget, and the changed cross-graph constructor removed
+the released JVM one-argument descriptor. The default non-budgeted benchmark
+evidence remains valid, but it does not measure the HTTP budget-enabled path.
+
+### 2026-08-28 - Attempt 018: Complete request-level work accounting
+
+**Review findings reproduced:** a two-unit budget completed a four-hop variable
+path because `PathFinder` did not receive the tracker. Mapped string misses and
+index construction inspected hundreds of values while charging only returned
+matches. Fanout created one tracker per graph, so a one-unit request could read
+two one-node graphs, while fixed shares also rejected a first graph needing six
+of a ten-unit request. `javap` confirmed that the released
+`CrossGraphCypherExecutor(List)` constructor was absent.
+
+A valid integer `LIMIT` above `Int.MAX_VALUE` was also narrowed with `toInt()`.
+That wrapped `2147483648` to a negative value, causing the label-histogram fast
+path to return an empty result and preventing the HTTP row cap from replacing
+the oversized literal.
+
+**Retained design:** `CypherExecutionContext` owns the mutable tracker for one
+HTTP request. Single-graph, cross-graph, UNION, and fanout execution all use that
+same context; the existing `CypherExecutor(graph, budget)` API still creates a
+fresh tracker per `execute` call. Fanout no longer divides the budget and stops
+opening graphs once the global row limit is full.
+
+`PathFinder` now charges source-node reads, every edge candidate before type
+filtering, and every target-node read. Mapped string lookup implements a new
+optional `WorkAwareStringPropertyLookup` without changing the existing
+`StringPropertyLookup` ABI. It reports raw node scans, first index construction,
+unique-string/posting inspection, and indexed node-ID scans. Budgeted execution
+falls back to a tracked generic node scan for graph implementations that only
+support the legacy lookup. A custom tracking sequence charges before reading
+the next candidate and avoids the allocation and dispatch cost of `onEach`.
+
+LIMIT evaluation now saturates out-of-range integer values at the JVM `Int`
+bounds. A large positive library LIMIT therefore preserves all available rows,
+while `execute(query, maxRows)` safely replaces it with the server row cap.
+
+The explicit `CrossGraphCypherExecutor(List)` constructor is restored. A JVM
+reflection regression test resolves and invokes that exact descriptor. Other
+tests prove variable-path rejection, mapped miss/build/existing-index charging,
+one-match success without double charging, fanout total-budget enforcement, and
+no fixed-share false rejection. They also cover a label histogram and a
+server-capped query with `LIMIT 2147483648`. The full
+`./gradlew check -S --no-daemon` gate, including all three large-corpus
+end-to-end tests, passes. Application line
+coverage is `98.2569%` for Core, `97.9167%` for Cypher, `98.0213%` for WebGraph,
+and `98.1046%` for Explore.
+
+**Budget-enabled executor cost used by HTTP:** `BudgetedCypherBenchmark`
+isolates successful unbudgeted and budgeted executor calls against the same 500
+two-hop chains. It does not include Jetty or network time. This is separate from
+`CypherBenchmark`, which remains the base/PR regression gate for the default
+library API.
+
+```shell
+./gradlew :cypher:jmhJar --no-daemon
+java -jar graphite-cypher/build/libs/cypher-1.0.0-SNAPSHOT-jmh.jar \
+  'BudgetedCypherBenchmark.*' \
+  -wi 3 -i 5 -w 1s -r 1s -f 2 -foe true
+```
+
+Apple M3 Max, 64 GiB RAM, macOS arm64, OpenJDK 17.0.18, JMH 1.37, one
+benchmark thread. Values and 99.9% confidence errors are `us/op`.
+
+| Successful query | Unbudgeted | Budgeted | Budget-check cost |
+|------------------|-----------:|---------:|------------------:|
+| 500-node scan | `48.482 +/- 0.762` | `49.821 +/- 0.602` | `+2.8%` |
+| 500 single-hop relationships | `134.041 +/- 0.705` | `143.314 +/- 3.539` | `+6.9%` |
+| 500 two-hop variable paths | `238.680 +/- 2.788` | `239.933 +/- 4.472` | `+0.5%` |
+
+The budget check has a measurable cost; this is not described as a free change.
+The two-fork relationship result is the highest at 6.9%. A five-fork
+confirmation measured `135.500 +/- 0.879` unbudgeted and
+`143.276 +/- 2.465` budgeted (`+5.7%`), confirming that this path carries a
+stable overhead rather than only fork noise.
+
+**Corrected Android rejection evidence:** the benchmark setup now asserts the
+harness identity for Maven fixture `org.robolectric:android-all:14-robolectric-10818077`,
+which persists exactly 5,938,826 nodes. The exact command from Attempt 017 on
+the final implementation, with its declared `-Xmx16g` fork, measured
+`116.334 ms/op`, `363,221,955 B/op`, and `gc.count ~= 0` over three invocations.
+The independent review run measured lower allocation and one or two collections,
+so allocation and GC count are explicitly environment-sensitive observations,
+not a no-GC guarantee. The invariant is that every invocation rejects at the
+250,000-unit boundary before scanning the complete corpus.
+
+**Conclusion:** retained. All known graph traversal and mapped string lookup
+paths now consume the same request counter, fanout enforces exactly one global
+budget, and the released JVM constructor remains linkable. The safety bound is
+complete for the reviewed paths, while the measured successful-query cost is
+0.5% to 6.9% instead of being hidden behind unbudgeted benchmark results.
 
 ## PR verification summary
 
@@ -813,19 +903,20 @@ used the same machine and dependency caches.
 
 | `CypherBenchmark` | `main` | Branch | Change |
 |-------------------|-------:|-------:|-------:|
-| `aggregationCountGroupBy` | `34.443 us/op` | `34.449 us/op` | `+0.0%` |
-| `countStar` | `2.263 us/op` | `2.284 us/op` | `+0.9%` |
-| `functionCalls` | `24.868 us/op` | `24.683 us/op` | `-0.7%` |
-| `nodeMatchWithWhere` | `58.748 us/op` | `57.674 us/op` | `-1.8%` |
-| `regexFilter` | `23.571 us/op` | `24.045 us/op` | `+2.0%` |
-| `returnDistinct` | `103.294 us/op` | `102.030 us/op` | `-1.2%` |
-| `simpleNodeMatch` | `20.418 us/op` | `20.417 us/op` | `+0.0%` |
-| `singleHopRelationship` | `30.085 us/op` | `29.920 us/op` | `-0.5%` |
-| `variableLengthPath` | `26.093 us/op` | `26.071 us/op` | `-0.1%` |
-| `withPipeline` | `76.079 us/op` | `76.587 us/op` | `+0.7%` |
+| `aggregationCountGroupBy` | `34.390 us/op` | `34.883 us/op` | `+1.4%` |
+| `countStar` | `2.257 us/op` | `2.092 us/op` | `-7.3%` |
+| `functionCalls` | `24.502 us/op` | `24.626 us/op` | `+0.5%` |
+| `nodeMatchWithWhere` | `57.823 us/op` | `57.137 us/op` | `-1.2%` |
+| `regexFilter` | `24.107 us/op` | `24.221 us/op` | `+0.5%` |
+| `returnDistinct` | `102.087 us/op` | `103.817 us/op` | `+1.7%` |
+| `simpleNodeMatch` | `19.335 us/op` | `19.708 us/op` | `+1.9%` |
+| `singleHopRelationship` | `30.458 us/op` | `30.615 us/op` | `+0.5%` |
+| `variableLengthPath` | `26.878 us/op` | `25.188 us/op` | `-6.3%` |
+| `withPipeline` | `84.302 us/op` | `76.503 us/op` | `-9.3%` |
 
-The noisier regex and distinct rows were repeated across three forks; their
-confidence intervals overlap. There is no measured method-level regression.
+Every main/branch 99.9% confidence interval overlaps. There is no measured
+method-level regression on the default unbudgeted executor; the separate
+budget-enabled comparison above reports its production-path cost.
 
 ### Android mapped graph regression
 

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -893,7 +893,7 @@ Values and 99.9% confidence errors are `us/op`.
 |------------------|-----------:|---------:|------------------:|
 | 500-node scan | `48.613 +/- 0.240` | `49.312 +/- 0.666` | `+1.4%` |
 | 500 single-hop relationships | `148.846 +/- 0.731` | `157.375 +/- 4.496` | `+5.7%` |
-| 500 two-hop variable paths | `251.880 +/- 1.875` | `255.000 +/- 1.124` | `+1.2%` |
+| 500 materialized two-hop paths | `231.380 +/- 2.436` | `233.829 +/- 4.377` | `+1.1%` |
 
 The budget check has a measurable cost; this is not described as a free change.
 The relationship result is the highest at 5.7%, and its 99.9% confidence
@@ -901,7 +901,9 @@ interval does not overlap the unbudgeted result. Its unbudgeted path now relies
 on the graph's typed traversal without applying a duplicate relationship-type
 filter. The budgeted path still reads the untyped edge sequence so it can charge
 every rejected candidate before filtering; the benchmark includes source-node,
-edge-candidate, and target-node accounting.
+edge-candidate, and target-node accounting. The variable-path query binds and
+returns its relationship variable, so that row also covers concrete path
+materialization and its budget charge.
 
 **Corrected Android rejection evidence:** the benchmark setup now asserts the
 harness identity for Maven fixture `org.robolectric:android-all:14-robolectric-10818077`,

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -690,6 +690,41 @@ row expansion, aggregation, and sort in the histogram query allocate roughly
 deployment scale, this execution model is not viable; the histogram must use
 existing type metadata instead of visiting nodes.
 
+### 2026-08-28 - Attempt 016: Type-index label histogram
+
+**Design:** recognize the exact schema-discovery shape from Attempt 015 and
+derive its counts from `Graph.nodeCount(concreteType)`. Graphite labels are a
+fixed projection of concrete node types, including aggregate labels such as
+`Constant`, `Resource`, and `Annotation`. The executor sums each type count into
+those labels, sorts the small metadata result, and retains cross-graph
+provenance. It does not load or materialize a node.
+
+The optimization is deliberately narrow. It requires an unlabeled single-node
+`MATCH`, `UNWIND labels()` of that node, a label plus `count(*)` projection,
+ordering by the count alias, and a literal limit. Unsupported shapes use the
+generic pipeline. A graph that cannot provide an indexed `nodeCount` also falls
+back to the generic implementation.
+
+Tests prove that the optimized query never calls `Graph.nodes`, returns concrete
+and aggregate label counts, supports aliases and limits, sums counts across
+graphs, and preserves every contributing graph ID. A separate fallback test
+uses a graph with no count metadata and verifies the original scan result.
+
+The same Android benchmark and JVM settings from Attempt 015 produce:
+
+| Query | Baseline | Attempt 016 | Change |
+|-------|---------:|------------:|-------:|
+| `labels/keys LIMIT 20` | `0.018 ms/op`, `56,480 B/op` | `0.014 ms/op`, `52,944 B/op` | no regression |
+| `UNWIND labels + count` | `8,733.299 ms/op`, `11,211,740,267 B/op` | `0.010 ms/op`, `35,768 B/op` | `873,330x` faster, `313,456x` less allocation |
+
+`./gradlew :cypher:check --no-daemon` passes, including tests, detekt, and Kover
+verification. Explicit application line coverage is `98.1245%`.
+
+**Conclusion:** retained. The production query is now bounded by the number of
+Graphite node types and selected graphs rather than the number of nodes. The
+5.9-million-node Android result exceeds the 100x target by more than four orders
+of magnitude, and the already-limited labels/keys sample does not regress.
+
 ## PR verification summary
 
 **Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -656,6 +656,40 @@ persisted graphs, remains lazy for single-graph limits, uses memory independent
 of match count for qualified execution, and preserves the Android-scale
 speedup.
 
+### 2026-08-28 - Attempt 015: Android schema-discovery baseline
+
+**Observed query shape:** an agent first samples labels and property keys with
+`MATCH (n) RETURN labels(n), keys(n) LIMIT 20`, then requests a label histogram
+with `MATCH (n) UNWIND labels(n) AS label RETURN label, count(*) AS c ORDER BY c
+DESC LIMIT 50`. The first query inspects only 20 nodes because the generic
+pipeline can push its limit into the match. The second query cannot push its
+limit through `UNWIND`, aggregation, and ordering, so it materializes and
+expands every matched node before retaining the top 50 result rows.
+
+**Benchmark:** `AndroidSchemaDiscoveryBenchmark` runs both unmodified queries
+against the persisted 5,938,827-node Android graph. The benchmark name describes
+the workload rather than the client that generated it, so it remains usable for
+CLI, HTTP, and agent callers.
+
+```shell
+./gradlew :webgraph:jmhJar --no-daemon
+java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
+  'AndroidSchemaDiscoveryBenchmark.*' \
+  -wi 1 -i 3 -w 1s -r 1s -f 1 -prof gc -foe true
+```
+
+| Query | Time | Allocation per operation | GC time |
+|-------|-----:|-------------------------:|--------:|
+| `labels/keys LIMIT 20` | `0.018 ms/op` | `56,480 B/op` | `17 ms` total |
+| `UNWIND labels + count` | `8,733.299 ms/op` | `11,211,740,267 B/op` | `12,313 ms` total |
+
+**Conclusion:** retained as the baseline. Calling `labels()` or `keys()` is not
+itself the pressure source when an early limit applies. The full-node scan,
+row expansion, aggregation, and sort in the histogram query allocate roughly
+11.2 GB per execution even at 5.9 million nodes. At the reported 80-million-node
+deployment scale, this execution model is not viable; the histogram must use
+existing type metadata instead of visiting nodes.
+
 ## PR verification summary
 
 **Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -813,16 +813,28 @@ That wrapped `2147483648` to a negative value, causing the label-histogram fast
 path to return an empty result and preventing the HTTP row cap from replacing
 the oversized literal.
 
+The first path-budget fix still copied each state's complete node and edge lists
+and collected all paths before the caller could apply `LIMIT`. A long explicit
+`*..N` chain therefore retained O(N^2) path references even though traversal
+candidates were counted.
+
 **Retained design:** `CypherExecutionContext` owns the mutable tracker for one
 HTTP request. Single-graph, cross-graph, UNION, and fanout execution all use that
 same context; the existing `CypherExecutor(graph, budget)` API still creates a
 fresh tracker per `execute` call. Fanout no longer divides the budget and stops
 opening graphs once the global row limit is full.
 
-`PathFinder` now charges source-node reads, every edge candidate before type
-filtering, and every target-node read. Mapped string lookup implements a new
-optional `WorkAwareStringPropertyLookup` without changing the existing
-`StringPropertyLookup` ABI. It reports raw node scans, first index construction,
+`PathFinder` now stores one parent link per BFS state and exposes an internal
+lazy sequence. The pattern pipeline stays eager for ordinary unbounded queries
+but streams relationship patterns when a safe early `LIMIT` is available, so
+the limit stops sequence consumption without discarding a later branch that can
+complete a longer pattern. Source-node reads, every edge candidate before type
+filtering, and every target-node read are charged; when a relationship variable
+requires a concrete path, its full node-and-edge materialization cost is charged
+before allocating the path containers. Mapped string
+lookup implements a new optional `WorkAwareStringPropertyLookup` without
+changing the existing `StringPropertyLookup` ABI. It reports raw node scans,
+first index construction,
 unique-string/posting inspection, and indexed node-ID scans. Budgeted execution
 falls back to a tracked generic node scan for graph implementations that only
 support the legacy lookup. A custom tracking sequence charges before reading
@@ -837,10 +849,13 @@ reflection regression test resolves and invokes that exact descriptor. Other
 tests prove variable-path rejection, mapped miss/build/existing-index charging,
 one-match success without double charging, fanout total-budget enforcement, and
 no fixed-share false rejection. They also cover a label histogram and a
-server-capped query with `LIMIT 2147483648`. The full
+server-capped query with `LIMIT 2147483648`, path-materialization rejection, a
+1,000-hop graph queried with `*..100000 LIMIT 1` that stops after the first
+outgoing expansion, and a multi-stage pattern whose first branch is a dead end.
+The full
 `./gradlew check -S --no-daemon` gate, including all three large-corpus
 end-to-end tests, passes. Application line
-coverage is `98.2569%` for Core, `97.9167%` for Cypher, `98.0213%` for WebGraph,
+coverage is `98.2569%` for Core, `98.0623%` for Cypher, `98.0213%` for WebGraph,
 and `98.1046%` for Explore.
 
 **Budget-enabled executor cost used by HTTP:** `BudgetedCypherBenchmark`
@@ -861,15 +876,14 @@ benchmark thread. Values and 99.9% confidence errors are `us/op`.
 
 | Successful query | Unbudgeted | Budgeted | Budget-check cost |
 |------------------|-----------:|---------:|------------------:|
-| 500-node scan | `48.482 +/- 0.762` | `49.821 +/- 0.602` | `+2.8%` |
-| 500 single-hop relationships | `134.041 +/- 0.705` | `143.314 +/- 3.539` | `+6.9%` |
-| 500 two-hop variable paths | `238.680 +/- 2.788` | `239.933 +/- 4.472` | `+0.5%` |
+| 500-node scan | `47.346 +/- 0.688` | `47.491 +/- 0.127` | `+0.3%` |
+| 500 single-hop relationships | `135.942 +/- 1.614` | `140.351 +/- 2.536` | `+3.2%` |
+| 500 two-hop variable paths | `243.617 +/- 6.476` | `245.246 +/- 2.213` | `+0.7%` |
 
 The budget check has a measurable cost; this is not described as a free change.
-The two-fork relationship result is the highest at 6.9%. A five-fork
-confirmation measured `135.500 +/- 0.879` unbudgeted and
-`143.276 +/- 2.465` budgeted (`+5.7%`), confirming that this path carries a
-stable overhead rather than only fork noise.
+The relationship result is the highest at 3.2% and is the only pair whose 99.9%
+confidence intervals do not overlap. The node and variable-path intervals
+overlap.
 
 **Corrected Android rejection evidence:** the benchmark setup now asserts the
 harness identity for Maven fixture `org.robolectric:android-all:14-robolectric-10818077`,
@@ -884,8 +898,9 @@ not a no-GC guarantee. The invariant is that every invocation rejects at the
 **Conclusion:** retained. All known graph traversal and mapped string lookup
 paths now consume the same request counter, fanout enforces exactly one global
 budget, and the released JVM constructor remains linkable. The safety bound is
-complete for the reviewed paths, while the measured successful-query cost is
-0.5% to 6.9% instead of being hidden behind unbudgeted benchmark results.
+complete for the reviewed paths, including path materialization rather than only
+candidate reads, while the measured successful-query cost is reported instead
+of being hidden behind unbudgeted benchmark results.
 
 ## PR verification summary
 
@@ -903,20 +918,22 @@ used the same machine and dependency caches.
 
 | `CypherBenchmark` | `main` | Branch | Change |
 |-------------------|-------:|-------:|-------:|
-| `aggregationCountGroupBy` | `34.390 us/op` | `34.883 us/op` | `+1.4%` |
-| `countStar` | `2.257 us/op` | `2.092 us/op` | `-7.3%` |
-| `functionCalls` | `24.502 us/op` | `24.626 us/op` | `+0.5%` |
-| `nodeMatchWithWhere` | `57.823 us/op` | `57.137 us/op` | `-1.2%` |
-| `regexFilter` | `24.107 us/op` | `24.221 us/op` | `+0.5%` |
-| `returnDistinct` | `102.087 us/op` | `103.817 us/op` | `+1.7%` |
-| `simpleNodeMatch` | `19.335 us/op` | `19.708 us/op` | `+1.9%` |
-| `singleHopRelationship` | `30.458 us/op` | `30.615 us/op` | `+0.5%` |
-| `variableLengthPath` | `26.878 us/op` | `25.188 us/op` | `-6.3%` |
-| `withPipeline` | `84.302 us/op` | `76.503 us/op` | `-9.3%` |
+| `aggregationCountGroupBy` | `34.390 us/op` | `36.163 us/op` | `+5.2%` |
+| `countStar` | `2.257 us/op` | `2.447 us/op` | `+8.4%` |
+| `functionCalls` | `24.502 us/op` | `24.137 us/op` | `-1.5%` |
+| `nodeMatchWithWhere` | `57.823 us/op` | `57.595 us/op` | `-0.4%` |
+| `regexFilter` | `24.107 us/op` | `23.643 us/op` | `-1.9%` |
+| `returnDistinct` | `102.087 us/op` | `96.102 us/op` | `-5.9%` |
+| `simpleNodeMatch` | `19.335 us/op` | `19.243 us/op` | `-0.5%` |
+| `singleHopRelationship` | `30.458 us/op` | `29.534 us/op` | `-3.0%` |
+| `variableLengthPath` | `26.878 us/op` | `25.733 us/op` | `-4.3%` |
+| `withPipeline` | `84.302 us/op` | `76.995 us/op` | `-8.7%` |
 
-Every main/branch 99.9% confidence interval overlaps. There is no measured
-method-level regression on the default unbudgeted executor; the separate
-budget-enabled comparison above reports its production-path cost.
+The slower rows with non-overlapping main/branch 99.9% confidence intervals are
+`aggregationCountGroupBy` (`+5.2%`) and `countStar` (`+8.4%`), both below the
+workflow's 10% regression threshold. `returnDistinct` and `withPipeline` are
+the non-overlapping faster rows. The separate budget-enabled comparison above
+reports the production-path cost.
 
 ### Android mapped graph regression
 

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -942,7 +942,9 @@ used the same machine and dependency caches.
 | `withPipeline` | `84.302 us/op` | `76.995 us/op` | `-8.7%` |
 
 The one-fork table's slower rows are `aggregationCountGroupBy` (`+5.2%`) and
-`countStar` (`+8.4%`), both below the workflow's 10% regression threshold. A
+`countStar` (`+8.4%`), both below the workflow's configured 15% regression
+threshold. These are local measurements, separate from the same-runner CI
+artifact. A
 focused five-fork base/head confirmation measured aggregation at
 `34.605 +/- 0.526` versus `35.523 +/- 0.569 us/op` (`+2.7%`) and count at
 `2.344 +/- 0.017` versus `2.363 +/- 0.084 us/op` (`+0.8%`); both confidence

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -867,7 +867,7 @@ seeks.
 The full
 `./gradlew check -S --no-daemon` gate, including all three large-corpus
 end-to-end tests, passes. Application line
-coverage is `98.2569%` for Core, `98.1832%` for Cypher, `98.0213%` for WebGraph,
+coverage is `98.2569%` for Core, `98.1846%` for Cypher, `98.0213%` for WebGraph,
 and `98.1046%` for Explore.
 
 **Budget-enabled executor cost used by HTTP:** `BudgetedCypherBenchmark`
@@ -878,24 +878,30 @@ library API.
 
 ```shell
 ./gradlew :cypher:jmhJar --no-daemon
-java -jar graphite-cypher/build/libs/cypher-1.0.0-SNAPSHOT-jmh.jar \
-  'BudgetedCypherBenchmark.*' \
-  -wi 3 -i 5 -w 1s -r 1s -f 2 -foe true
+for pair in NodeScan Relationship VariableLengthPath; do
+  java -jar graphite-cypher/build/libs/cypher-1.0.0-SNAPSHOT-jmh.jar \
+    "BudgetedCypherBenchmark.(budgeted${pair}|unbudgeted${pair})$" \
+    -wi 3 -i 5 -w 1s -r 1s -f 5 -foe true
+done
 ```
 
 Apple M3 Max, 64 GiB RAM, macOS arm64, OpenJDK 17.0.18, JMH 1.37, one
-benchmark thread. Values and 99.9% confidence errors are `us/op`.
+benchmark thread, five forks, and 25 measurement iterations per benchmark.
+Values and 99.9% confidence errors are `us/op`.
 
 | Successful query | Unbudgeted | Budgeted | Budget-check cost |
 |------------------|-----------:|---------:|------------------:|
-| 500-node scan | `47.002 +/- 0.478` | `47.836 +/- 0.958` | `+1.8%` |
-| 500 single-hop relationships | `142.833 +/- 4.256` | `143.634 +/- 1.466` | `+0.6%` |
-| 500 two-hop variable paths | `243.109 +/- 3.029` | `244.341 +/- 0.970` | `+0.5%` |
+| 500-node scan | `48.613 +/- 0.240` | `49.312 +/- 0.666` | `+1.4%` |
+| 500 single-hop relationships | `148.846 +/- 0.731` | `157.375 +/- 4.496` | `+5.7%` |
+| 500 two-hop variable paths | `251.880 +/- 1.875` | `255.000 +/- 1.124` | `+1.2%` |
 
 The budget check has a measurable cost; this is not described as a free change.
-The node result is the highest at 1.8%, and all three 99.9% confidence intervals
-overlap. The relationship benchmark includes source-node, every untyped edge
-candidate, and target-node accounting.
+The relationship result is the highest at 5.7%, and its 99.9% confidence
+interval does not overlap the unbudgeted result. Its unbudgeted path now relies
+on the graph's typed traversal without applying a duplicate relationship-type
+filter. The budgeted path still reads the untyped edge sequence so it can charge
+every rejected candidate before filtering; the benchmark includes source-node,
+edge-candidate, and target-node accounting.
 
 **Corrected Android rejection evidence:** the benchmark setup now asserts the
 harness identity for Maven fixture `org.robolectric:android-all:14-robolectric-10818077`,
@@ -1010,6 +1016,6 @@ per-module threshold even though `check` passed locally before coverage was
 printed. Follow-up behavior tests cover unlabeled element-ID seeks, empty direct
 string-filter results, every supported mapped raw string field, mapped metadata
 access, ABI fallback, predicate admission bounds, and admission reset after
-cache clearing or LRU eviction. Final application line coverage is `98.3471%`
-for Core, `98.0897%` for Cypher, and `98.0072%` for WebGraph; the complete
-CI-equivalent `check` gate passes after these tests.
+cache clearing or LRU eviction. Final application line coverage is `98.2569%`
+for Core, `98.1846%` for Cypher, `98.0213%` for WebGraph, and `98.1046%` for
+Explore; the complete CI-equivalent `check` gate passes after these tests.

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -725,6 +725,78 @@ Graphite node types and selected graphs rather than the number of nodes. The
 5.9-million-node Android result exceeds the 100x target by more than four orders
 of magnitude, and the already-limited labels/keys sample does not regress.
 
+### 2026-08-28 - Attempt 017: Cypher admission and work budgets
+
+**Remaining risk:** the label histogram fast path cannot cover every query an
+agent can generate. For example, replacing `labels(n)` with `keys(n)` requires
+per-node property inspection. A result `LIMIT` still applies after `UNWIND`,
+aggregation, and ordering, so it does not bound the preceding scan or retained
+match rows.
+
+**Design:** HTTP Cypher endpoints now share a non-queuing semaphore with a
+default of two active queries. Each admitted request also receives a 250,000
+work-unit budget, where one node candidate or relationship candidate is one
+unit. Generic node scans, direct string-filter candidates, relationship scans,
+path reconstruction, UNION segments, and cross-graph sources share the request
+budget. Metadata fast paths consume no units. Fanout divides the request budget
+across selected graphs so its maximum aggregate work stays bounded.
+
+The limits are configurable with `--max-concurrent-cypher` and
+`--cypher-work-budget`. Concurrency and work-budget rejections return HTTP 429
+with machine-readable codes `cypher_concurrency_limit` and
+`cypher_work_budget_exceeded`; only concurrency rejection includes
+`Retry-After`. Syntax and semantic query errors remain HTTP 400. The OpenAPI
+document and README describe both responses and options.
+
+An initial implementation consulted a `ThreadLocal` even when no budget was
+configured. Its first JMH run moved `singleHopRelationship` from `29.230` to
+`30.278 us/op`, with separated confidence intervals. The retained design makes
+work tracking a construction-time pipeline capability: the default library
+executor never sets or reads the tracker, while HTTP creates a budget-enabled
+pipeline.
+
+**Android budget benchmark:** the new SingleShot benchmark runs the unoptimized
+`MATCH (n) UNWIND keys(n) ... count(*) ... LIMIT 50` shape on the persisted
+5,938,827-node Android graph. With a 250,000-unit budget, all three measured
+invocations reject at exactly the configured limit in `109.710 ms/op` and
+allocate `259,665,267 B/op`; no measured invocation triggers GC. The query is
+stopped during `MATCH`, before 5.9 million bindings can be materialized or keys
+expanded.
+
+```shell
+java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
+  'AndroidSchemaDiscoveryBenchmark.boundedPropertyKeyHistogram' \
+  -i 3 -r 1s -f 1 -prof gc -foe true
+```
+
+**Method-level regression:** latest `main` (`44b5756`) and the branch were run
+from separate local checkouts on the same machine with the standard JMH task.
+Values are `us/op`; every confidence interval overlaps and every score change
+is below 4%.
+
+| `CypherBenchmark` | `main` | Attempt 017 | Change |
+|-------------------|-------:|------------:|-------:|
+| `aggregationCountGroupBy` | `34.278` | `34.885` | `+1.8%` |
+| `countStar` | `2.340` | `2.425` | `+3.6%` |
+| `functionCalls` | `24.710` | `24.736` | `+0.1%` |
+| `nodeMatchWithWhere` | `57.667` | `57.034` | `-1.1%` |
+| `regexFilter` | `23.387` | `23.885` | `+2.1%` |
+| `returnDistinct` | `101.791` | `103.822` | `+2.0%` |
+| `simpleNodeMatch` | `20.256` | `19.594` | `-3.3%` |
+| `singleHopRelationship` | `29.230` | `29.582` | `+1.2%` |
+| `variableLengthPath` | `26.138` | `25.583` | `-2.1%` |
+| `withPipeline` | `76.788` | `76.558` | `-0.3%` |
+
+Tests verify node, relationship, UNION, cross-graph, reset, and metadata budget
+semantics; HTTP tests verify 429 work rejection, immediate concurrent rejection,
+permit release, and recovery. `:cypher:check` and `:explore:check` pass. Explicit
+application line coverage is `98.108%` for Cypher and `98.0857%` for Explore.
+
+**Conclusion:** retained. Known schema discovery uses an O(type-count) fast
+path, while unknown full-graph shapes now fail within a configurable work and
+concurrency envelope instead of consuming every graph node or every Jetty
+worker. Default non-budgeted Cypher execution shows no measured regression.
+
 ## PR verification summary
 
 **Environment:** Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK
@@ -789,7 +861,7 @@ the primary pressure result.
 
 `GraphEndToEndBenchmark` covers Android JAR analysis, graph build, save, mapped
 load, and Cypher count query. The single-shot result was `30,182.415 ms/op` on
-`main` and `23,877.213 ms/op` on the branch. This benchmark is intentionally
+`main` and `24,165.015 ms/op` on the final branch. This benchmark is intentionally
 coarse and noisy, but it shows no end-to-end regression. The optimization does
 not change graph building or the persisted format.
 

--- a/docs/cross-graph-cypher-optimization-attempts.md
+++ b/docs/cross-graph-cypher-optimization-attempts.md
@@ -840,22 +840,34 @@ falls back to a tracked generic node scan for graph implementations that only
 support the legacy lookup. A custom tracking sequence charges before reading
 the next candidate and avoids the allocation and dispatch cost of `onEach`.
 
+Single-hop traversal uses untyped edge sequences while a tracker is active, so
+every edge is charged before relationship-type filtering; unbudgeted execution
+retains the graph's typed overload. Fast and generic single-hop paths also charge
+the direct target-node load. Direct `elementId` seeks charge their node load in
+both single-graph and qualified execution. Nested execution saves and restores
+the previous thread-local tracker instead of clearing the outer request state.
+
 LIMIT evaluation now saturates out-of-range integer values at the JVM `Int`
 bounds. A large positive library LIMIT therefore preserves all available rows,
 while `execute(query, maxRows)` safely replaces it with the server row cap.
 
-The explicit `CrossGraphCypherExecutor(List)` constructor is restored. A JVM
-reflection regression test resolves and invokes that exact descriptor. Other
+The explicit `CrossGraphCypherExecutor(List)` and `QueryPipeline(List)`
+constructors are restored, as is
+`MappedStringPropertyIndex.matchingNodeIds(StringMatchMode, String)`. JVM
+reflection regressions resolve and invoke those exact descriptors. Other
 tests prove variable-path rejection, mapped miss/build/existing-index charging,
 one-match success without double charging, fanout total-budget enforcement, and
 no fixed-share false rejection. They also cover a label histogram and a
 server-capped query with `LIMIT 2147483648`, path-materialization rejection, a
 1,000-hop graph queried with `*..100000 LIMIT 1` that stops after the first
-outgoing expansion, and a multi-stage pattern whose first branch is a dead end.
+outgoing expansion, a multi-stage pattern whose first branch is a dead end,
+fast/generic target-node reads, 100 rejected relationship candidates before a
+typed match, reentrant execution, and unqualified/qualified `elementId` UNION
+seeks.
 The full
 `./gradlew check -S --no-daemon` gate, including all three large-corpus
 end-to-end tests, passes. Application line
-coverage is `98.2569%` for Core, `98.0623%` for Cypher, `98.0213%` for WebGraph,
+coverage is `98.2569%` for Core, `98.1832%` for Cypher, `98.0213%` for WebGraph,
 and `98.1046%` for Explore.
 
 **Budget-enabled executor cost used by HTTP:** `BudgetedCypherBenchmark`
@@ -876,14 +888,14 @@ benchmark thread. Values and 99.9% confidence errors are `us/op`.
 
 | Successful query | Unbudgeted | Budgeted | Budget-check cost |
 |------------------|-----------:|---------:|------------------:|
-| 500-node scan | `47.346 +/- 0.688` | `47.491 +/- 0.127` | `+0.3%` |
-| 500 single-hop relationships | `135.942 +/- 1.614` | `140.351 +/- 2.536` | `+3.2%` |
-| 500 two-hop variable paths | `243.617 +/- 6.476` | `245.246 +/- 2.213` | `+0.7%` |
+| 500-node scan | `47.002 +/- 0.478` | `47.836 +/- 0.958` | `+1.8%` |
+| 500 single-hop relationships | `142.833 +/- 4.256` | `143.634 +/- 1.466` | `+0.6%` |
+| 500 two-hop variable paths | `243.109 +/- 3.029` | `244.341 +/- 0.970` | `+0.5%` |
 
 The budget check has a measurable cost; this is not described as a free change.
-The relationship result is the highest at 3.2% and is the only pair whose 99.9%
-confidence intervals do not overlap. The node and variable-path intervals
-overlap.
+The node result is the highest at 1.8%, and all three 99.9% confidence intervals
+overlap. The relationship benchmark includes source-node, every untyped edge
+candidate, and target-node accounting.
 
 **Corrected Android rejection evidence:** the benchmark setup now asserts the
 harness identity for Maven fixture `org.robolectric:android-all:14-robolectric-10818077`,
@@ -929,11 +941,13 @@ used the same machine and dependency caches.
 | `variableLengthPath` | `26.878 us/op` | `25.733 us/op` | `-4.3%` |
 | `withPipeline` | `84.302 us/op` | `76.995 us/op` | `-8.7%` |
 
-The slower rows with non-overlapping main/branch 99.9% confidence intervals are
-`aggregationCountGroupBy` (`+5.2%`) and `countStar` (`+8.4%`), both below the
-workflow's 10% regression threshold. `returnDistinct` and `withPipeline` are
-the non-overlapping faster rows. The separate budget-enabled comparison above
-reports the production-path cost.
+The one-fork table's slower rows are `aggregationCountGroupBy` (`+5.2%`) and
+`countStar` (`+8.4%`), both below the workflow's 10% regression threshold. A
+focused five-fork base/head confirmation measured aggregation at
+`34.605 +/- 0.526` versus `35.523 +/- 0.569 us/op` (`+2.7%`) and count at
+`2.344 +/- 0.017` versus `2.363 +/- 0.084 us/op` (`+0.8%`); both confidence
+interval pairs overlap. The separate budget-enabled comparison above reports
+the production-path cost.
 
 ### Android mapped graph regression
 

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -37,6 +37,23 @@ interface StringPropertyLookup {
     ): Sequence<T>?
 }
 
+/** Receives one callback for each storage item inspected by a graph lookup. */
+fun interface GraphWorkConsumer {
+    fun consume()
+}
+
+/** Optional string lookup capability that exposes its internal work to callers. */
+interface WorkAwareStringPropertyLookup : StringPropertyLookup {
+    fun <T : Node> nodesByStringProperty(
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int,
+        workConsumer: GraphWorkConsumer
+    ): Sequence<T>?
+}
+
 /**
  * The unified program graph that combines all analysis graphs.
  * This is the central abstraction of Graphite.
@@ -210,6 +227,17 @@ fun <T : Node> Graph.nodesByStringProperty(
     limit: Int = Int.MAX_VALUE
 ): Sequence<T>? = (this as? StringPropertyLookup)
     ?.nodesByStringProperty(type, property, mode, expected, limit)
+
+/** Use a storage lookup only when it can report every inspected work item. */
+fun <T : Node> Graph.nodesByStringProperty(
+    type: Class<T>,
+    property: String,
+    mode: StringMatchMode,
+    expected: String,
+    limit: Int,
+    workConsumer: GraphWorkConsumer
+): Sequence<T>? = (this as? WorkAwareStringPropertyLookup)
+    ?.nodesByStringProperty(type, property, mode, expected, limit, workConsumer)
 
 /**
  * Pattern for matching methods.

--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/BudgetedCypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/BudgetedCypherBenchmark.kt
@@ -1,0 +1,88 @@
+package io.johnsonlee.graphite.cypher
+
+import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.core.DataFlowEdge
+import io.johnsonlee.graphite.core.DataFlowKind
+import io.johnsonlee.graphite.core.IntConstant
+import io.johnsonlee.graphite.core.LocalVariable
+import io.johnsonlee.graphite.core.MethodDescriptor
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.TypeDescriptor
+import io.johnsonlee.graphite.graph.DefaultGraph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+open class BudgetedCypherBenchmark {
+    private lateinit var unbudgeted: CypherExecutor
+    private lateinit var budgeted: CypherExecutor
+
+    @Setup
+    fun setup() {
+        NodeId.reset()
+        val owner = TypeDescriptor("com.example.BenchmarkService")
+        val valueType = TypeDescriptor("int")
+        val returnType = TypeDescriptor("void")
+        val caller = MethodDescriptor(owner, "run", emptyList(), returnType)
+        val callee = MethodDescriptor(
+            TypeDescriptor("com.example.BenchmarkRepository"),
+            "save",
+            listOf(valueType),
+            returnType
+        )
+        val graph = DefaultGraph.Builder().apply {
+            repeat(GRAPH_WIDTH) { index ->
+                val constant = IntConstant(NodeId.next(), index)
+                val local = LocalVariable(NodeId.next(), "value$index", valueType, caller)
+                val call = CallSiteNode(NodeId.next(), caller, callee, index, null, listOf(constant.id))
+                addNode(constant)
+                addNode(local)
+                addNode(call)
+                addEdge(DataFlowEdge(constant.id, local.id, DataFlowKind.ASSIGN))
+                addEdge(DataFlowEdge(local.id, call.id, DataFlowKind.PARAMETER_PASS))
+            }
+        }.build()
+        unbudgeted = CypherExecutor(graph)
+        budgeted = CypherExecutor(graph, CypherExecutionBudget(BENCHMARK_WORK_BUDGET))
+    }
+
+    @Benchmark
+    fun unbudgetedNodeScan(): CypherResult = unbudgeted.execute(NODE_SCAN_QUERY)
+
+    @Benchmark
+    fun budgetedNodeScan(): CypherResult = budgeted.execute(NODE_SCAN_QUERY)
+
+    @Benchmark
+    fun unbudgetedRelationship(): CypherResult = unbudgeted.execute(RELATIONSHIP_QUERY)
+
+    @Benchmark
+    fun budgetedRelationship(): CypherResult = budgeted.execute(RELATIONSHIP_QUERY)
+
+    @Benchmark
+    fun unbudgetedVariableLengthPath(): CypherResult = unbudgeted.execute(VARIABLE_PATH_QUERY)
+
+    @Benchmark
+    fun budgetedVariableLengthPath(): CypherResult = budgeted.execute(VARIABLE_PATH_QUERY)
+}
+
+private const val GRAPH_WIDTH = 500
+private const val BENCHMARK_WORK_BUDGET = 10_000L
+private const val NODE_SCAN_QUERY = "MATCH (n:IntConstant) RETURN n.value LIMIT 500"
+private const val RELATIONSHIP_QUERY =
+    "MATCH (n:IntConstant)-[:DATAFLOW]->(v:LocalVariable) RETURN n.value, v.name LIMIT 500"
+private const val VARIABLE_PATH_QUERY =
+    "MATCH (n:IntConstant)-[:DATAFLOW*2..2]->(c:CallSiteNode) RETURN n.value, c.callee_name LIMIT 500"

--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/BudgetedCypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/BudgetedCypherBenchmark.kt
@@ -85,4 +85,4 @@ private const val NODE_SCAN_QUERY = "MATCH (n:IntConstant) RETURN n.value LIMIT 
 private const val RELATIONSHIP_QUERY =
     "MATCH (n:IntConstant)-[:DATAFLOW]->(v:LocalVariable) RETURN n.value, v.name LIMIT 500"
 private const val VARIABLE_PATH_QUERY =
-    "MATCH (n:IntConstant)-[:DATAFLOW*2..2]->(c:CallSiteNode) RETURN n.value, c.callee_name LIMIT 500"
+    "MATCH (n:IntConstant)-[r:DATAFLOW*2..2]->(c:CallSiteNode) RETURN r LIMIT 500"

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
@@ -1,10 +1,12 @@
 package io.johnsonlee.graphite.cypher
 
+import io.johnsonlee.graphite.graph.GraphWorkConsumer
+
 /**
  * Bounds graph work performed by one Cypher execution.
  *
- * A work unit is one node candidate or relationship candidate read by the
- * generic query pipeline. Metadata fast paths do not consume work units.
+ * A work unit is one node, relationship, or storage-index candidate inspected
+ * by the query pipeline. Metadata fast paths do not consume work units.
  */
 data class CypherExecutionBudget(val maxWorkUnits: Long) {
     init {
@@ -12,20 +14,30 @@ data class CypherExecutionBudget(val maxWorkUnits: Long) {
     }
 }
 
+/**
+ * Shares one work counter across sequential Cypher executions in a logical request.
+ * A context is request-scoped and must not be used concurrently.
+ */
+class CypherExecutionContext(val executionBudget: CypherExecutionBudget) {
+    internal val workTracker = CypherWorkTracker(executionBudget)
+}
+
 class CypherBudgetExceededException(
     val maxWorkUnits: Long
 ) : RuntimeException(
-    "Cypher work budget exceeded after $maxWorkUnits node or relationship visits; " +
+    "Cypher work budget exceeded after $maxWorkUnits graph candidate inspections; " +
         "add a selective label/filter or use a metadata-backed query"
 )
 
-internal class CypherWorkTracker(private val budget: CypherExecutionBudget) {
-    private var consumed = 0L
+internal class CypherWorkTracker(
+    private val budget: CypherExecutionBudget
+) : GraphWorkConsumer {
+    private var remaining = budget.maxWorkUnits
 
-    fun consume() {
-        if (consumed >= budget.maxWorkUnits) {
+    override fun consume() {
+        if (remaining == 0L) {
             throw CypherBudgetExceededException(budget.maxWorkUnits)
         }
-        consumed++
+        remaining--
     }
 }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
@@ -1,0 +1,31 @@
+package io.johnsonlee.graphite.cypher
+
+/**
+ * Bounds graph work performed by one Cypher execution.
+ *
+ * A work unit is one node candidate or relationship candidate read by the
+ * generic query pipeline. Metadata fast paths do not consume work units.
+ */
+data class CypherExecutionBudget(val maxWorkUnits: Long) {
+    init {
+        require(maxWorkUnits > 0) { "maxWorkUnits must be positive" }
+    }
+}
+
+class CypherBudgetExceededException(
+    val maxWorkUnits: Long
+) : RuntimeException(
+    "Cypher work budget exceeded after $maxWorkUnits node or relationship visits; " +
+        "add a selective label/filter or use a metadata-backed query"
+)
+
+internal class CypherWorkTracker(private val budget: CypherExecutionBudget) {
+    private var consumed = 0L
+
+    fun consume() {
+        if (consumed >= budget.maxWorkUnits) {
+            throw CypherBudgetExceededException(budget.maxWorkUnits)
+        }
+        consumed++
+    }
+}

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
@@ -5,7 +5,7 @@ import io.johnsonlee.graphite.graph.GraphWorkConsumer
 /**
  * Bounds graph work performed by one Cypher execution.
  *
- * A work unit is one node, relationship, or storage-index candidate inspected
+ * A work unit is one graph candidate inspected or one path element materialized
  * by the query pipeline. Metadata fast paths do not consume work units.
  */
 data class CypherExecutionBudget(val maxWorkUnits: Long) {
@@ -25,7 +25,7 @@ class CypherExecutionContext(val executionBudget: CypherExecutionBudget) {
 class CypherBudgetExceededException(
     val maxWorkUnits: Long
 ) : RuntimeException(
-    "Cypher work budget exceeded after $maxWorkUnits graph candidate inspections; " +
+    "Cypher work budget exceeded after $maxWorkUnits graph work units; " +
         "add a selective label/filter or use a metadata-backed query"
 )
 
@@ -34,10 +34,13 @@ internal class CypherWorkTracker(
 ) : GraphWorkConsumer {
     private var remaining = budget.maxWorkUnits
 
-    override fun consume() {
-        if (remaining == 0L) {
+    override fun consume() = consume(1)
+
+    fun consume(workUnits: Long) {
+        if (workUnits > remaining) {
+            remaining = 0
             throw CypherBudgetExceededException(budget.maxWorkUnits)
         }
-        remaining--
+        remaining -= workUnits
     }
 }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
@@ -43,32 +43,44 @@ private const val PROPERTY_NAME = "name"
  * [QueryPipeline] against the graph. Node values in result rows are
  * converted to property maps for interoperability.
  */
-class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
+class CypherExecutor internal constructor(
+    private val pipeline: QueryPipeline,
+    private val executionBudget: CypherExecutionBudget? = null
+) {
 
     constructor(graph: Graph) : this(QueryPipeline(graph))
+
+    constructor(graph: Graph, executionBudget: CypherExecutionBudget) :
+        this(QueryPipeline(graph, workTrackingEnabled = true), executionBudget)
 
     fun execute(cypher: String): CypherResult {
         // 1. Parse Cypher text into internal AST clauses
         val clauses = CypherDslAdapter.parse(cypher)
-        return executeClauses(clauses, maxRows = null)
+        return executeClauses(clauses, maxRows = null, newWorkTracker())
     }
 
     fun execute(cypher: String, maxRows: Int): CypherResult {
         require(maxRows >= 0) { "maxRows must be non-negative" }
         val clauses = CypherDslAdapter.parse(cypher)
-        return executeClauses(clauses, maxRows)
+        return executeClauses(clauses, maxRows, newWorkTracker())
     }
 
-    private fun executeClauses(clauses: List<CypherClause>, maxRows: Int?): CypherResult {
+    private fun newWorkTracker(): CypherWorkTracker? = executionBudget?.let(::CypherWorkTracker)
+
+    private fun executeClauses(
+        clauses: List<CypherClause>,
+        maxRows: Int?,
+        workTracker: CypherWorkTracker?
+    ): CypherResult {
         // Handle UNION by splitting into sub-queries
         val unionIndex = clauses.indexOfFirst { it is CypherClause.Union }
         if (unionIndex >= 0) {
-            return executeUnion(clauses, maxRows)
+            return executeUnion(clauses, maxRows, workTracker)
         }
 
         // Execute via pipeline
         val boundedClauses = maxRows?.let { applyMaxRows(clauses, it) } ?: clauses
-        val raw = pipeline.execute(boundedClauses)
+        val raw = pipeline.execute(boundedClauses, workTracker)
 
         // Post-process: convert Node values to property maps
         return materializeResult(raw)
@@ -127,7 +139,11 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
      * Execute a UNION query by splitting into sub-queries, executing each,
      * and combining results.
      */
-    private fun executeUnion(clauses: List<CypherClause>, maxRows: Int?): CypherResult {
+    private fun executeUnion(
+        clauses: List<CypherClause>,
+        maxRows: Int?,
+        workTracker: CypherWorkTracker?
+    ): CypherResult {
         val segments = mutableListOf<List<CypherClause>>()
         var current = mutableListOf<CypherClause>()
         var unionAll = false
@@ -144,26 +160,30 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
         segments.add(current)
 
         return if (unionAll) {
-            executeUnionAll(segments, maxRows)
+            executeUnionAll(segments, maxRows, workTracker)
         } else {
-            executeUnionDistinct(segments, maxRows)
+            executeUnionDistinct(segments, maxRows, workTracker)
         }
     }
 
-    private fun executeUnionAll(segments: List<List<CypherClause>>, maxRows: Int?): CypherResult {
+    private fun executeUnionAll(
+        segments: List<List<CypherClause>>,
+        maxRows: Int?,
+        workTracker: CypherWorkTracker?
+    ): CypherResult {
         var columns = emptyList<String>()
         val rows = mutableListOf<Map<String, Any?>>()
         for (segment in segments) {
             val remaining = maxRows?.minus(rows.size)
             if (remaining != null && remaining <= 0) {
                 if (columns.isEmpty()) {
-                    columns = pipeline.execute(applyMaxRowsToSegment(segment, 0)).columns
+                    columns = pipeline.execute(applyMaxRowsToSegment(segment, 0), workTracker).columns
                 }
                 break
             }
 
             val boundedSegment = remaining?.let { applyMaxRowsToSegment(segment, it) } ?: segment
-            val result = pipeline.execute(boundedSegment)
+            val result = pipeline.execute(boundedSegment, workTracker)
             if (columns.isEmpty()) columns = result.columns
             if (remaining == null) {
                 rows.addAll(result.rows)
@@ -174,10 +194,14 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
         return materializeResult(CypherResult(columns, rows))
     }
 
-    private fun executeUnionDistinct(segments: List<List<CypherClause>>, maxRows: Int?): CypherResult {
+    private fun executeUnionDistinct(
+        segments: List<List<CypherClause>>,
+        maxRows: Int?,
+        workTracker: CypherWorkTracker?
+    ): CypherResult {
         if (maxRows == 0) {
             val columns = segments.firstOrNull()
-                ?.let { pipeline.execute(applyMaxRowsToSegment(it, 0)).columns }
+                ?.let { pipeline.execute(applyMaxRowsToSegment(it, 0), workTracker).columns }
                 .orEmpty()
             return CypherResult(columns, emptyList())
         }
@@ -186,7 +210,7 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
         // Later segments can still add provenance to a retained duplicate row.
         for (segment in segments) {
             val boundedSegment = maxRows?.let { applyMaxRowsToSegment(segment, it) } ?: segment
-            val result = pipeline.execute(boundedSegment)
+            val result = pipeline.execute(boundedSegment, workTracker)
             if (columns.isEmpty()) columns = result.columns
             result.rows.forEach { row -> addDistinctRow(rows, row, maxRows) }
         }
@@ -348,12 +372,18 @@ class CypherExecutor internal constructor(private val pipeline: QueryPipeline) {
  * traversal never crosses graph boundaries; independent patterns and joins can
  * bind values from different graphs in the same result row.
  */
-class CrossGraphCypherExecutor(graphs: List<CypherGraph>) {
+class CrossGraphCypherExecutor(
+    graphs: List<CypherGraph>,
+    executionBudget: CypherExecutionBudget? = null
+) {
     private val delegate: CypherExecutor
 
     init {
         require(graphs.map { it.id }.distinct().size == graphs.size) { "Graph ids must be unique" }
-        delegate = CypherExecutor(QueryPipeline(graphs))
+        delegate = CypherExecutor(
+            QueryPipeline(graphs, workTrackingEnabled = executionBudget != null),
+            executionBudget
+        )
     }
 
     fun execute(cypher: String): CypherResult = delegate.execute(cypher).withExplicitMetadata()

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutor.kt
@@ -45,13 +45,18 @@ private const val PROPERTY_NAME = "name"
  */
 class CypherExecutor internal constructor(
     private val pipeline: QueryPipeline,
-    private val executionBudget: CypherExecutionBudget? = null
+    private val workTrackerFactory: () -> CypherWorkTracker?
 ) {
 
-    constructor(graph: Graph) : this(QueryPipeline(graph))
+    internal constructor(pipeline: QueryPipeline) : this(pipeline, { null })
+
+    constructor(graph: Graph) : this(QueryPipeline(graph), { null })
 
     constructor(graph: Graph, executionBudget: CypherExecutionBudget) :
-        this(QueryPipeline(graph, workTrackingEnabled = true), executionBudget)
+        this(QueryPipeline(graph, workTrackingEnabled = true), { CypherWorkTracker(executionBudget) })
+
+    constructor(graph: Graph, executionContext: CypherExecutionContext) :
+        this(QueryPipeline(graph, workTrackingEnabled = true), { executionContext.workTracker })
 
     fun execute(cypher: String): CypherResult {
         // 1. Parse Cypher text into internal AST clauses
@@ -65,7 +70,7 @@ class CypherExecutor internal constructor(
         return executeClauses(clauses, maxRows, newWorkTracker())
     }
 
-    private fun newWorkTracker(): CypherWorkTracker? = executionBudget?.let(::CypherWorkTracker)
+    private fun newWorkTracker(): CypherWorkTracker? = workTrackerFactory()
 
     private fun executeClauses(
         clauses: List<CypherClause>,
@@ -129,8 +134,10 @@ class CypherExecutor internal constructor(
     private fun literalLimitCount(expr: CypherExpr): Int? {
         val literal = expr as? CypherExpr.Literal ?: return null
         return when (val value = literal.value) {
-            is Number -> value.toInt()
-            is String -> value.toIntOrNull()
+            is Number -> value.toLong().coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong()).toInt()
+            is String -> value.toLongOrNull()
+                ?.coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+                ?.toInt()
             else -> null
         }
     }
@@ -372,17 +379,26 @@ class CypherExecutor internal constructor(
  * traversal never crosses graph boundaries; independent patterns and joins can
  * bind values from different graphs in the same result row.
  */
-class CrossGraphCypherExecutor(
+class CrossGraphCypherExecutor private constructor(
     graphs: List<CypherGraph>,
-    executionBudget: CypherExecutionBudget? = null
+    workTrackingEnabled: Boolean,
+    workTrackerFactory: () -> CypherWorkTracker?
 ) {
     private val delegate: CypherExecutor
+
+    constructor(graphs: List<CypherGraph>) : this(graphs, false, { null })
+
+    constructor(graphs: List<CypherGraph>, executionBudget: CypherExecutionBudget) :
+        this(graphs, true, { CypherWorkTracker(executionBudget) })
+
+    constructor(graphs: List<CypherGraph>, executionContext: CypherExecutionContext) :
+        this(graphs, true, { executionContext.workTracker })
 
     init {
         require(graphs.map { it.id }.distinct().size == graphs.size) { "Graph ids must be unique" }
         delegate = CypherExecutor(
-            QueryPipeline(graphs, workTrackingEnabled = executionBudget != null),
-            executionBudget
+            QueryPipeline(graphs, workTrackingEnabled),
+            workTrackerFactory
         )
     }
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherFunctions.kt
@@ -61,6 +61,30 @@ private const val FUNCTION_STDEVP = "stdevp"
 private const val DEFAULT_PERCENTILE = 0.5
 private const val CONSTANT_LABEL = "Constant"
 
+internal data class NodeLabelDescriptor(
+    val type: Class<out Node>,
+    val labels: List<String>
+)
+
+internal val nodeLabelDescriptors = listOf(
+    NodeLabelDescriptor(CallSiteNode::class.java, listOf("CallSiteNode")),
+    NodeLabelDescriptor(IntConstant::class.java, listOf("IntConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(StringConstant::class.java, listOf("StringConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(LongConstant::class.java, listOf("LongConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(FloatConstant::class.java, listOf("FloatConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(DoubleConstant::class.java, listOf("DoubleConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(BooleanConstant::class.java, listOf("BooleanConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(NullConstant::class.java, listOf("NullConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(EnumConstant::class.java, listOf("EnumConstant", CONSTANT_LABEL)),
+    NodeLabelDescriptor(LocalVariable::class.java, listOf("LocalVariable")),
+    NodeLabelDescriptor(FieldNode::class.java, listOf("FieldNode")),
+    NodeLabelDescriptor(ParameterNode::class.java, listOf("ParameterNode")),
+    NodeLabelDescriptor(ReturnNode::class.java, listOf("ReturnNode")),
+    NodeLabelDescriptor(ResourceFileNode::class.java, listOf("ResourceFileNode", "ResourceFile")),
+    NodeLabelDescriptor(ResourceValueNode::class.java, listOf("ResourceValueNode", "ResourceValue", "Resource")),
+    NodeLabelDescriptor(AnnotationNode::class.java, listOf("AnnotationNode", "Annotation"))
+)
+
 /**
  * Complete openCypher function library.
  *

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -21,11 +21,33 @@ object PathFinder {
         val workTracker: CypherWorkTracker? = null
     )
 
-    private data class State(
-        val nodeId: NodeId,
-        val pathNodes: List<Node>,
-        val pathEdges: List<Edge>
+    internal class SearchState(
+        val node: Node,
+        val incomingEdge: Edge?,
+        val parent: SearchState?,
+        val depth: Int
     )
+
+    internal class PathMatch(private val state: SearchState) {
+        fun endNode(): Node = state.node
+
+        fun materialize(workTracker: CypherWorkTracker?): Path {
+            workTracker?.consume(state.depth.toLong() * 2 + 1)
+            val nodes = ArrayList<Node>(state.depth + 1)
+            val edges = ArrayList<Edge>(state.depth)
+            var cursor: SearchState? = state
+            while (cursor != null) {
+                nodes.add(cursor.node)
+                cursor.incomingEdge?.let { edge ->
+                    edges.add(edge)
+                }
+                cursor = cursor.parent
+            }
+            nodes.reverse()
+            edges.reverse()
+            return Path(nodes, edges)
+        }
+    }
 
     /**
      * Find all paths from source nodes to target nodes via BFS.
@@ -47,53 +69,48 @@ object PathFinder {
         minDepth: Int = 1,
         maxDepth: Int = 10,
         direction: Direction = Direction.OUTGOING
-    ): List<Path> = findPaths(
+    ): List<Path> = findPathMatches(
         graph,
         sources,
         SearchOptions(targets, edgeType, minDepth, maxDepth, direction)
-    )
+    ).map { it.materialize(workTracker = null) }.toList()
 
-    internal fun findPaths(
+    internal fun findPathMatches(
         graph: Graph,
         sources: Set<NodeId>,
         options: SearchOptions
-    ): List<Path> {
-        val results = mutableListOf<Path>()
-
+    ): Sequence<PathMatch> = sequence {
         for (source in sources) {
             val startNode = loadNode(graph, source, options.workTracker) ?: continue
-            bfs(graph, startNode, options, results)
+            yieldAll(bfs(graph, startNode, options))
         }
-
-        return results
     }
 
     private fun bfs(
         graph: Graph,
         startNode: Node,
-        options: SearchOptions,
-        results: MutableList<Path>
-    ) {
+        options: SearchOptions
+    ): Sequence<PathMatch> = sequence {
         val visited = mutableSetOf<Int>()
-        val queue = ArrayDeque<State>()
-        queue.add(State(startNode.id, listOf(startNode), emptyList()))
+        val queue = ArrayDeque<SearchState>()
+        queue.add(SearchState(startNode, incomingEdge = null, parent = null, depth = 0))
 
         while (queue.isNotEmpty()) {
-            val (current, pathNodes, pathEdges) = queue.removeFirst()
-            val depth = pathEdges.size
+            val state = queue.removeFirst()
+            val current = state.node.id
 
-            if (depth >= options.minDepth && (options.targets == null || current in options.targets)) {
-                results.add(Path(pathNodes, pathEdges))
+            if (state.depth >= options.minDepth && (options.targets == null || current in options.targets)) {
+                yield(PathMatch(state))
             }
 
-            if (depth >= options.maxDepth) continue
+            if (state.depth >= options.maxDepth) continue
             if (!visited.add(current.value)) continue
 
             val edges = edgesForDirection(graph, current, options)
             for (edge in edges) {
                 val nextId = nextNodeId(edge, current, options.direction)
                 val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
-                queue.add(State(nextId, pathNodes + nextNode, pathEdges + edge))
+                queue.add(SearchState(nextNode, edge, state, state.depth + 1))
             }
         }
     }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -12,6 +12,21 @@ object PathFinder {
 
     data class Path(val nodes: List<Node>, val edges: List<Edge>)
 
+    internal data class SearchOptions(
+        val targets: Set<NodeId>?,
+        val edgeType: Class<out Edge>?,
+        val minDepth: Int,
+        val maxDepth: Int,
+        val direction: Direction,
+        val workTracker: CypherWorkTracker? = null
+    )
+
+    private data class State(
+        val nodeId: NodeId,
+        val pathNodes: List<Node>,
+        val pathEdges: List<Edge>
+    )
+
     /**
      * Find all paths from source nodes to target nodes via BFS.
      *
@@ -32,12 +47,22 @@ object PathFinder {
         minDepth: Int = 1,
         maxDepth: Int = 10,
         direction: Direction = Direction.OUTGOING
+    ): List<Path> = findPaths(
+        graph,
+        sources,
+        SearchOptions(targets, edgeType, minDepth, maxDepth, direction)
+    )
+
+    internal fun findPaths(
+        graph: Graph,
+        sources: Set<NodeId>,
+        options: SearchOptions
     ): List<Path> {
         val results = mutableListOf<Path>()
 
         for (source in sources) {
-            val startNode = graph.node(source) ?: continue
-            bfs(graph, startNode, targets, edgeType, minDepth, maxDepth, direction, results)
+            val startNode = loadNode(graph, source, options.workTracker) ?: continue
+            bfs(graph, startNode, options, results)
         }
 
         return results
@@ -46,15 +71,9 @@ object PathFinder {
     private fun bfs(
         graph: Graph,
         startNode: Node,
-        targets: Set<NodeId>?,
-        edgeType: Class<out Edge>?,
-        minDepth: Int,
-        maxDepth: Int,
-        direction: Direction,
+        options: SearchOptions,
         results: MutableList<Path>
     ) {
-        data class State(val nodeId: NodeId, val pathNodes: List<Node>, val pathEdges: List<Edge>)
-
         val visited = mutableSetOf<Int>()
         val queue = ArrayDeque<State>()
         queue.add(State(startNode.id, listOf(startNode), emptyList()))
@@ -63,35 +82,53 @@ object PathFinder {
             val (current, pathNodes, pathEdges) = queue.removeFirst()
             val depth = pathEdges.size
 
-            if (depth >= minDepth && (targets == null || current in targets)) {
+            if (depth >= options.minDepth && (options.targets == null || current in options.targets)) {
                 results.add(Path(pathNodes, pathEdges))
             }
 
-            if (depth >= maxDepth) continue
+            if (depth >= options.maxDepth) continue
             if (!visited.add(current.value)) continue
 
-            val edges = when (direction) {
-                Direction.OUTGOING -> filteredEdges(graph.outgoing(current), edgeType)
-                Direction.INCOMING -> filteredEdges(graph.incoming(current), edgeType)
-                Direction.BOTH -> filteredEdges(graph.outgoing(current), edgeType) +
-                        filteredEdges(graph.incoming(current), edgeType)
-            }
-
+            val edges = edgesForDirection(graph, current, options)
             for (edge in edges) {
-                val nextId = when (direction) {
-                    Direction.OUTGOING -> edge.to
-                    Direction.INCOMING -> edge.from
-                    Direction.BOTH -> if (edge.from == current) edge.to else edge.from
-                }
-                val nextNode = graph.node(nextId) ?: continue
+                val nextId = nextNodeId(edge, current, options.direction)
+                val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
                 queue.add(State(nextId, pathNodes + nextNode, pathEdges + edge))
             }
         }
     }
 
-    private fun filteredEdges(edges: Sequence<Edge>, edgeType: Class<out Edge>?): List<Edge> =
-        if (edgeType != null) edges.filter { edgeType.isInstance(it) }.toList()
-        else edges.toList()
+    private fun edgesForDirection(graph: Graph, nodeId: NodeId, options: SearchOptions): List<Edge> =
+        when (options.direction) {
+            Direction.OUTGOING -> filteredEdges(graph.outgoing(nodeId), options.edgeType, options.workTracker)
+            Direction.INCOMING -> filteredEdges(graph.incoming(nodeId), options.edgeType, options.workTracker)
+            Direction.BOTH -> filteredEdges(graph.outgoing(nodeId), options.edgeType, options.workTracker) +
+                filteredEdges(graph.incoming(nodeId), options.edgeType, options.workTracker)
+        }
+
+    private fun nextNodeId(edge: Edge, current: NodeId, direction: Direction): NodeId = when (direction) {
+        Direction.OUTGOING -> edge.to
+        Direction.INCOMING -> edge.from
+        Direction.BOTH -> if (edge.from == current) edge.to else edge.from
+    }
+
+    private fun loadNode(graph: Graph, nodeId: NodeId, workTracker: CypherWorkTracker?): Node? {
+        workTracker?.consume()
+        return graph.node(nodeId)
+    }
+
+    private fun filteredEdges(
+        edges: Sequence<Edge>,
+        edgeType: Class<out Edge>?,
+        workTracker: CypherWorkTracker?
+    ): List<Edge> {
+        val result = mutableListOf<Edge>()
+        for (edge in edges) {
+            workTracker?.consume()
+            if (edgeType == null || edgeType.isInstance(edge)) result.add(edge)
+        }
+        return result
+    }
 
     enum class Direction { OUTGOING, INCOMING, BOTH }
 }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -86,7 +86,9 @@ class QueryPipeline private constructor(
     internal constructor(graph: Graph, workTrackingEnabled: Boolean) :
         this(listOf(CypherGraph(SINGLE_GRAPH_ID, graph)), false, workTrackingEnabled)
 
-    internal constructor(graphs: List<CypherGraph>, workTrackingEnabled: Boolean = false) :
+    internal constructor(graphs: List<CypherGraph>) : this(graphs, true, false)
+
+    internal constructor(graphs: List<CypherGraph>, workTrackingEnabled: Boolean) :
         this(graphs, true, workTrackingEnabled)
 
     init {
@@ -108,11 +110,16 @@ class QueryPipeline private constructor(
         workTracker: CypherWorkTracker?
     ): CypherResult {
         if (workTracker == null) return executeWithActiveBudget(clauses)
+        val previousTracker = activeWorkTracker.get()
         activeWorkTracker.set(workTracker)
         return try {
             executeWithActiveBudget(clauses)
         } finally {
-            activeWorkTracker.remove()
+            if (previousTracker == null) {
+                activeWorkTracker.remove()
+            } else {
+                activeWorkTracker.set(previousTracker)
+            }
         }
     }
 
@@ -253,7 +260,7 @@ class QueryPipeline private constructor(
     private fun seekNode(elementId: String): Pair<CypherGraph, Node>? {
         if (!qualified) {
             val nodeId = elementId.toIntOrNull() ?: return null
-            return sources.single().let { source -> source.graph.node(NodeId(nodeId))?.let { source to it } }
+            return sources.single().let { source -> trackedNode(source.graph, NodeId(nodeId))?.let { source to it } }
         }
 
         val separator = elementId.lastIndexOf(':')
@@ -261,7 +268,7 @@ class QueryPipeline private constructor(
         val graphId = elementId.substring(0, separator)
         val nodeId = elementId.substring(separator + 1).toIntOrNull() ?: return null
         val source = sources.firstOrNull { it.id == graphId } ?: return null
-        return source.graph.node(NodeId(nodeId))?.let { source to it }
+        return trackedNode(source.graph, NodeId(nodeId))?.let { source to it }
     }
 
     /**
@@ -816,7 +823,7 @@ class QueryPipeline private constructor(
                 if (!matchesRelConstraints(edge.edge, rel, sourceBindings)) continue
 
                 val targetId = resolveTargetId(edge.edge, source.node.id, rel.direction)
-                val target = source.source.graph.node(targetId) ?: continue
+                val target = trackedNode(source.source.graph, targetId) ?: continue
                 val targetValue = nodeValue(source.source, target)
                 val targetBindings = matchTargetNode(targetPattern, targetValue, sourceBindings) ?: continue
 
@@ -1138,7 +1145,7 @@ class QueryPipeline private constructor(
 
         for (edge in edges) {
             val targetId = resolveTargetId(edge.edge, sourceNode.node.id, rel.direction)
-            val targetNode = sourceNode.source.graph.node(targetId) ?: continue
+            val targetNode = trackedNode(sourceNode.source.graph, targetId) ?: continue
             val targetValue = nodeValue(sourceNode.source, targetNode)
 
             // Check relationship property constraints
@@ -1308,18 +1315,23 @@ class QueryPipeline private constructor(
     ): Sequence<EdgeCursor> {
         val graph = node.source.graph
         val nodeId = node.node.id
+        val tracked = workTrackingEnabled && activeWorkTracker.get() != null
         val edges = when (direction) {
-        Direction.OUTGOING ->
-            if (edgeClass != null) graph.outgoing(nodeId, edgeClass) else graph.outgoing(nodeId)
-        Direction.INCOMING ->
-            if (edgeClass != null) graph.incoming(nodeId, edgeClass) else graph.incoming(nodeId)
-        Direction.BOTH -> {
-            val out = if (edgeClass != null) graph.outgoing(nodeId, edgeClass) else graph.outgoing(nodeId)
-            val inc = if (edgeClass != null) graph.incoming(nodeId, edgeClass) else graph.incoming(nodeId)
-            out + inc
+            Direction.OUTGOING ->
+                if (!tracked && edgeClass != null) graph.outgoing(nodeId, edgeClass) else graph.outgoing(nodeId)
+            Direction.INCOMING ->
+                if (!tracked && edgeClass != null) graph.incoming(nodeId, edgeClass) else graph.incoming(nodeId)
+            Direction.BOTH -> {
+                val outgoing =
+                    if (!tracked && edgeClass != null) graph.outgoing(nodeId, edgeClass) else graph.outgoing(nodeId)
+                val incoming =
+                    if (!tracked && edgeClass != null) graph.incoming(nodeId, edgeClass) else graph.incoming(nodeId)
+                outgoing + incoming
+            }
         }
-        }
-        return trackWork(edges).map { edge -> EdgeCursor(node.source, edge, edgeValue(node.source, edge)) }
+        return trackWork(edges)
+            .filter { edge -> edgeClass == null || edgeClass.isInstance(edge) }
+            .map { edge -> EdgeCursor(node.source, edge, edgeValue(node.source, edge)) }
     }
 
     private fun resolveTargetId(edge: Edge, sourceId: NodeId, direction: Direction): NodeId =
@@ -1353,6 +1365,11 @@ class QueryPipeline private constructor(
         } else {
             activeWorkTracker.get()?.let { tracker -> WorkTrackingSequence(values, tracker) } ?: values
         }
+    }
+
+    private fun trackedNode(graph: Graph, nodeId: NodeId): Node? {
+        if (workTrackingEnabled) activeWorkTracker.get()?.consume()
+        return graph.node(nodeId)
     }
 
     private fun <T : Node> stringPropertyCandidates(

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -58,12 +58,17 @@ private val DIRECT_STRING_NODE_PROPERTIES = listOf(
 @Suppress("LargeClass")
 class QueryPipeline private constructor(
     private val sources: List<CypherGraph>,
-    private val qualified: Boolean
+    private val qualified: Boolean,
+    private val workTrackingEnabled: Boolean
 ) {
 
-    constructor(graph: Graph) : this(listOf(CypherGraph(SINGLE_GRAPH_ID, graph)), false)
+    constructor(graph: Graph) : this(listOf(CypherGraph(SINGLE_GRAPH_ID, graph)), false, false)
 
-    internal constructor(graphs: List<CypherGraph>) : this(graphs, true)
+    internal constructor(graph: Graph, workTrackingEnabled: Boolean) :
+        this(listOf(CypherGraph(SINGLE_GRAPH_ID, graph)), false, workTrackingEnabled)
+
+    internal constructor(graphs: List<CypherGraph>, workTrackingEnabled: Boolean = false) :
+        this(graphs, true, workTrackingEnabled)
 
     init {
         require(sources.map { it.id }.distinct().size == sources.size) { "Graph ids must be unique" }
@@ -72,11 +77,28 @@ class QueryPipeline private constructor(
     private val graph: Graph get() = sources.single().graph
 
     private val evaluator = ExpressionEvaluator()
+    private val activeWorkTracker = ThreadLocal<CypherWorkTracker?>()
 
     /**
      * Execute a list of clauses and return the final result.
      */
-    fun execute(clauses: List<CypherClause>): CypherResult {
+    fun execute(clauses: List<CypherClause>): CypherResult = execute(clauses, null)
+
+    internal fun execute(
+        clauses: List<CypherClause>,
+        workTracker: CypherWorkTracker?
+    ): CypherResult {
+        if (workTracker == null) return executeWithActiveBudget(clauses)
+        activeWorkTracker.set(workTracker)
+        return try {
+            executeWithActiveBudget(clauses)
+        } finally {
+            activeWorkTracker.remove()
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun executeWithActiveBudget(clauses: List<CypherClause>): CypherResult {
         val fastResult = tryFastNodeCount(clauses)
             ?: tryFastLabelHistogram(clauses)
             ?: tryFastDistinctPropertyLimit(clauses)
@@ -560,7 +582,9 @@ class QueryPipeline private constructor(
                 filter.expected,
                 limit - rows.size
             )
-            val candidates = indexedNodes ?: source.graph.nodes(nodeClass).filter(filter::matches)
+            val candidates = indexedNodes
+                ?.let(::trackWork)
+                ?: trackWork(source.graph.nodes(nodeClass)).filter(filter::matches)
             for (node in candidates) {
 
                 val candidate = nodeValue(source, node)
@@ -618,9 +642,9 @@ class QueryPipeline private constructor(
                 )
             }
             val candidates = if (accelerated.any { it == null }) {
-                graph.nodes(candidateType).filter(disjunction::matches)
+                trackWork(graph.nodes(candidateType)).filter(disjunction::matches)
             } else {
-                filterOwnedNodes(filters, accelerated.filterNotNull())
+                filterOwnedNodes(filters, accelerated.filterNotNull().map(::trackWork))
             }
             for (node in candidates) yield(node)
         }
@@ -945,9 +969,9 @@ class QueryPipeline private constructor(
                         val prev = nodeCursor(prevValue)
                         val next = nodeCursor(nextValue)
                         if (prev != null && next != null && prev.source.id == next.source.id) {
-                            val foundEdge = prev.source.graph.outgoing(prev.node.id)
+                            val foundEdge = trackWork(prev.source.graph.outgoing(prev.node.id))
                                 .firstOrNull { it.to == next.node.id }
-                                ?: prev.source.graph.incoming(prev.node.id)
+                                ?: trackWork(prev.source.graph.incoming(prev.node.id))
                                     .firstOrNull { it.from == next.node.id }
                             if (foundEdge != null) path.add(edgeValue(prev.source, foundEdge))
                         }
@@ -1216,7 +1240,7 @@ class QueryPipeline private constructor(
             out + inc
         }
         }
-        return edges.map { edge -> EdgeCursor(node.source, edge, edgeValue(node.source, edge)) }
+        return trackWork(edges).map { edge -> EdgeCursor(node.source, edge, edgeValue(node.source, edge)) }
     }
 
     private fun resolveTargetId(edge: Edge, sourceId: NodeId, direction: Direction): NodeId =
@@ -1238,11 +1262,19 @@ class QueryPipeline private constructor(
     private fun <T : Node> nodeCandidates(type: Class<T>): Sequence<Any> =
         if (qualified) {
             sources.asSequence().flatMap { source ->
-                source.graph.nodes(type).map { node -> QualifiedNode(source.id, source.graph, node) }
+                trackWork(source.graph.nodes(type)).map { node -> QualifiedNode(source.id, source.graph, node) }
             }
         } else {
-            graph.nodes(type).map { it as Any }
+            trackWork(graph.nodes(type)).map { it as Any }
         }
+
+    private fun <T> trackWork(values: Sequence<T>): Sequence<T> {
+        return if (!workTrackingEnabled) {
+            values
+        } else {
+            activeWorkTracker.get()?.let { tracker -> values.onEach { tracker.consume() } } ?: values
+        }
+    }
 
     private fun nodeCursor(value: Any?): NodeCursor? = when (value) {
         is QualifiedNode -> NodeCursor(CypherGraph(value.graphId, value.graph), value.node, value)

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -1329,9 +1329,13 @@ class QueryPipeline private constructor(
                 outgoing + incoming
             }
         }
-        return trackWork(edges)
-            .filter { edge -> edgeClass == null || edgeClass.isInstance(edge) }
-            .map { edge -> EdgeCursor(node.source, edge, edgeValue(node.source, edge)) }
+        val candidates = trackWork(edges)
+        val filtered = if (tracked && edgeClass != null) {
+            candidates.filter(edgeClass::isInstance)
+        } else {
+            candidates
+        }
+        return filtered.map { edge -> EdgeCursor(node.source, edge, edgeValue(node.source, edge)) }
     }
 
     private fun resolveTargetId(edge: Edge, sourceId: NodeId, direction: Direction): NodeId =

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -18,6 +18,7 @@ import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.graph.nodesByStringProperty
 
 private const val COUNT_QUERY_CLAUSES = 2
+private const val LABEL_HISTOGRAM_QUERY_CLAUSES = 5
 private const val DISTINCT_LIMIT_QUERY_CLAUSES = 3
 private const val FILTERED_LIMIT_QUERY_CLAUSES = 4
 private const val SINGLE_HOP_LIMIT_QUERY_CLAUSES = 3
@@ -77,6 +78,7 @@ class QueryPipeline private constructor(
      */
     fun execute(clauses: List<CypherClause>): CypherResult {
         val fastResult = tryFastNodeCount(clauses)
+            ?: tryFastLabelHistogram(clauses)
             ?: tryFastDistinctPropertyLimit(clauses)
             ?: tryFastFilteredNodeLimit(clauses)
             ?: tryFastSingleHopRelationshipLimit(clauses)
@@ -276,6 +278,95 @@ class QueryPipeline private constructor(
             }
         }
         else -> null
+    }
+
+    /**
+     * Fast path for Graphite schema discovery:
+     *
+     *   MATCH (n)
+     *   UNWIND labels(n) AS label
+     *   RETURN label, count(*) AS count
+     *   ORDER BY count DESC
+     *   LIMIT k
+     *
+     * Graphite's labels are derived from concrete node types. Backends with a
+     * type index can therefore answer this histogram without loading nodes.
+     */
+    @Suppress("ReturnCount")
+    private fun tryFastLabelHistogram(clauses: List<CypherClause>): CypherResult? {
+        val query = LabelHistogramQuery.compile(clauses) ?: return null
+        if (query.limit <= 0) return CypherResult(query.columns, emptyList())
+
+        val counts = linkedMapOf<String, Long>()
+        val provenance = if (qualified) mutableMapOf<String, MutableSet<String>>() else null
+        for (source in sources) {
+            for (descriptor in nodeLabelDescriptors) {
+                val count = source.graph.nodeCount(descriptor.type) ?: return null
+                if (count <= 0) continue
+                for (label in descriptor.labels) {
+                    counts[label] = counts.getOrDefault(label, 0L) + count
+                    provenance?.getOrPut(label, ::linkedSetOf)?.add(source.id)
+                }
+            }
+        }
+
+        val comparator = compareBy<Map.Entry<String, Long>> { it.value }
+        val ordered = counts.entries.sortedWith(
+            if (query.ascending) comparator else comparator.reversed()
+        )
+        val rows = ordered.take(query.limit).map { (label, count) ->
+            mutableMapOf<String, Any?>(
+                query.labelColumn to label,
+                query.countColumn to count
+            ).apply {
+                provenance?.get(label)?.takeIf { it.isNotEmpty() }?.let { put(INTERNAL_PROVENANCE_KEY, it) }
+            }
+        }
+        return CypherResult(query.columns, rows)
+    }
+
+    private data class LabelHistogramQuery(
+        val labelColumn: String,
+        val countColumn: String,
+        val ascending: Boolean,
+        val limit: Int
+    ) {
+        val columns: List<String> = listOf(labelColumn, countColumn)
+
+        companion object {
+            @Suppress("ComplexCondition", "CyclomaticComplexMethod", "MagicNumber", "ReturnCount")
+            fun compile(clauses: List<CypherClause>): LabelHistogramQuery? {
+                if (clauses.size != LABEL_HISTOGRAM_QUERY_CLAUSES) return null
+                val match = clauses[0] as? CypherClause.Match ?: return null
+                val unwind = clauses[1] as? CypherClause.Unwind ?: return null
+                val ret = clauses[2] as? CypherClause.Return ?: return null
+                val orderBy = clauses[3] as? CypherClause.OrderBy ?: return null
+                val limit = clauses[4] as? CypherClause.Limit ?: return null
+                if (match.optional || match.patterns.size != 1 || ret.distinct || ret.items.size != 2) return null
+
+                val pattern = match.patterns.single()
+                if (pattern.pathVariable != null || pattern.elements.size != 1) return null
+                val nodePattern = pattern.elements.single() as? PatternElement.NodePattern ?: return null
+                val nodeVariable = nodePattern.variable ?: return null
+                if (nodePattern.labels.isNotEmpty() || nodePattern.properties.isNotEmpty()) return null
+
+                val labelsCall = unwind.expression as? CypherExpr.FunctionCall ?: return null
+                if (!labelsCall.name.equals("labels", ignoreCase = true) || labelsCall.distinct) return null
+                if (labelsCall.args.singleOrNull() != CypherExpr.Variable(nodeVariable)) return null
+
+                val labelItem = ret.items[0]
+                if (labelItem.expression != CypherExpr.Variable(unwind.variable)) return null
+                val countItem = ret.items[1]
+                if (countItem.expression != CypherExpr.CountStar) return null
+                val labelColumn = labelItem.alias ?: labelItem.expression.toCypherString()
+                val countColumn = countItem.alias ?: countItem.expression.toCypherString()
+
+                val sort = orderBy.items.singleOrNull() ?: return null
+                if (sort.expression != CypherExpr.Variable(countColumn)) return null
+                val limitCount = (limit.count as? CypherExpr.Literal)?.value as? Number ?: return null
+                return LabelHistogramQuery(labelColumn, countColumn, sort.ascending, limitCount.toInt())
+            }
+        }
     }
 
     /**

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -917,8 +917,31 @@ class QueryPipeline private constructor(
         val elements = pattern.elements
         if (elements.isEmpty()) return listOf(existingBindings)
 
-        // A pattern is a chain: Node [Rel Node [Rel Node ...]]
-        // Start by matching the first node, then alternate rel+node.
+        val matches = if (limit != null && elements.size > 1) {
+            matchPatternLazily(elements, existingBindings, limit)
+        } else {
+            matchPatternEagerly(elements, existingBindings, limit)
+        }
+
+        // If the pattern has a path variable, bind it to the matched path
+        if (pattern.pathVariable != null) {
+            return matches.map { bindings ->
+                val path = buildPathRepresentation(pattern, bindings)
+                bindings.toMutableMap().apply {
+                    this[pattern.pathVariable] = path
+                    addProvenance(this, path)
+                }
+            }
+        }
+
+        return matches
+    }
+
+    private fun matchPatternEagerly(
+        elements: List<PatternElement>,
+        existingBindings: Map<String, Any?>,
+        limit: Int?
+    ): List<Map<String, Any?>> {
         var currentMatches = matchNodeElement(elements[0] as PatternElement.NodePattern, existingBindings, limit)
 
         var i = 1
@@ -929,28 +952,38 @@ class QueryPipeline private constructor(
 
             val nextMatches = mutableListOf<Map<String, Any?>>()
             for (bindings in currentMatches) {
-                nextMatches.addAll(matchRelationship(rel, targetNode, bindings))
-                if (limit != null && nextMatches.size >= limit) break
+                nextMatches.addAll(matchRelationship(rel, targetNode, bindings, limit = null))
             }
-            currentMatches = if (limit != null && nextMatches.size > limit) {
-                nextMatches.subList(0, limit)
-            } else {
-                nextMatches
-            }
-        }
-
-        // If the pattern has a path variable, bind it to the matched path
-        if (pattern.pathVariable != null) {
-            return currentMatches.map { bindings ->
-                val path = buildPathRepresentation(pattern, bindings)
-                bindings.toMutableMap().apply {
-                    this[pattern.pathVariable] = path
-                    addProvenance(this, path)
-                }
-            }
+            currentMatches = nextMatches
         }
 
         return currentMatches
+    }
+
+    private fun matchPatternLazily(
+        elements: List<PatternElement>,
+        existingBindings: Map<String, Any?>,
+        limit: Int
+    ): List<Map<String, Any?>> {
+        var currentMatches = matchNodeElementLazily(
+            elements[0] as PatternElement.NodePattern,
+            existingBindings
+        )
+
+        var i = 1
+        while (i < elements.size) {
+            val rel = elements[i] as PatternElement.RelationshipPattern
+            val targetNode = elements[i + 1] as PatternElement.NodePattern
+            i += 2
+
+            val relationshipLimit = limit.takeIf { i >= elements.size }
+            val nextMatches = currentMatches.flatMap { bindings ->
+                matchRelationship(rel, targetNode, bindings, relationshipLimit).asSequence()
+            }
+            currentMatches = relationshipLimit?.let(nextMatches::take) ?: nextMatches
+        }
+
+        return currentMatches.toList()
     }
 
     /**
@@ -1016,13 +1049,29 @@ class QueryPipeline private constructor(
         limit: Int? = null
     ): List<Map<String, Any?>> {
         val results = mutableListOf<Map<String, Any?>>()
+        for (candidate in nodeElementCandidates(nodePattern, existingBindings)) {
+            val bindings = bindNodeCandidate(candidate, nodePattern, existingBindings) ?: continue
+            results.add(bindings)
+            if (limit != null && results.size >= limit) break
+        }
+        return results
+    }
 
-        // Determine the node class from the first label (if any)
+    private fun matchNodeElementLazily(
+        nodePattern: PatternElement.NodePattern,
+        existingBindings: Map<String, Any?>
+    ): Sequence<Map<String, Any?>> = nodeElementCandidates(nodePattern, existingBindings)
+        .mapNotNull { candidate -> bindNodeCandidate(candidate, nodePattern, existingBindings) }
+
+    private fun nodeElementCandidates(
+        nodePattern: PatternElement.NodePattern,
+        existingBindings: Map<String, Any?>
+    ): Sequence<Any> {
         val nodeClass = nodePattern.labels.firstOrNull()
             ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
             ?: Node::class.java
 
-        val candidates: Sequence<Any> = if (nodePattern.variable != null &&
+        return if (nodePattern.variable != null &&
             existingBindings.containsKey(nodePattern.variable)
         ) {
             val existing = existingBindings[nodePattern.variable]
@@ -1035,20 +1084,20 @@ class QueryPipeline private constructor(
         } else {
             nodeCandidates(nodeClass)
         }
+    }
 
-        for (candidate in candidates) {
-            if (matchesNodeConstraints(candidate, nodePattern, existingBindings)) {
-                val bindings = existingBindings.toMutableMap()
-                if (nodePattern.variable != null) {
-                    bindings[nodePattern.variable] = candidate
-                    addProvenance(bindings, candidate)
-                }
-                results.add(bindings)
-                if (limit != null && results.size >= limit) break
+    private fun bindNodeCandidate(
+        candidate: Any,
+        nodePattern: PatternElement.NodePattern,
+        existingBindings: Map<String, Any?>
+    ): Map<String, Any?>? {
+        if (!matchesNodeConstraints(candidate, nodePattern, existingBindings)) return null
+        return existingBindings.toMutableMap().apply {
+            if (nodePattern.variable != null) {
+                this[nodePattern.variable] = candidate
+                addProvenance(this, candidate)
             }
         }
-
-        return results
     }
 
     /**
@@ -1057,7 +1106,8 @@ class QueryPipeline private constructor(
     private fun matchRelationship(
         rel: PatternElement.RelationshipPattern,
         targetNodePattern: PatternElement.NodePattern,
-        bindings: Map<String, Any?>
+        bindings: Map<String, Any?>,
+        limit: Int?
     ): List<Map<String, Any?>> {
         val results = mutableListOf<Map<String, Any?>>()
 
@@ -1067,9 +1117,9 @@ class QueryPipeline private constructor(
         val edgeClass = rel.types.firstOrNull()?.let { NodePropertyAccessor.resolveEdgeType(it) }
 
         if (rel.variableLength) {
-            matchVariableLengthPath(rel, targetNodePattern, sourceNode, bindings, edgeClass, results)
+            matchVariableLengthPath(rel, targetNodePattern, sourceNode, bindings, edgeClass, limit, results)
         } else {
-            matchSingleHop(rel, targetNodePattern, sourceNode, bindings, edgeClass, results)
+            matchSingleHop(rel, targetNodePattern, sourceNode, bindings, edgeClass, limit, results)
         }
 
         return results
@@ -1081,6 +1131,7 @@ class QueryPipeline private constructor(
         sourceNode: NodeCursor,
         bindings: Map<String, Any?>,
         edgeClass: Class<out Edge>?,
+        limit: Int?,
         results: MutableList<Map<String, Any?>>
     ) {
         val edges = edgesForDirection(sourceNode, rel.direction, edgeClass)
@@ -1101,6 +1152,7 @@ class QueryPipeline private constructor(
                 addProvenance(newBindings, edge.value)
             }
             results.add(newBindings)
+            if (limit != null && results.size >= limit) break
         }
     }
 
@@ -1110,6 +1162,7 @@ class QueryPipeline private constructor(
         sourceNode: NodeCursor,
         bindings: Map<String, Any?>,
         edgeClass: Class<out Edge>?,
+        limit: Int?,
         results: MutableList<Map<String, Any?>>
     ) {
         val direction = when (rel.direction) {
@@ -1118,7 +1171,8 @@ class QueryPipeline private constructor(
             Direction.BOTH -> PathFinder.Direction.BOTH
         }
 
-        val paths = PathFinder.findPaths(
+        val workTracker = if (workTrackingEnabled) activeWorkTracker.get() else null
+        val paths = PathFinder.findPathMatches(
             graph = sourceNode.source.graph,
             sources = setOf(sourceNode.node.id),
             options = PathFinder.SearchOptions(
@@ -1127,18 +1181,19 @@ class QueryPipeline private constructor(
                 minDepth = rel.minHops ?: 1,
                 maxDepth = rel.maxHops ?: 10,
                 direction = direction,
-                workTracker = if (workTrackingEnabled) activeWorkTracker.get() else null
+                workTracker = workTracker
             )
         )
 
-        for (path in paths) {
-            val endNode = path.nodes.last()
-            val endValue = nodeValue(sourceNode.source, endNode)
+        for (pathMatch in paths) {
+            val endValue = nodeValue(sourceNode.source, pathMatch.endNode())
             val targetMatch = matchTargetNode(targetNodePattern, endValue, bindings) ?: continue
 
             val newBindings = targetMatch.toMutableMap()
             if (rel.variable != null) {
+                val path = pathMatch.materialize(workTracker)
                 val pathValue = if (qualified) {
+                    workTracker?.consume(path.nodes.size.toLong() + path.edges.size)
                     QualifiedPath(
                         graphId = sourceNode.source.id,
                         nodes = path.nodes.map { QualifiedNode(sourceNode.source.id, sourceNode.source.graph, it) },
@@ -1151,6 +1206,7 @@ class QueryPipeline private constructor(
                 addProvenance(newBindings, pathValue)
             }
             results.add(newBindings)
+            if (limit != null && results.size >= limit) break
         }
     }
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -24,6 +24,25 @@ private const val FILTERED_LIMIT_QUERY_CLAUSES = 4
 private const val SINGLE_HOP_LIMIT_QUERY_CLAUSES = 3
 private const val SINGLE_HOP_PATTERN_ELEMENTS = 3
 private const val SINGLE_GRAPH_ID = "single"
+
+private class WorkTrackingSequence<T>(
+    private val source: Sequence<T>,
+    private val workTracker: CypherWorkTracker
+) : Sequence<T> {
+    override fun iterator(): Iterator<T> {
+        val sourceIterator = source.iterator()
+        return object : Iterator<T> {
+            override fun hasNext(): Boolean = sourceIterator.hasNext()
+
+            override fun next(): T {
+                if (!sourceIterator.hasNext()) throw NoSuchElementException()
+                workTracker.consume()
+                return sourceIterator.next()
+            }
+        }
+    }
+}
+
 private val QUALIFIED_NODE_PROPERTIES = setOf(GRAPH_ID_PROPERTY, ELEMENT_ID_PROPERTY, QUALIFIED_ID_PROPERTY)
 private val DIRECT_STRING_NODE_PROPERTIES = listOf(
     EnumConstant::class.java to setOf("name"),
@@ -386,7 +405,7 @@ class QueryPipeline private constructor(
                 val sort = orderBy.items.singleOrNull() ?: return null
                 if (sort.expression != CypherExpr.Variable(countColumn)) return null
                 val limitCount = (limit.count as? CypherExpr.Literal)?.value as? Number ?: return null
-                return LabelHistogramQuery(labelColumn, countColumn, sort.ascending, limitCount.toInt())
+                return LabelHistogramQuery(labelColumn, countColumn, sort.ascending, limitCount.toCypherInt())
             }
         }
     }
@@ -575,7 +594,8 @@ class QueryPipeline private constructor(
     ): CypherResult {
         val rows = mutableListOf<Map<String, Any?>>()
         for (source in sources) {
-            val indexedNodes = source.graph.nodesByStringProperty(
+            val indexedNodes = stringPropertyCandidates(
+                source.graph,
                 nodeClass,
                 filter.property,
                 filter.mode,
@@ -583,7 +603,6 @@ class QueryPipeline private constructor(
                 limit - rows.size
             )
             val candidates = indexedNodes
-                ?.let(::trackWork)
                 ?: trackWork(source.graph.nodes(nodeClass)).filter(filter::matches)
             for (node in candidates) {
 
@@ -633,7 +652,8 @@ class QueryPipeline private constructor(
                 ?.toInt()
                 ?: Int.MAX_VALUE
             val accelerated = filters.map { filter ->
-                graph.nodesByStringProperty(
+                stringPropertyCandidates(
+                    graph,
                     candidateType,
                     filter.property,
                     filter.mode,
@@ -644,7 +664,7 @@ class QueryPipeline private constructor(
             val candidates = if (accelerated.any { it == null }) {
                 trackWork(graph.nodes(candidateType)).filter(disjunction::matches)
             } else {
-                filterOwnedNodes(filters, accelerated.filterNotNull().map(::trackWork))
+                filterOwnedNodes(filters, accelerated.filterNotNull())
             }
             for (node in candidates) yield(node)
         }
@@ -1101,11 +1121,14 @@ class QueryPipeline private constructor(
         val paths = PathFinder.findPaths(
             graph = sourceNode.source.graph,
             sources = setOf(sourceNode.node.id),
-            targets = null,
-            edgeType = edgeClass,
-            minDepth = rel.minHops ?: 1,
-            maxDepth = rel.maxHops ?: 10,
-            direction = direction
+            options = PathFinder.SearchOptions(
+                targets = null,
+                edgeType = edgeClass,
+                minDepth = rel.minHops ?: 1,
+                maxDepth = rel.maxHops ?: 10,
+                direction = direction,
+                workTracker = if (workTrackingEnabled) activeWorkTracker.get() else null
+            )
         )
 
         for (path in paths) {
@@ -1272,7 +1295,23 @@ class QueryPipeline private constructor(
         return if (!workTrackingEnabled) {
             values
         } else {
-            activeWorkTracker.get()?.let { tracker -> values.onEach { tracker.consume() } } ?: values
+            activeWorkTracker.get()?.let { tracker -> WorkTrackingSequence(values, tracker) } ?: values
+        }
+    }
+
+    private fun <T : Node> stringPropertyCandidates(
+        graph: Graph,
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int
+    ): Sequence<T>? {
+        val tracker = if (workTrackingEnabled) activeWorkTracker.get() else null
+        return if (tracker != null) {
+            graph.nodesByStringProperty(type, property, mode, expected, limit, tracker)
+        } else {
+            graph.nodesByStringProperty(type, property, mode, expected, limit)
         }
     }
 
@@ -1570,12 +1609,19 @@ class QueryPipeline private constructor(
     private fun evaluateToInt(expr: CypherExpr, bindings: Map<String, Any?>): Int {
         val value = evaluator.evaluate(expr, bindings)
         return when (value) {
-            is Number -> value.toInt()
-            is String -> value.toIntOrNull() ?: 0
+            is Number -> value.toCypherInt()
+            is String -> value.toLongOrNull()
+                ?.coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+                ?.toInt()
+                ?: 0
             else -> 0
         }
     }
 }
+
+private fun Number.toCypherInt(): Int = toLong()
+    .coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+    .toInt()
 
 // ========================================================================
 // Pattern variable extraction

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -44,6 +44,32 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `retains QueryPipeline JVM one argument list constructor`() {
+        val constructor = assertNotNull(QueryPipeline::class.java.getConstructor(List::class.java))
+        val pipeline = constructor.newInstance(
+            listOf(CypherGraph("orders", graph(IntConstant(NodeId(1), 10))))
+        ) as QueryPipeline
+
+        val result = pipeline.execute(CypherDslAdapter.parse("MATCH (n:IntConstant) RETURN n.value"))
+        assertEquals(10, result.rows.single()["n.value"])
+    }
+
+    @Test
+    fun `execution budget charges qualified element id seeks across union segments`() {
+        val executor = CrossGraphCypherExecutor(
+            listOf(CypherGraph("orders", graph(IntConstant(NodeId(1), 10)))),
+            CypherExecutionBudget(maxWorkUnits = 1)
+        )
+
+        assertFailsWith<CypherBudgetExceededException> {
+            executor.execute(
+                "MATCH (n) WHERE elementId(n) = 'orders:1' RETURN n.id AS id " +
+                    "UNION ALL MATCH (n) WHERE elementId(n) = 'orders:1' RETURN n.id AS id"
+            )
+        }
+    }
+
+    @Test
     fun `qualifies colliding local node ids and records row provenance`() {
         val executor = executor(
             "orders" to graph(IntConstant(NodeId(1), 10)),

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -123,6 +123,35 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `label histogram sums type counts and retains contributors`() {
+        val executor = executor(
+            "orders" to graph(
+                IntConstant(NodeId(1), 10),
+                IntConstant(NodeId(2), 20),
+                StringConstant(NodeId(3), "shared")
+            ),
+            "billing" to graph(IntConstant(NodeId(1), 30))
+        )
+
+        val result = executor.execute(
+            """
+            MATCH (n)
+            UNWIND labels(n) AS label
+            RETURN label, count(*) AS c
+            ORDER BY c DESC
+            LIMIT 50
+            """.trimIndent()
+        )
+        val constant = result.rows.first { it["label"] == "Constant" }
+        val string = result.rows.first { it["label"] == "StringConstant" }
+
+        assertEquals(4L, constant["c"])
+        assertEquals(listOf("billing", "orders"), graphIds(constant))
+        assertEquals(1L, string["c"])
+        assertEquals(listOf("orders"), graphIds(string))
+    }
+
+    @Test
     fun `relationship and named path rows retain graph identity`() {
         val orders = DefaultGraph.Builder()
             .addNode(IntConstant(NodeId(1), 10))

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -209,6 +209,12 @@ class CrossGraphCypherExecutorTest {
             "MATCH (a:IntConstant)-[r:DATAFLOW*1..2]->(b:IntConstant) RETURN r"
         )
         assertEquals("orders", (variablePath.rows.single()["r"] as Map<*, *>)["graphId"])
+
+        val budgetedVariablePath = CrossGraphCypherExecutor(
+            listOf(CypherGraph("orders", orders)),
+            CypherExecutionBudget(maxWorkUnits = 20)
+        ).execute("MATCH (a:IntConstant)-[r:DATAFLOW*1..2]->(b:IntConstant) RETURN r")
+        assertEquals("orders", (budgetedVariablePath.rows.single()["r"] as Map<*, *>)["graphId"])
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -152,6 +152,21 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `cross graph execution shares one work budget`() {
+        val executor = CrossGraphCypherExecutor(
+            listOf(
+                CypherGraph("orders", graph(IntConstant(NodeId(1), 10), IntConstant(NodeId(2), 20))),
+                CypherGraph("billing", graph(IntConstant(NodeId(1), 30), IntConstant(NodeId(2), 40)))
+            ),
+            CypherExecutionBudget(maxWorkUnits = 3)
+        )
+
+        assertFailsWith<CypherBudgetExceededException> {
+            executor.execute("MATCH (n) RETURN n.id")
+        }
+    }
+
+    @Test
     fun `relationship and named path rows retain graph identity`() {
         val orders = DefaultGraph.Builder()
             .addNode(IntConstant(NodeId(1), 10))

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -25,10 +25,23 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CrossGraphCypherExecutorTest {
+
+    @Test
+    fun `retains JVM one argument constructor`() {
+        val constructor = assertNotNull(
+            CrossGraphCypherExecutor::class.java.getConstructor(List::class.java)
+        )
+        val executor = constructor.newInstance(
+            listOf(CypherGraph("orders", graph(IntConstant(NodeId(1), 10))))
+        ) as CrossGraphCypherExecutor
+
+        assertEquals(10, executor.execute("MATCH (n:IntConstant) RETURN n.value").rows.single()["n.value"])
+    }
 
     @Test
     fun `qualifies colliding local node ids and records row provenance`() {

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -707,6 +707,79 @@ class CypherExecutorTest {
         assertEquals(2L, result.rows[0]["cnt"])
     }
 
+    @Test
+    fun `label histogram uses node count metadata without scanning nodes`() {
+        var countCalls = 0
+        val metadataGraph = object : Graph by graph {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                error("label histogram must not scan nodes")
+
+            override fun nodeCount(type: Class<out Node>): Long? {
+                countCalls++
+                return graph.nodeCount(type)
+            }
+        }
+
+        val result = CypherExecutor(metadataGraph).execute(
+            """
+            MATCH (n)
+            UNWIND labels(n) AS label
+            RETURN label, count(*) AS c
+            ORDER BY c DESC
+            LIMIT 50
+            """.trimIndent()
+        )
+        val counts = result.rows.associate { it["label"] as String to it["c"] as Long }
+
+        assertEquals(listOf("label", "c"), result.columns)
+        assertEquals("Constant", result.rows.first()["label"])
+        assertEquals(9L, counts["Constant"])
+        assertEquals(2L, counts["CallSiteNode"])
+        assertEquals(2L, counts["Annotation"])
+        assertEquals(1L, counts["Resource"])
+        assertEquals(nodeLabelDescriptors.size, countCalls)
+    }
+
+    @Test
+    fun `label histogram supports aliases and limit`() {
+        val result = executor.execute(
+            """
+            MATCH (node)
+            UNWIND labels(node) AS rawLabel
+            RETURN rawLabel AS kind, count(*) AS total
+            ORDER BY total DESC
+            LIMIT 1
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("kind", "total"), result.columns)
+        assertEquals(listOf(mapOf("kind" to "Constant", "total" to 9L)), result.rows)
+    }
+
+    @Test
+    fun `label histogram falls back when node counts are unavailable`() {
+        var scanned = false
+        val scanningGraph = object : Graph by graph {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                graph.nodes(type).onEach { scanned = true }
+
+            override fun nodeCount(type: Class<out Node>): Long? = null
+        }
+
+        val result = CypherExecutor(scanningGraph).execute(
+            """
+            MATCH (n)
+            UNWIND labels(n) AS label
+            RETURN label, count(*) AS c
+            ORDER BY c DESC
+            LIMIT 1
+            """.trimIndent()
+        )
+
+        assertTrue(scanned)
+        assertEquals(listOf(mapOf("label" to "Constant", "c" to 9L)), result.rows)
+    }
+
     // --- EXISTS function ---
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -223,6 +223,65 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `execution budget rejects non-positive limits`() {
+        assertFailsWith<IllegalArgumentException> { CypherExecutionBudget(0) }
+    }
+
+    @Test
+    fun `execution budget stops a full node scan and resets per query`() {
+        val budgeted = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 2))
+
+        val error = assertFailsWith<CypherBudgetExceededException> {
+            budgeted.execute("MATCH (n) RETURN n.id")
+        }
+        assertEquals(2L, error.maxWorkUnits)
+        assertTrue(error.message.orEmpty().contains("selective label/filter"))
+
+        repeat(2) {
+            val result = budgeted.execute("MATCH (n) RETURN n.id LIMIT 2")
+            assertEquals(2, result.rows.size)
+        }
+    }
+
+    @Test
+    fun `execution budget counts relationship candidates`() {
+        val budgeted = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1))
+
+        assertFailsWith<CypherBudgetExceededException> {
+            budgeted.execute("MATCH (a:ParameterNode)-[r]->(b) RETURN b")
+        }
+    }
+
+    @Test
+    fun `execution budget is shared by union segments`() {
+        val budgeted = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 3))
+
+        assertFailsWith<CypherBudgetExceededException> {
+            budgeted.execute(
+                "MATCH (n:IntConstant) RETURN n.value AS value " +
+                    "UNION ALL MATCH (n:CallSiteNode) RETURN n.line AS value"
+            )
+        }
+    }
+
+    @Test
+    fun `execution budget does not charge metadata label histogram`() {
+        val budgeted = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1))
+
+        val result = budgeted.execute(
+            """
+            MATCH (n)
+            UNWIND labels(n) AS label
+            RETURN label, count(*) AS c
+            ORDER BY c DESC
+            LIMIT 50
+            """.trimIndent()
+        )
+
+        assertEquals(9L, result.rows.first { it["label"] == "Constant" }["c"])
+    }
+
+    @Test
     fun `execute with maxRows caps expression limit`() {
         var consumed = 0
         val counting = object : Graph by graph {

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -205,6 +205,12 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `execute with maxRows caps literal limit above Int range`() {
+        val result = executor.execute("MATCH (n) RETURN n.id LIMIT 2147483648", maxRows = 2)
+        assertEquals(2, result.rows.size)
+    }
+
+    @Test
     fun `execute with maxRows preserves smaller literal limit`() {
         val result = executor.execute("MATCH (n) RETURN n.id LIMIT 1", maxRows = 5)
         assertEquals(1, result.rows.size)
@@ -249,6 +255,18 @@ class CypherExecutorTest {
 
         assertFailsWith<CypherBudgetExceededException> {
             budgeted.execute("MATCH (a:ParameterNode)-[r]->(b) RETURN b")
+        }
+    }
+
+    @Test
+    fun `execution budget stops variable length path traversal`() {
+        val budgeted = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 2))
+
+        assertFailsWith<CypherBudgetExceededException> {
+            budgeted.execute(
+                "MATCH (a:IntConstant)-[:DATAFLOW*2..5]->(b:CallSiteNode) " +
+                    "RETURN a.value, b.callee_name"
+            )
         }
     }
 
@@ -813,6 +831,22 @@ class CypherExecutorTest {
 
         assertEquals(listOf("kind", "total"), result.columns)
         assertEquals(listOf(mapOf("kind" to "Constant", "total" to 9L)), result.rows)
+    }
+
+    @Test
+    fun `label histogram preserves literal limit above Int range`() {
+        val query = """
+            MATCH (n)
+            UNWIND labels(n) AS label
+            RETURN label, count(*) AS c
+            ORDER BY c DESC
+        """.trimIndent()
+
+        val expected = executor.execute("$query LIMIT 2147483647")
+        val result = executor.execute("$query LIMIT 2147483648")
+
+        assertTrue(result.rows.isNotEmpty())
+        assertEquals(expected, result)
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -284,6 +284,81 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `execution budget charges single hop target nodes on fast and generic paths`() {
+        val queries = listOf(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable) RETURN b.name LIMIT 1",
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable) RETURN b.name"
+        )
+
+        for (query in queries) {
+            val budgeted = CypherExecutor(dataFlowChain(length = 1), CypherExecutionBudget(maxWorkUnits = 2))
+            assertFailsWith<CypherBudgetExceededException> { budgeted.execute(query) }
+        }
+    }
+
+    @Test
+    fun `execution budget charges edges before type filtering on fast and generic paths`() {
+        val owner = TypeDescriptor("com.example.MixedEdges")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val source = IntConstant(NodeId.next(), 0)
+        val target = LocalVariable(NodeId.next(), "target", valueType, method)
+        val builder = DefaultGraph.Builder().addNode(source).addNode(target)
+        repeat(100) {
+            val wrongTarget = ReturnNode(NodeId.next(), method, valueType)
+            builder.addNode(wrongTarget)
+            builder.addEdge(CallEdge(source.id, wrongTarget.id, false))
+        }
+        builder.addEdge(DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN))
+        val mixedGraph = builder.build()
+        val queries = listOf(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable) RETURN b.name LIMIT 1",
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable) RETURN b.name"
+        )
+
+        for (query in queries) {
+            val budgeted = CypherExecutor(mixedGraph, CypherExecutionBudget(maxWorkUnits = 3))
+            assertFailsWith<CypherBudgetExceededException> { budgeted.execute(query) }
+        }
+    }
+
+    @Test
+    fun `execution budget survives a nested execution on the same pipeline`() {
+        val chain = dataFlowChain(length = 1)
+        lateinit var budgeted: CypherExecutor
+        var nested = false
+        val reentrantGraph = object : Graph by chain {
+            override fun outgoing(node: NodeId): Sequence<Edge> {
+                if (!nested) {
+                    nested = true
+                    budgeted.execute("RETURN 1")
+                }
+                return chain.outgoing(node)
+            }
+        }
+        budgeted = CypherExecutor(reentrantGraph, CypherExecutionBudget(maxWorkUnits = 1))
+
+        assertFailsWith<CypherBudgetExceededException> {
+            budgeted.execute(
+                "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable) RETURN b.name LIMIT 1"
+            )
+        }
+    }
+
+    @Test
+    fun `execution budget charges element id seeks across union segments`() {
+        val budgeted = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1))
+        val id = intConst42.value.toString()
+
+        assertFailsWith<CypherBudgetExceededException> {
+            budgeted.execute(
+                "MATCH (n) WHERE elementId(n) = '$id' RETURN n.id AS id " +
+                    "UNION ALL MATCH (n) WHERE elementId(n) = '$id' RETURN n.id AS id"
+            )
+        }
+    }
+
+    @Test
     fun `execution budget stops variable length path traversal`() {
         val budgeted = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 2))
 

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -229,6 +229,16 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `bound variable element id predicate uses normal match semantics`() {
+        val result = executor.execute(
+            "MATCH (n:IntConstant) MATCH (n) " +
+                "WHERE elementId(n) = '${intConst42.value}' RETURN n.value"
+        )
+
+        assertEquals(listOf(mapOf("n.value" to 42)), result.rows)
+    }
+
+    @Test
     fun `execution budget rejects non-positive limits`() {
         assertFailsWith<IllegalArgumentException> { CypherExecutionBudget(0) }
     }
@@ -246,6 +256,21 @@ class CypherExecutorTest {
         repeat(2) {
             val result = budgeted.execute("MATCH (n) RETURN n.id LIMIT 2")
             assertEquals(2, result.rows.size)
+        }
+    }
+
+    @Test
+    fun `execution context shares one budget across executors`() {
+        val chain = dataFlowChain(length = 1)
+        val context = CypherExecutionContext(CypherExecutionBudget(maxWorkUnits = 1))
+
+        val first = CypherExecutor(chain, context).execute(
+            "MATCH (n:IntConstant) RETURN n.value LIMIT 1"
+        )
+        assertEquals(listOf(mapOf("n.value" to 0)), first.rows)
+
+        assertFailsWith<CypherBudgetExceededException> {
+            CypherExecutor(chain, context).execute("MATCH (n:IntConstant) RETURN n.value LIMIT 1")
         }
     }
 
@@ -268,6 +293,81 @@ class CypherExecutorTest {
                     "RETURN a.value, b.callee_name"
             )
         }
+    }
+
+    @Test
+    fun `execution budget charges variable path materialization`() {
+        val budgeted = CypherExecutor(dataFlowChain(length = 1), CypherExecutionBudget(maxWorkUnits = 4))
+
+        assertFailsWith<CypherBudgetExceededException> {
+            budgeted.execute(
+                "MATCH (a:IntConstant)-[r:DATAFLOW*1..10000]->(b:LocalVariable) RETURN r LIMIT 1"
+            )
+        }
+    }
+
+    @Test
+    fun `variable path limit stops a high max hops traversal lazily`() {
+        val chain = dataFlowChain(length = 1_000)
+        var outgoingCalls = 0
+        val countingGraph = object : Graph by chain {
+            override fun outgoing(node: NodeId): Sequence<Edge> {
+                outgoingCalls++
+                return chain.outgoing(node)
+            }
+        }
+
+        val result = CypherExecutor(countingGraph).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW*1..100000]->(b:LocalVariable) RETURN b.name LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("b.name" to "local-0")), result.rows)
+        assertEquals(1, outgoingCalls)
+    }
+
+    @Test
+    fun `untyped variable path follows available relationships`() {
+        val result = CypherExecutor(dataFlowChain(length = 1)).execute(
+            "MATCH (a:IntConstant)-[*1..100]->(b:LocalVariable) RETURN b.name LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("b.name" to "local-0")), result.rows)
+    }
+
+    @Test
+    fun `single hop limit skips a target with the wrong type`() {
+        val result = CypherExecutor(dataFlowChain(length = 1)).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:CallSiteNode) RETURN b.callee_name LIMIT 1"
+        )
+
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `limit does not discard a later branch that completes the pattern`() {
+        val owner = TypeDescriptor("com.example.BranchLimit")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val source = IntConstant(NodeId.next(), 0)
+        val deadEnd = LocalVariable(NodeId.next(), "dead-end", valueType, method)
+        val liveMiddle = LocalVariable(NodeId.next(), "live-middle", valueType, method)
+        val target = LocalVariable(NodeId.next(), "target", valueType, method)
+        val branchGraph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(deadEnd)
+            .addNode(liveMiddle)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, deadEnd.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(source.id, liveMiddle.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(liveMiddle.id, target.id, DataFlowKind.ASSIGN))
+            .build()
+
+        val result = CypherExecutor(branchGraph).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable)" +
+                "-[:DATAFLOW]->(c:LocalVariable) RETURN c.name LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("c.name" to "target")), result.rows)
     }
 
     @Test
@@ -564,6 +664,16 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `match with STARTS WITH filter and limit`() {
+        val result = executor.execute(
+            "MATCH (n:CallSiteNode) WHERE n.callee_name STARTS WITH 'sa' " +
+                "RETURN n.callee_name LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("n.callee_name" to "save")), result.rows)
+    }
+
+    @Test
     fun `match with CONTAINS filter`() {
         val result = executor.execute("MATCH (n:CallSiteNode) WHERE n.callee_name CONTAINS 'av' RETURN n.callee_name")
         assertEquals(1, result.rows.size)
@@ -831,6 +941,22 @@ class CypherExecutorTest {
 
         assertEquals(listOf("kind", "total"), result.columns)
         assertEquals(listOf(mapOf("kind" to "Constant", "total" to 9L)), result.rows)
+    }
+
+    @Test
+    fun `label histogram with label ordering falls back without changing results`() {
+        val result = executor.execute(
+            """
+            MATCH (n)
+            UNWIND labels(n) AS label
+            RETURN label, count(*) AS c
+            ORDER BY label
+            LIMIT 50
+            """.trimIndent()
+        )
+
+        assertTrue(result.rows.isNotEmpty())
+        assertEquals(result.rows.map { it["label"] }.sortedBy(Any?::toString), result.rows.map { it["label"] })
     }
 
     @Test
@@ -1983,5 +2109,20 @@ class CypherExecutorTest {
         val constant = IntConstant(NodeId.next(), 42)
         assertTrue(PropertyFilter("value", FilterOperator.EQUALS, 42L, emptySet(), "n").matches(constant))
         assertFalse(PropertyFilter("value", FilterOperator.LESS_THAN, "x", emptySet(), "n").matches(constant))
+    }
+
+    private fun dataFlowChain(length: Int): Graph {
+        val owner = TypeDescriptor("com.example.PathBudget")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val builder = DefaultGraph.Builder()
+        var previous: Node = IntConstant(NodeId.next(), 0).also(builder::addNode)
+        repeat(length) { index ->
+            val next = LocalVariable(NodeId.next(), "local-$index", valueType, method)
+            builder.addNode(next)
+            builder.addEdge(DataFlowEdge(previous.id, next.id, DataFlowKind.ASSIGN))
+            previous = next
+        }
+        return builder.build()
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
@@ -81,6 +81,28 @@ class PathFinderTest {
     }
 
     @Test
+    fun `budgeted lazy match materializes its parent linked path`() {
+        val tracker = CypherWorkTracker(CypherExecutionBudget(maxWorkUnits = 20))
+        val match = PathFinder.findPathMatches(
+            graph,
+            setOf(nodeA),
+            PathFinder.SearchOptions(
+                targets = setOf(nodeD),
+                edgeType = DataFlowEdge::class.java,
+                minDepth = 1,
+                maxDepth = 5,
+                direction = PathFinder.Direction.OUTGOING,
+                workTracker = tracker
+            )
+        ).single()
+
+        assertEquals(nodeD, match.endNode().id)
+        val path = match.materialize(tracker)
+        assertEquals(listOf(nodeA, nodeB, nodeC, nodeD), path.nodes.map(Node::id))
+        assertEquals(3, path.edges.size)
+    }
+
+    @Test
     fun `depth limit prevents finding distant nodes`() {
         val paths = PathFinder.findPaths(
             graph, setOf(nodeA), setOf(nodeD),

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuard.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuard.kt
@@ -1,6 +1,7 @@
 package io.johnsonlee.graphite.cli
 
 import io.johnsonlee.graphite.cypher.CypherExecutionBudget
+import io.johnsonlee.graphite.cypher.CypherExecutionContext
 import java.util.concurrent.Semaphore
 
 internal const val DEFAULT_MAX_CONCURRENT_CYPHER = 2
@@ -15,17 +16,17 @@ internal class CypherQueryGuard(
     maxWorkUnits: Long = DEFAULT_CYPHER_WORK_BUDGET
 ) {
     private val permits: Semaphore
-    val executionBudget = CypherExecutionBudget(maxWorkUnits)
+    private val executionBudget = CypherExecutionBudget(maxWorkUnits)
 
     init {
         require(maxConcurrent > 0) { "maxConcurrent must be positive" }
         permits = Semaphore(maxConcurrent)
     }
 
-    fun <T> execute(block: (CypherExecutionBudget) -> T): T {
+    fun <T> execute(block: (CypherExecutionContext) -> T): T {
         if (!permits.tryAcquire()) throw CypherConcurrencyLimitException(maxConcurrent)
         return try {
-            block(executionBudget)
+            block(CypherExecutionContext(executionBudget))
         } finally {
             permits.release()
         }

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuard.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuard.kt
@@ -1,0 +1,33 @@
+package io.johnsonlee.graphite.cli
+
+import io.johnsonlee.graphite.cypher.CypherExecutionBudget
+import java.util.concurrent.Semaphore
+
+internal const val DEFAULT_MAX_CONCURRENT_CYPHER = 2
+internal const val DEFAULT_CYPHER_WORK_BUDGET = 250_000L
+
+internal class CypherConcurrencyLimitException(maxConcurrent: Int) : RuntimeException(
+    "Cypher concurrency limit reached ($maxConcurrent active queries); retry later"
+)
+
+internal class CypherQueryGuard(
+    private val maxConcurrent: Int = DEFAULT_MAX_CONCURRENT_CYPHER,
+    maxWorkUnits: Long = DEFAULT_CYPHER_WORK_BUDGET
+) {
+    private val permits: Semaphore
+    val executionBudget = CypherExecutionBudget(maxWorkUnits)
+
+    init {
+        require(maxConcurrent > 0) { "maxConcurrent must be positive" }
+        permits = Semaphore(maxConcurrent)
+    }
+
+    fun <T> execute(block: (CypherExecutionBudget) -> T): T {
+        if (!permits.tryAcquire()) throw CypherConcurrencyLimitException(maxConcurrent)
+        return try {
+            block(executionBudget)
+        } finally {
+            permits.release()
+        }
+    }
+}

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
@@ -18,6 +18,8 @@ import java.util.concurrent.Callable
 private const val DEFAULT_PORT = 8080
 private const val DEFAULT_PORT_TEXT = "8080"
 private const val DEFAULT_LOAD_MODE_TEXT = "MAPPED"
+private const val DEFAULT_MAX_CONCURRENT_CYPHER_TEXT = "2"
+private const val DEFAULT_CYPHER_WORK_BUDGET_TEXT = "250000"
 
 @Command(
     name = "serve",
@@ -59,10 +61,28 @@ open class ServeCommand : Callable<Int> {
     )
     var topology: Path? = null
 
+    @Option(
+        names = ["--max-concurrent-cypher"],
+        description = ["Maximum number of Cypher queries executing at once"],
+        defaultValue = DEFAULT_MAX_CONCURRENT_CYPHER_TEXT
+    )
+    var maxConcurrentCypher: Int = DEFAULT_MAX_CONCURRENT_CYPHER
+
+    @Option(
+        names = ["--cypher-work-budget"],
+        description = ["Maximum node and relationship visits per Cypher request"],
+        defaultValue = DEFAULT_CYPHER_WORK_BUDGET_TEXT
+    )
+    var cypherWorkBudget: Long = DEFAULT_CYPHER_WORK_BUDGET
+
     private val gson = GsonBuilder().setPrettyPrinting().create()
 
     @Suppress("ReturnCount", "TooGenericExceptionCaught")
     override fun call(): Int {
+        if (maxConcurrentCypher <= 0 || cypherWorkBudget <= 0) {
+            System.err.println("Error: Cypher concurrency and work budget must be positive")
+            return 1
+        }
         val hasInitialGraphs = graphDir != null || graphSpecs.isNotEmpty()
         if (!hasInitialGraphs && data == null) {
             System.err.println("Error: --data is required when starting without an initial graph")
@@ -101,6 +121,9 @@ open class ServeCommand : Callable<Int> {
                 "Topology: ${topologySummary.graphCount} graphs, " +
                     "${topologySummary.relationCount} relations"
             )
+            System.err.println(
+                "Cypher limits: $maxConcurrentCypher concurrent, $cypherWorkBudget work units per request"
+            )
             System.err.println("Press Ctrl+C to stop")
 
             Thread.currentThread().join()
@@ -113,11 +136,11 @@ open class ServeCommand : Callable<Int> {
     }
 
     internal fun registerApiRoutes(app: Javalin, graph: Graph) {
-        ExploreRoutes().register(app, graph)
+        ExploreRoutes(CypherQueryGuard(maxConcurrentCypher, cypherWorkBudget)).register(app, graph)
     }
 
     internal fun registerApiRoutes(app: Javalin, registry: GraphRegistry, topology: TopologyService) {
-        ExploreRoutes().register(app, registry, topology)
+        ExploreRoutes(CypherQueryGuard(maxConcurrentCypher, cypherWorkBudget)).register(app, registry, topology)
     }
 
     internal fun buildSubgraph(graph: Graph, center: NodeId, depth: Int): Map<String, Any> =

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
@@ -70,7 +70,7 @@ open class ServeCommand : Callable<Int> {
 
     @Option(
         names = ["--cypher-work-budget"],
-        description = ["Maximum node and relationship visits per Cypher request"],
+        description = ["Maximum graph candidate inspections per Cypher request"],
         defaultValue = DEFAULT_CYPHER_WORK_BUDGET_TEXT
     )
     var cypherWorkBudget: Long = DEFAULT_CYPHER_WORK_BUDGET

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
@@ -70,7 +70,7 @@ open class ServeCommand : Callable<Int> {
 
     @Option(
         names = ["--cypher-work-budget"],
-        description = ["Maximum graph candidate inspections per Cypher request"],
+        description = ["Maximum graph work units per Cypher request"],
         defaultValue = DEFAULT_CYPHER_WORK_BUDGET_TEXT
     )
     var cypherWorkBudget: Long = DEFAULT_CYPHER_WORK_BUDGET

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
@@ -11,7 +11,7 @@ import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.cypher.CrossGraphCypherExecutor
 import io.johnsonlee.graphite.cypher.CypherBudgetExceededException
-import io.johnsonlee.graphite.cypher.CypherExecutionBudget
+import io.johnsonlee.graphite.cypher.CypherExecutionContext
 import io.johnsonlee.graphite.cypher.CypherExecutor
 import io.johnsonlee.graphite.cypher.CypherGraph
 import io.johnsonlee.graphite.graph.ClassDependency
@@ -540,8 +540,8 @@ internal class ExploreRoutes(
     @Suppress("TooGenericExceptionCaught")
     private fun executeSingleGraphCypher(ctx: Context, graph: Graph, query: String) {
         try {
-            val result = cypherGuard.execute { budget ->
-                CypherExecutor(graph, budget).execute(
+            val result = cypherGuard.execute { executionContext ->
+                CypherExecutor(graph, executionContext).execute(
                     query,
                     boundedLimit(ctx, DEFAULT_CYPHER_ROW_LIMIT, MAX_CYPHER_ROW_LIMIT)
                 )
@@ -659,10 +659,10 @@ internal class ExploreRoutes(
         val limit = boundedLimit(ctx, DEFAULT_CYPHER_ROW_LIMIT, MAX_CYPHER_ROW_LIMIT)
         withAllGraphs(ctx, acquire) { leases ->
             try {
-                val result = cypherGuard.execute { budget ->
+                val result = cypherGuard.execute { executionContext ->
                     CrossGraphCypherExecutor(
                         leases.map { lease -> CypherGraph(lease.id, lease.graph) },
-                        budget
+                        executionContext
                     ).execute(query, limit)
                 }
                 ctx.json(
@@ -776,14 +776,14 @@ internal class ExploreRoutes(
             val graphIds = if (request.allGraphs) registry.ids() else request.graphIds
             val leases = registry.acquireAll(graphIds)
             try {
-                cypherGuard.execute { budget ->
+                cypherGuard.execute { executionContext ->
                     when (request.mode) {
                         MultiGraphQueryMode.CROSS_GRAPH -> {
                             require(request.perGraphLimit == null) { "perGraphLimit is only valid in fanout mode" }
                             require(!request.includeGraphRows) { "includeGraphRows is only valid in fanout mode" }
                             val result = CrossGraphCypherExecutor(
                                 leases.map { lease -> CypherGraph(lease.id, lease.graph) },
-                                budget
+                                executionContext
                             ).execute(request.query, request.limit)
                             ctx.json(
                                 mapOf(
@@ -800,7 +800,7 @@ internal class ExploreRoutes(
                         MultiGraphQueryMode.FANOUT -> {
                             val perGraphLimit = request.perGraphLimit
                                 ?: defaultPerGraphLimit(graphIds.size, request.limit)
-                            ctx.json(executeFanoutQuery(request, leases, perGraphLimit, budget))
+                            ctx.json(executeFanoutQuery(request, leases, perGraphLimit, executionContext))
                         }
                     }
                 }
@@ -820,20 +820,17 @@ internal class ExploreRoutes(
         request: MultiGraphCypherRequest,
         leases: List<GraphLease>,
         perGraphLimit: Int,
-        executionBudget: CypherExecutionBudget
+        executionContext: CypherExecutionContext
     ): Map<String, Any?> {
         val results = mutableListOf<MultiGraphCypherResult>()
         var remainingRows = request.limit
         var truncated = false
-        val perGraphWorkBudget = CypherExecutionBudget(
-            maxOf(1L, executionBudget.maxWorkUnits / maxOf(1, leases.size))
-        )
         for (lease in leases) {
             if (remainingRows <= 0) {
                 truncated = true
                 break
             }
-            val result = CypherExecutor(lease.graph, perGraphWorkBudget)
+            val result = CypherExecutor(lease.graph, executionContext)
                 .execute(request.query, minOf(perGraphLimit, remainingRows))
             val rows = result.rows.map { rowWithGraphId(lease.id, it) }
             remainingRows -= rows.size

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
@@ -10,6 +10,8 @@ import io.johnsonlee.graphite.core.Edge
 import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.cypher.CrossGraphCypherExecutor
+import io.johnsonlee.graphite.cypher.CypherBudgetExceededException
+import io.johnsonlee.graphite.cypher.CypherExecutionBudget
 import io.johnsonlee.graphite.cypher.CypherExecutor
 import io.johnsonlee.graphite.cypher.CypherGraph
 import io.johnsonlee.graphite.graph.ClassDependency
@@ -22,7 +24,9 @@ import java.io.IOException
 import java.nio.file.Path
 
 @Suppress("LargeClass", "StringLiteralDuplication", "TooManyFunctions")
-internal class ExploreRoutes {
+internal class ExploreRoutes(
+    private val cypherGuard: CypherQueryGuard = CypherQueryGuard()
+) {
 
     private val endpointExtractor = EndpointExtractor()
     private val openApiSpecBuilder = OpenApiSpecBuilder()
@@ -518,18 +522,7 @@ internal class ExploreRoutes {
                         return@withGraph
                     }
                 }
-                try {
-                    val result = CypherExecutor(graph).execute(query, boundedLimit(ctx, DEFAULT_CYPHER_ROW_LIMIT, MAX_CYPHER_ROW_LIMIT))
-                    ctx.json(
-                        mapOf(
-                            API_FIELD_COLUMNS to result.columns,
-                            API_FIELD_ROWS to result.rows,
-                            API_FIELD_ROW_COUNT to result.rows.size
-                        )
-                    )
-                } catch (e: Exception) {
-                    ctx.status(HTTP_BAD_REQUEST).json(mapOf(API_FIELD_ERROR to (e.message ?: "Query execution failed")))
-                }
+                executeSingleGraphCypher(ctx, graph, query)
             }
         }
 
@@ -539,19 +532,29 @@ internal class ExploreRoutes {
                     ctx.status(HTTP_BAD_REQUEST).result("Missing 'query' parameter")
                     return@withGraph
                 }
-                try {
-                    val result = CypherExecutor(graph).execute(query, boundedLimit(ctx, DEFAULT_CYPHER_ROW_LIMIT, MAX_CYPHER_ROW_LIMIT))
-                    ctx.json(
-                        mapOf(
-                            API_FIELD_COLUMNS to result.columns,
-                            API_FIELD_ROWS to result.rows,
-                            API_FIELD_ROW_COUNT to result.rows.size
-                        )
-                    )
-                } catch (e: Exception) {
-                    ctx.status(HTTP_BAD_REQUEST).json(mapOf(API_FIELD_ERROR to (e.message ?: "Query execution failed")))
-                }
+                executeSingleGraphCypher(ctx, graph, query)
             }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun executeSingleGraphCypher(ctx: Context, graph: Graph, query: String) {
+        try {
+            val result = cypherGuard.execute { budget ->
+                CypherExecutor(graph, budget).execute(
+                    query,
+                    boundedLimit(ctx, DEFAULT_CYPHER_ROW_LIMIT, MAX_CYPHER_ROW_LIMIT)
+                )
+            }
+            ctx.json(
+                mapOf(
+                    API_FIELD_COLUMNS to result.columns,
+                    API_FIELD_ROWS to result.rows,
+                    API_FIELD_ROW_COUNT to result.rows.size
+                )
+            )
+        } catch (error: RuntimeException) {
+            respondCypherError(ctx, error)
         }
     }
 
@@ -656,9 +659,12 @@ internal class ExploreRoutes {
         val limit = boundedLimit(ctx, DEFAULT_CYPHER_ROW_LIMIT, MAX_CYPHER_ROW_LIMIT)
         withAllGraphs(ctx, acquire) { leases ->
             try {
-                val result = CrossGraphCypherExecutor(
-                    leases.map { lease -> CypherGraph(lease.id, lease.graph) }
-                ).execute(query, limit)
+                val result = cypherGuard.execute { budget ->
+                    CrossGraphCypherExecutor(
+                        leases.map { lease -> CypherGraph(lease.id, lease.graph) },
+                        budget
+                    ).execute(query, limit)
+                }
                 ctx.json(
                     mapOf(
                         API_FIELD_COLUMNS to result.columns,
@@ -668,9 +674,7 @@ internal class ExploreRoutes {
                     )
                 )
             } catch (error: RuntimeException) {
-                ctx.status(HTTP_BAD_REQUEST).json(
-                    mapOf(API_FIELD_ERROR to (error.message ?: "Query execution failed"))
-                )
+                respondCypherError(ctx, error)
             }
         }
     }
@@ -687,6 +691,22 @@ internal class ExploreRoutes {
             return null
         }
         return query.trim()
+    }
+
+    private fun respondCypherError(ctx: Context, error: Throwable) {
+        val code = when (error) {
+            is CypherConcurrencyLimitException -> "cypher_concurrency_limit"
+            is CypherBudgetExceededException -> "cypher_work_budget_exceeded"
+            else -> "cypher_query_failed"
+        }
+        val status = if (code == "cypher_query_failed") HTTP_BAD_REQUEST else HTTP_TOO_MANY_REQUESTS
+        if (error is CypherConcurrencyLimitException) ctx.header("Retry-After", "1")
+        ctx.status(status).json(
+            mapOf(
+                API_FIELD_ERROR to (error.message ?: "Query execution failed"),
+                "code" to code
+            )
+        )
     }
 
     private fun registerAllC4Response(ctx: Context, acquire: (Context) -> List<GraphLease>) {
@@ -756,54 +776,65 @@ internal class ExploreRoutes {
             val graphIds = if (request.allGraphs) registry.ids() else request.graphIds
             val leases = registry.acquireAll(graphIds)
             try {
-                when (request.mode) {
-                    MultiGraphQueryMode.CROSS_GRAPH -> {
-                        require(request.perGraphLimit == null) { "perGraphLimit is only valid in fanout mode" }
-                        require(!request.includeGraphRows) { "includeGraphRows is only valid in fanout mode" }
-                        val result = CrossGraphCypherExecutor(
-                            leases.map { lease -> CypherGraph(lease.id, lease.graph) }
-                        ).execute(request.query, request.limit)
-                        ctx.json(
-                            mapOf(
-                                API_PARAM_MODE to request.mode.wireName,
-                                API_FIELD_GRAPHS to graphIds,
-                                "graphCount" to graphIds.size,
-                                API_FIELD_COLUMNS to result.columns,
-                                API_FIELD_ROWS to result.rows,
-                                API_FIELD_ROW_COUNT to result.rows.size,
-                                API_PARAM_LIMIT to request.limit
+                cypherGuard.execute { budget ->
+                    when (request.mode) {
+                        MultiGraphQueryMode.CROSS_GRAPH -> {
+                            require(request.perGraphLimit == null) { "perGraphLimit is only valid in fanout mode" }
+                            require(!request.includeGraphRows) { "includeGraphRows is only valid in fanout mode" }
+                            val result = CrossGraphCypherExecutor(
+                                leases.map { lease -> CypherGraph(lease.id, lease.graph) },
+                                budget
+                            ).execute(request.query, request.limit)
+                            ctx.json(
+                                mapOf(
+                                    API_PARAM_MODE to request.mode.wireName,
+                                    API_FIELD_GRAPHS to graphIds,
+                                    "graphCount" to graphIds.size,
+                                    API_FIELD_COLUMNS to result.columns,
+                                    API_FIELD_ROWS to result.rows,
+                                    API_FIELD_ROW_COUNT to result.rows.size,
+                                    API_PARAM_LIMIT to request.limit
+                                )
                             )
-                        )
-                    }
-                    MultiGraphQueryMode.FANOUT -> {
-                        val perGraphLimit = request.perGraphLimit
-                            ?: defaultPerGraphLimit(graphIds.size, request.limit)
-                        ctx.json(executeFanoutQuery(request, leases, perGraphLimit))
+                        }
+                        MultiGraphQueryMode.FANOUT -> {
+                            val perGraphLimit = request.perGraphLimit
+                                ?: defaultPerGraphLimit(graphIds.size, request.limit)
+                            ctx.json(executeFanoutQuery(request, leases, perGraphLimit, budget))
+                        }
                     }
                 }
             } finally {
                 leases.forEach { it.close() }
             }
         }.onFailure { error ->
-            val status = if (error is GraphNotLoadedException) HTTP_NOT_FOUND else HTTP_BAD_REQUEST
-            ctx.status(status).json(mapOf(API_FIELD_ERROR to (error.message ?: "Query execution failed")))
+            if (error is GraphNotLoadedException) {
+                ctx.status(HTTP_NOT_FOUND).json(mapOf(API_FIELD_ERROR to error.message))
+            } else {
+                respondCypherError(ctx, error)
+            }
         }
     }
 
     private fun executeFanoutQuery(
         request: MultiGraphCypherRequest,
         leases: List<GraphLease>,
-        perGraphLimit: Int
+        perGraphLimit: Int,
+        executionBudget: CypherExecutionBudget
     ): Map<String, Any?> {
         val results = mutableListOf<MultiGraphCypherResult>()
         var remainingRows = request.limit
         var truncated = false
+        val perGraphWorkBudget = CypherExecutionBudget(
+            maxOf(1L, executionBudget.maxWorkUnits / maxOf(1, leases.size))
+        )
         for (lease in leases) {
             if (remainingRows <= 0) {
                 truncated = true
                 break
             }
-            val result = CypherExecutor(lease.graph).execute(request.query, minOf(perGraphLimit, remainingRows))
+            val result = CypherExecutor(lease.graph, perGraphWorkBudget)
+                .execute(request.query, minOf(perGraphLimit, remainingRows))
             val rows = result.rows.map { rowWithGraphId(lease.id, it) }
             remainingRows -= rows.size
             truncated = truncated || remainingRows <= 0
@@ -1133,6 +1164,7 @@ internal class ExploreRoutes {
         private const val HTTP_BAD_REQUEST = 400
         private const val HTTP_NOT_FOUND = 404
         private const val HTTP_PAYLOAD_TOO_LARGE = 413
+        private const val HTTP_TOO_MANY_REQUESTS = 429
 
         private const val DEFAULT_ENTITY_LIMIT = 50
         private const val DEFAULT_EDGE_LIMIT = 200

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
@@ -65,6 +65,7 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
+                        "429" to response("Cypher concurrency or work budget exceeded"),
                         "404" to response("Graph not loaded")
                     )
                 ),
@@ -78,6 +79,7 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
+                        "429" to response("Cypher concurrency or work budget exceeded"),
                         "404" to response("Graph not loaded")
                     )
                 )
@@ -102,6 +104,7 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Multi-graph Cypher result with graphId-tagged rows"),
                         "400" to response("Missing or invalid query"),
+                        "429" to response("Cypher concurrency or work budget exceeded"),
                         "404" to response("Requested graph not loaded")
                     )
                 ),
@@ -121,6 +124,7 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Multi-graph Cypher result with graphId-tagged rows"),
                         "400" to response("Missing or invalid query"),
+                        "429" to response("Cypher concurrency or work budget exceeded"),
                         "404" to response("Requested graph not loaded")
                     )
                 )
@@ -287,7 +291,8 @@ internal class OpenApiSpecBuilder {
                     ),
                     responses = mapOf(
                         "200" to response("Cypher result"),
-                        "400" to response("Missing or invalid query")
+                        "400" to response("Missing or invalid query"),
+                        "429" to response("Cypher concurrency or work budget exceeded")
                     )
                 ),
                 "post" to operation(
@@ -298,7 +303,8 @@ internal class OpenApiSpecBuilder {
                     requestBody = cypherRequestBody(),
                     responses = mapOf(
                         "200" to response("Cypher result"),
-                        "400" to response("Missing or invalid query")
+                        "400" to response("Missing or invalid query"),
+                        "429" to response("Cypher concurrency or work budget exceeded")
                     )
                 )
             ),

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuardTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuardTest.kt
@@ -1,0 +1,29 @@
+package io.johnsonlee.graphite.cli
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CypherQueryGuardTest {
+
+    @Test
+    fun `guard validates concurrency and work limits`() {
+        assertFailsWith<IllegalArgumentException> {
+            CypherQueryGuard(maxConcurrent = 0, maxWorkUnits = 1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 0)
+        }
+    }
+
+    @Test
+    fun `guard releases permit when query fails`() {
+        val guard = CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 10)
+
+        assertFailsWith<IllegalStateException> {
+            guard.execute { error("query failed") }
+        }
+
+        assertEquals(10L, guard.execute { it.maxWorkUnits })
+    }
+}

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuardTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuardTest.kt
@@ -24,6 +24,6 @@ class CypherQueryGuardTest {
             guard.execute { error("query failed") }
         }
 
-        assertEquals(10L, guard.execute { it.maxWorkUnits })
+        assertEquals(10L, guard.execute { it.executionBudget.maxWorkUnits })
     }
 }

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -216,29 +216,42 @@ class ExploreCommandTest {
         return code to body
     }
 
-    private fun withExploreApp(graph: Graph, block: (Int) -> Unit) {
+    private fun withExploreApp(
+        graph: Graph,
+        routes: ExploreRoutes = ExploreRoutes(),
+        block: (Int) -> Unit
+    ) {
         val localApp = Javalin.create { config ->
             config.jsonMapper(JavalinGson(GsonBuilder().setPrettyPrinting().create()))
         }.start(0)
         try {
-            ExploreRoutes().register(localApp, graph)
+            routes.register(localApp, graph)
             block(localApp.port())
         } finally {
             localApp.stop()
         }
     }
 
-    private fun withRegistryApp(registry: GraphRegistry, block: (Int) -> Unit) {
+    private fun withRegistryApp(
+        registry: GraphRegistry,
+        routes: ExploreRoutes = ExploreRoutes(),
+        block: (Int) -> Unit
+    ) {
         val topology = TopologyService(registry, emptyList()).also { it.rebuild() }
-        withRegistryApp(registry, topology, block)
+        withRegistryApp(registry, topology, routes, block)
     }
 
-    private fun withRegistryApp(registry: GraphRegistry, topology: TopologyService, block: (Int) -> Unit) {
+    private fun withRegistryApp(
+        registry: GraphRegistry,
+        topology: TopologyService,
+        routes: ExploreRoutes = ExploreRoutes(),
+        block: (Int) -> Unit
+    ) {
         val localApp = Javalin.create { config ->
             config.jsonMapper(JavalinGson(GsonBuilder().setPrettyPrinting().create()))
         }.start(0)
         try {
-            ExploreRoutes().register(localApp, registry, topology)
+            routes.register(localApp, registry, topology)
             block(localApp.port())
         } finally {
             localApp.stop()
@@ -1109,7 +1122,8 @@ class ExploreCommandTest {
             }
             val registry = GraphRegistry(root, GraphStore.LoadMode.MAPPED)
 
-            withRegistryApp(registry) { targetPort ->
+            val routes = ExploreRoutes(CypherQueryGuard(maxConcurrent = 128, maxWorkUnits = 250_000))
+            withRegistryApp(registry, routes) { targetPort ->
                 repeat(graphCount) { index ->
                     val (loadCode, loadBody) = put(
                         targetPort,
@@ -1505,6 +1519,9 @@ class ExploreCommandTest {
         @Suppress("UNCHECKED_CAST")
         val post = cypher["post"] as Map<String, Any?>
         assertTrue(post.containsKey("requestBody"))
+        @Suppress("UNCHECKED_CAST")
+        val responses = post["responses"] as Map<String, Any?>
+        assertTrue(responses.containsKey("429"))
     }
 
     @Test
@@ -2067,6 +2084,22 @@ class ExploreCommandTest {
         assertNull(explore.graphId)
         assertNull(explore.topology)
         assertTrue(explore.graphSpecs.isEmpty())
+        assertEquals(DEFAULT_MAX_CONCURRENT_CYPHER, explore.maxConcurrentCypher)
+        assertEquals(DEFAULT_CYPHER_WORK_BUDGET, explore.cypherWorkBudget)
+    }
+
+    @Test
+    fun `serve rejects non-positive cypher limits`() {
+        val concurrency = ServeCommand().apply { maxConcurrentCypher = 0 }
+        val work = ServeCommand().apply { cypherWorkBudget = 0 }
+
+        val (_, concurrencyError, concurrencyCode) = captureOutput { concurrency.call() }
+        val (_, workError, workCode) = captureOutput { work.call() }
+
+        assertEquals(1, concurrencyCode)
+        assertEquals(1, workCode)
+        assertTrue(concurrencyError.contains("must be positive"), concurrencyError)
+        assertTrue(workError.contains("must be positive"), workError)
     }
 
     @Test
@@ -3487,6 +3520,72 @@ class ExploreCommandTest {
         val rows = result["rows"] as List<Map<String, Any?>>
         assertEquals(1, rows.size)
         assertEquals(1.0, result["rowCount"])
+    }
+
+    @Test
+    fun `cypher endpoint returns 429 when work budget is exceeded`() {
+        val budgetGraph = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId.next(), 1))
+            .addNode(IntConstant(NodeId.next(), 2))
+            .build()
+        val routes = ExploreRoutes(CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 1))
+
+        withExploreApp(budgetGraph, routes) { targetPort ->
+            val (limitedCode, limitedBody) = post(
+                targetPort,
+                "/api/cypher",
+                """{"query":"MATCH (n) RETURN n.id"}"""
+            )
+            assertEquals(429, limitedCode, limitedBody)
+            assertTrue(limitedBody.contains("cypher_work_budget_exceeded"), limitedBody)
+
+            val (metadataCode, metadataBody) = post(
+                targetPort,
+                "/api/cypher",
+                """{"query":"MATCH (n) UNWIND labels(n) AS label RETURN label, count(*) AS c ORDER BY c DESC LIMIT 50"}"""
+            )
+            assertEquals(200, metadataCode, metadataBody)
+        }
+    }
+
+    @Test
+    fun `cypher endpoint rejects excess concurrent queries`() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val backing = DefaultGraph.Builder().addNode(IntConstant(NodeId.next(), 1)).build()
+        val blockingGraph = object : Graph by backing {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> = sequence {
+                started.countDown()
+                check(release.await(5, TimeUnit.SECONDS))
+                yieldAll(backing.nodes(type))
+            }
+        }
+        val routes = ExploreRoutes(CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 10))
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            withExploreApp(blockingGraph, routes) { targetPort ->
+                val first = executor.submit<Pair<Int, String>> {
+                    post(targetPort, "/api/cypher", """{"query":"MATCH (n) RETURN n.id LIMIT 1"}""")
+                }
+                assertTrue(started.await(5, TimeUnit.SECONDS))
+
+                val (rejectedCode, rejectedBody) = post(
+                    targetPort,
+                    "/api/cypher",
+                    """{"query":"MATCH (n) RETURN n.id LIMIT 1"}"""
+                )
+                assertEquals(429, rejectedCode, rejectedBody)
+                assertTrue(rejectedBody.contains("cypher_concurrency_limit"), rejectedBody)
+
+                release.countDown()
+                val (firstCode, firstBody) = first.get(5, TimeUnit.SECONDS)
+                assertEquals(200, firstCode, firstBody)
+            }
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -962,6 +962,37 @@ class ExploreCommandTest {
     }
 
     @Test
+    fun `fanout lets the first graph use the remaining request budget`() {
+        val root = Files.createTempDirectory("explore-registry-fanout-budget-remainder")
+        try {
+            saveConstantGraph(root, "service-a", 101, 102, 103, 104, 105, 106)
+            saveConstantGraph(root, "service-b", 202)
+            val registry = GraphRegistry(root, GraphStore.LoadMode.MAPPED)
+            val routes = ExploreRoutes(CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 10))
+
+            withRegistryApp(registry, routes) { targetPort ->
+                registry.load("service-a", Path.of("service-a"))
+                registry.load("service-b", Path.of("service-b"))
+                val query = "MATCH (n:IntConstant) WHERE n.value = 106 RETURN n.value"
+                val (code, body) = post(
+                    targetPort,
+                    "/api/cypher/graphs",
+                    """{"query":"$query","allGraphs":true,"mode":"fanout","limit":1,"perGraphLimit":1}"""
+                )
+
+                assertEquals(200, code, body)
+                val result: Map<String, Any?> = parseJson(body)
+                assertEquals(1.0, result[API_FIELD_ROW_COUNT])
+                @Suppress("UNCHECKED_CAST")
+                val rows = result[API_FIELD_ROWS] as List<Map<String, Any?>>
+                assertEquals(106.0, rows.single()["n.value"])
+            }
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `registry cypher endpoint keeps default limit global across twenty one graphs`() {
         val root = Files.createTempDirectory("explore-registry-21-fanout")
         val graphCount = 21

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -926,6 +926,42 @@ class ExploreCommandTest {
     }
 
     @Test
+    fun `fanout shares one request work budget without fixed graph shares`() {
+        val root = Files.createTempDirectory("explore-registry-shared-fanout-budget")
+        try {
+            saveConstantGraph(root, "service-a", 101)
+            saveConstantGraph(root, "service-b", 202)
+            val registry = GraphRegistry(root, GraphStore.LoadMode.MAPPED)
+            val routes = ExploreRoutes(CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 1))
+
+            withRegistryApp(registry, routes) { targetPort ->
+                registry.load("service-a", Path.of("service-a"))
+                registry.load("service-b", Path.of("service-b"))
+                val query = "MATCH (n:IntConstant) RETURN n.value"
+
+                val (withinCode, withinBody) = post(
+                    targetPort,
+                    "/api/cypher/graphs",
+                    """{"query":"$query","allGraphs":true,"mode":"fanout","limit":1,"perGraphLimit":1}"""
+                )
+                assertEquals(200, withinCode, withinBody)
+                val within: Map<String, Any?> = parseJson(withinBody)
+                assertEquals(1.0, within[API_FIELD_ROW_COUNT])
+
+                val (exceededCode, exceededBody) = post(
+                    targetPort,
+                    "/api/cypher/graphs",
+                    """{"query":"$query","allGraphs":true,"mode":"fanout","limit":2,"perGraphLimit":1}"""
+                )
+                assertEquals(429, exceededCode, exceededBody)
+                assertTrue(exceededBody.contains("cypher_work_budget_exceeded"), exceededBody)
+            }
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `registry cypher endpoint keeps default limit global across twenty one graphs`() {
         val root = Files.createTempDirectory("explore-registry-21-fanout")
         val graphCount = 21

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidSchemaDiscoveryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidSchemaDiscoveryBenchmark.kt
@@ -1,5 +1,6 @@
 package io.johnsonlee.graphite.webgraph
 
+import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.cypher.CypherBudgetExceededException
 import io.johnsonlee.graphite.cypher.CypherExecutionBudget
 import io.johnsonlee.graphite.cypher.CypherExecutor
@@ -35,6 +36,7 @@ open class AndroidSchemaDiscoveryBenchmark {
         mappedGraph = GraphStore.loadMapped(
             BenchmarkCorpus.persistedGraph(BenchmarkCorpusKind.ANDROID)
         )
+        check(mappedGraph.nodeCount(Node::class.java) == BenchmarkCorpusKind.ANDROID.expectedNodeCount)
         budgetedExecutor = CypherExecutor(
             mappedGraph,
             CypherExecutionBudget(SCHEMA_DISCOVERY_WORK_BUDGET)

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidSchemaDiscoveryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidSchemaDiscoveryBenchmark.kt
@@ -1,0 +1,72 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.cypher.query
+import io.johnsonlee.graphite.graph.Graph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 1, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(1, jvmArgs = ["-Xmx16g"])
+open class AndroidSchemaDiscoveryBenchmark {
+    private lateinit var mappedGraph: Graph
+
+    @Setup
+    fun setup() {
+        mappedGraph = GraphStore.loadMapped(
+            BenchmarkCorpus.persistedGraph(BenchmarkCorpusKind.ANDROID)
+        )
+        val sample = sampleLabelsAndKeys()
+        check(sample.rows.size == SCHEMA_SAMPLE_LIMIT)
+        val histogram = labelHistogram()
+        check(histogram.rows.isNotEmpty())
+        check(
+            histogram.rows.all {
+                (it[SCHEMA_COUNT_COLUMN] as? Number)?.toLong()?.let { count -> count > 0L } == true
+            }
+        )
+    }
+
+    @TearDown
+    fun tearDown() {
+        (mappedGraph as? Closeable)?.close()
+    }
+
+    @Benchmark
+    fun sampleLabelsAndKeys(): CypherResult = mappedGraph.query(SAMPLE_LABELS_AND_KEYS_QUERY)
+
+    @Benchmark
+    fun labelHistogram(): CypherResult = mappedGraph.query(LABEL_HISTOGRAM_QUERY)
+}
+
+private const val SCHEMA_SAMPLE_LIMIT = 20
+private const val SCHEMA_COUNT_COLUMN = "c"
+
+private const val SAMPLE_LABELS_AND_KEYS_QUERY = """
+MATCH (n)
+RETURN labels(n) AS labels, keys(n) AS keys
+LIMIT 20
+"""
+
+private const val LABEL_HISTOGRAM_QUERY = """
+MATCH (n)
+UNWIND labels(n) AS label
+RETURN label, count(*) AS c
+ORDER BY c DESC
+LIMIT 50
+"""

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidSchemaDiscoveryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidSchemaDiscoveryBenchmark.kt
@@ -1,5 +1,8 @@
 package io.johnsonlee.graphite.webgraph
 
+import io.johnsonlee.graphite.cypher.CypherBudgetExceededException
+import io.johnsonlee.graphite.cypher.CypherExecutionBudget
+import io.johnsonlee.graphite.cypher.CypherExecutor
 import io.johnsonlee.graphite.cypher.CypherResult
 import io.johnsonlee.graphite.cypher.query
 import io.johnsonlee.graphite.graph.Graph
@@ -25,11 +28,16 @@ import java.util.concurrent.TimeUnit
 @Fork(1, jvmArgs = ["-Xmx16g"])
 open class AndroidSchemaDiscoveryBenchmark {
     private lateinit var mappedGraph: Graph
+    private lateinit var budgetedExecutor: CypherExecutor
 
     @Setup
     fun setup() {
         mappedGraph = GraphStore.loadMapped(
             BenchmarkCorpus.persistedGraph(BenchmarkCorpusKind.ANDROID)
+        )
+        budgetedExecutor = CypherExecutor(
+            mappedGraph,
+            CypherExecutionBudget(SCHEMA_DISCOVERY_WORK_BUDGET)
         )
         val sample = sampleLabelsAndKeys()
         check(sample.rows.size == SCHEMA_SAMPLE_LIMIT)
@@ -52,10 +60,22 @@ open class AndroidSchemaDiscoveryBenchmark {
 
     @Benchmark
     fun labelHistogram(): CypherResult = mappedGraph.query(LABEL_HISTOGRAM_QUERY)
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 3)
+    fun boundedPropertyKeyHistogram(): Long = try {
+        budgetedExecutor.execute(PROPERTY_KEY_HISTOGRAM_QUERY)
+        error("property-key histogram unexpectedly completed within its work budget")
+    } catch (error: CypherBudgetExceededException) {
+        error.maxWorkUnits
+    }
 }
 
 private const val SCHEMA_SAMPLE_LIMIT = 20
 private const val SCHEMA_COUNT_COLUMN = "c"
+private const val SCHEMA_DISCOVERY_WORK_BUDGET = 250_000L
 
 private const val SAMPLE_LABELS_AND_KEYS_QUERY = """
 MATCH (n)
@@ -67,6 +87,14 @@ private const val LABEL_HISTOGRAM_QUERY = """
 MATCH (n)
 UNWIND labels(n) AS label
 RETURN label, count(*) AS c
+ORDER BY c DESC
+LIMIT 50
+"""
+
+private const val PROPERTY_KEY_HISTOGRAM_QUERY = """
+MATCH (n)
+UNWIND keys(n) AS key
+RETURN key, count(*) AS c
 ORDER BY c DESC
 LIMIT 50
 """

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -15,9 +15,10 @@ import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.GraphWorkConsumer
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.graph.StringMatchMode
-import io.johnsonlee.graphite.graph.StringPropertyLookup
+import io.johnsonlee.graphite.graph.WorkAwareStringPropertyLookup
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.ints.IntArrayList
@@ -75,7 +76,7 @@ internal class MappedWebGraphBackedGraph(
     private val metadata: Lazy<GraphMetadata>,
     private val classOverviewProvider: (Int) -> ClassOverview?,
     private val resourceAccessor: Lazy<ResourceAccessor>
-) : Graph, StringPropertyLookup, Closeable {
+) : Graph, WorkAwareStringPropertyLookup, Closeable {
 
     override val resources: ResourceAccessor
         get() = resourceAccessor.value
@@ -131,6 +132,25 @@ internal class MappedWebGraphBackedGraph(
         mode: StringMatchMode,
         expected: String,
         limit: Int
+    ): Sequence<T>? = lookupStringProperty(type, property, mode, expected, limit, workConsumer = null)
+
+    override fun <T : Node> nodesByStringProperty(
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int,
+        workConsumer: GraphWorkConsumer
+    ): Sequence<T>? = lookupStringProperty(type, property, mode, expected, limit, workConsumer)
+
+    @Suppress("UNCHECKED_CAST", "ReturnCount")
+    private fun <T : Node> lookupStringProperty(
+        type: Class<T>,
+        property: String,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int,
+        workConsumer: GraphWorkConsumer?
     ): Sequence<T>? {
         if (!supportsRawStringProperty(type, property)) return null
         if (limit <= 0) return emptySequence()
@@ -138,7 +158,7 @@ internal class MappedWebGraphBackedGraph(
         synchronized(stringPropertyIndexLock) {
             stringPropertyIndexes[key]
         }?.let { index ->
-            return indexedNodes(index, mode, expected, limit)
+            return indexedNodes(index, mode, expected, limit, workConsumer)
         }
 
         val admission = StringPropertyAdmissionKey(key, mode, expected, limit)
@@ -149,13 +169,13 @@ internal class MappedWebGraphBackedGraph(
             return if (limit == Int.MAX_VALUE) {
                 null
             } else {
-                rawStringPropertyScan(type, property, mode, expected, limit, admission)
+                rawStringPropertyScan(type, property, mode, expected, limit, admission, workConsumer)
             }
         }
 
         val index = synchronized(stringPropertyIndexLock) {
             stringPropertyIndexes[key] ?: run {
-                buildStringPropertyIndex(type, property)?.also {
+                buildStringPropertyIndex(type, property, workConsumer)?.also {
                     stringPropertyIndexes[key] = it
                     stringPropertyAdmissions.clear(key)
                 } ?: run {
@@ -166,9 +186,9 @@ internal class MappedWebGraphBackedGraph(
         } ?: return if (limit == Int.MAX_VALUE) {
             null
         } else {
-            rawStringPropertyScan(type, property, mode, expected, limit, admission)
+            rawStringPropertyScan(type, property, mode, expected, limit, admission, workConsumer)
         }
-        return indexedNodes(index, mode, expected, limit)
+        return indexedNodes(index, mode, expected, limit, workConsumer)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -176,8 +196,9 @@ internal class MappedWebGraphBackedGraph(
         index: MappedStringPropertyIndex,
         mode: StringMatchMode,
         expected: String,
-        limit: Int
-    ): Sequence<T> = index.matchingNodeIds(mode, expected)
+        limit: Int,
+        workConsumer: GraphWorkConsumer?
+    ): Sequence<T> = index.matchingNodeIds(mode, expected, workConsumer)
         .take(limit)
         .mapNotNull { node(NodeId(it)) as? T }
 
@@ -188,12 +209,14 @@ internal class MappedWebGraphBackedGraph(
         mode: StringMatchMode,
         expected: String,
         limit: Int,
-        admission: StringPropertyAdmissionKey
+        admission: StringPropertyAdmissionKey,
+        workConsumer: GraphWorkConsumer?
     ): Sequence<T> = sequence {
         var inspected = 0
         var yielded = 0
         var admitted = false
         for (nodeId in nodeTypeIndex.ids(type)) {
+            workConsumer?.consume()
             inspected++
             if (!admitted && inspected > MAX_STRING_PROPERTY_ADMISSION_NODES) {
                 synchronized(stringPropertyIndexLock) {
@@ -332,7 +355,8 @@ internal class MappedWebGraphBackedGraph(
 
     private fun buildStringPropertyIndex(
         type: Class<out Node>,
-        property: String
+        property: String,
+        workConsumer: GraphWorkConsumer?
     ): MappedStringPropertyIndex? {
         val nodeCount = nodeTypeIndex.count(type)
         if (estimatedStringPropertyIndexBytes(nodeCount) > MAX_STRING_PROPERTY_INDEX_RETAINED_BYTES) return null
@@ -341,6 +365,7 @@ internal class MappedWebGraphBackedGraph(
         val stringIds = IntArray(capacity)
         var size = 0
         for (nodeId in nodeTypeIndex.ids(type)) {
+            workConsumer?.consume()
             val stringId = rawStringPropertyIndex(nodeId, type, property) ?: continue
             nodeIds[size] = nodeId
             stringIds[size] = stringId
@@ -538,7 +563,8 @@ internal class MappedStringPropertyIndex(
     private val maxMatchingStringCacheEntries: Int = MAX_STRING_MATCH_CACHE_ENTRIES,
     private val maxMatchingStringCacheBytes: Long = MAX_STRING_MATCH_CACHE_BYTES
 ) {
-    private val trigramIndex: Int2ObjectOpenHashMap<IntArray>? by lazy(::buildTrigramIndex)
+    private var trigramIndexInitialized = false
+    private var trigramIndex: Int2ObjectOpenHashMap<IntArray>? = null
     private val matchingStrings = LinkedHashMap<StringMatchKey, IntArray>(
         MAX_STRING_MATCH_CACHE_ENTRIES + 1,
         STRING_PROPERTY_INDEX_LOAD_FACTOR,
@@ -546,23 +572,34 @@ internal class MappedStringPropertyIndex(
     )
     private var matchingStringCacheBytes = 0L
 
-    fun matchingNodeIds(mode: StringMatchMode, expected: String): Sequence<Int> {
-        val matchedStrings = matchingStringIds(mode, expected)
+    fun matchingNodeIds(
+        mode: StringMatchMode,
+        expected: String,
+        workConsumer: GraphWorkConsumer? = null
+    ): Sequence<Int> {
+        val matchedStrings = matchingStringIds(mode, expected, workConsumer)
         if (matchedStrings.isEmpty()) return emptySequence()
         return nodeIds.indices.asSequence()
-            .filter { java.util.Arrays.binarySearch(matchedStrings, stringIds[it]) >= 0 }
+            .filter {
+                workConsumer?.consume()
+                java.util.Arrays.binarySearch(matchedStrings, stringIds[it]) >= 0
+            }
             .map { nodeIds[it] }
     }
 
     @Synchronized
-    private fun matchingStringIds(mode: StringMatchMode, expected: String): IntArray {
+    private fun matchingStringIds(
+        mode: StringMatchMode,
+        expected: String,
+        workConsumer: GraphWorkConsumer?
+    ): IntArray {
         val key = StringMatchKey(mode, expected)
         matchingStrings[key]?.let { return it }
 
         val result = when {
             mode == StringMatchMode.CONTAINS && expected.length >= MIN_TRIGRAM_LENGTH ->
-                matchingContainsStringIds(expected)
-            else -> scanMatchingStringIds(mode, expected)
+                matchingContainsStringIds(expected, workConsumer)
+            else -> scanMatchingStringIds(mode, expected, workConsumer)
         }
         cacheMatchingStrings(key, result)
         return result
@@ -587,8 +624,12 @@ internal class MappedStringPropertyIndex(
     internal fun matchingStringCacheSize(): Int = matchingStrings.size
 
     @Suppress("ReturnCount")
-    private fun matchingContainsStringIds(expected: String): IntArray {
-        val index = trigramIndex ?: return scanMatchingStringIds(StringMatchMode.CONTAINS, expected)
+    private fun matchingContainsStringIds(
+        expected: String,
+        workConsumer: GraphWorkConsumer?
+    ): IntArray {
+        val index = getTrigramIndex(workConsumer)
+            ?: return scanMatchingStringIds(StringMatchMode.CONTAINS, expected, workConsumer)
         var candidates: IntArray? = null
         val seenTrigrams = IntOpenHashSet()
         for (position in 0..expected.length - MIN_TRIGRAM_LENGTH) {
@@ -602,15 +643,21 @@ internal class MappedStringPropertyIndex(
         val matched = IntArray(shortestPosting.size)
         var size = 0
         for (stringId in shortestPosting) {
+            workConsumer?.consume()
             if (stringTable.get(stringId).contains(expected)) matched[size++] = stringId
         }
         return matched.copyOf(size).also(java.util.Arrays::sort)
     }
 
-    private fun scanMatchingStringIds(mode: StringMatchMode, expected: String): IntArray {
+    private fun scanMatchingStringIds(
+        mode: StringMatchMode,
+        expected: String,
+        workConsumer: GraphWorkConsumer?
+    ): IntArray {
         val matched = IntArray(uniqueStringIds.size)
         var size = 0
         for (stringId in uniqueStringIds) {
+            workConsumer?.consume()
             val actual = stringTable.get(stringId)
             val matches = when (mode) {
                 StringMatchMode.STARTS_WITH -> actual.startsWith(expected)
@@ -622,14 +669,26 @@ internal class MappedStringPropertyIndex(
         return matched.copyOf(size)
     }
 
-    private fun buildTrigramIndex(): Int2ObjectOpenHashMap<IntArray>? {
-        if (uniqueStringIds.size > MAX_TRIGRAM_INDEX_STRINGS) return null
-        val builder = TrigramIndexBuilder(maxTrigramPostings, maxTrigramBytes)
-        return if (populateTrigramIndex(builder)) builder.build() else null
+    private fun getTrigramIndex(workConsumer: GraphWorkConsumer?): Int2ObjectOpenHashMap<IntArray>? {
+        if (!trigramIndexInitialized) {
+            trigramIndex = buildTrigramIndex(workConsumer)
+            trigramIndexInitialized = true
+        }
+        return trigramIndex
     }
 
-    private fun populateTrigramIndex(builder: TrigramIndexBuilder): Boolean {
+    private fun buildTrigramIndex(workConsumer: GraphWorkConsumer?): Int2ObjectOpenHashMap<IntArray>? {
+        if (uniqueStringIds.size > MAX_TRIGRAM_INDEX_STRINGS) return null
+        val builder = TrigramIndexBuilder(maxTrigramPostings, maxTrigramBytes)
+        return if (populateTrigramIndex(builder, workConsumer)) builder.build() else null
+    }
+
+    private fun populateTrigramIndex(
+        builder: TrigramIndexBuilder,
+        workConsumer: GraphWorkConsumer?
+    ): Boolean {
         for (stringId in uniqueStringIds) {
+            workConsumer?.consume()
             if (!builder.add(stringId, stringTable.get(stringId))) return false
         }
         return true

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -574,8 +574,13 @@ internal class MappedStringPropertyIndex(
 
     fun matchingNodeIds(
         mode: StringMatchMode,
+        expected: String
+    ): Sequence<Int> = matchingNodeIds(mode, expected, workConsumer = null)
+
+    fun matchingNodeIds(
+        mode: StringMatchMode,
         expected: String,
-        workConsumer: GraphWorkConsumer? = null
+        workConsumer: GraphWorkConsumer?
     ): Sequence<Int> {
         val matchedStrings = matchingStringIds(mode, expected, workConsumer)
         if (matchedStrings.isEmpty()) return emptySequence()

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -317,6 +317,33 @@ class GraphStoreTest {
     }
 
     @Test
+    fun `mapped string index retains two argument JVM lookup method`() {
+        val dir = Files.createTempDirectory("webgraph-string-index-abi")
+        try {
+            val strings = StringTable.build(listOf("alpha"), dir)
+            val index = MappedStringPropertyIndex(
+                nodeIds = intArrayOf(10),
+                stringIds = intArrayOf(strings.indexOf("alpha")),
+                uniqueStringIds = intArrayOf(strings.indexOf("alpha")),
+                stringTable = strings
+            )
+            val method = assertNotNull(
+                MappedStringPropertyIndex::class.java.getMethod(
+                    "matchingNodeIds",
+                    StringMatchMode::class.java,
+                    String::class.java
+                )
+            )
+
+            @Suppress("UNCHECKED_CAST")
+            val result = method.invoke(index, StringMatchMode.STARTS_WITH, "alpha") as Sequence<Int>
+            assertEquals(listOf(10), result.toList())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `mapped string lookup admits an index only after a long raw scan`() {
         val graph = DefaultGraph.Builder().apply {
             repeat(300) { index ->

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/MappedCypherBudgetTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/MappedCypherBudgetTest.kt
@@ -1,0 +1,86 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.StringConstant
+import io.johnsonlee.graphite.cypher.CypherBudgetExceededException
+import io.johnsonlee.graphite.cypher.CypherExecutionBudget
+import io.johnsonlee.graphite.cypher.CypherExecutor
+import io.johnsonlee.graphite.graph.DefaultGraph
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MappedCypherBudgetTest {
+
+    @Test
+    fun `mapped raw string miss charges every inspected node`() = withMappedStrings { graph ->
+        val matched = CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1)).execute(
+            "MATCH (n:StringConstant) WHERE n.value CONTAINS 'value-0' RETURN n.value LIMIT 1"
+        )
+        assertEquals("value-0", matched.rows.single()["n.value"])
+
+        assertFailsWith<CypherBudgetExceededException> {
+            CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1)).execute(
+                "MATCH (n:StringConstant) WHERE n.value CONTAINS 'raw-never-present' " +
+                    "RETURN n.value LIMIT 1"
+            )
+        }
+        assertEquals(0, graph.stringPropertyIndexCount())
+    }
+
+    @Test
+    fun `mapped first string index build charges every inspected node`() = withMappedStrings { graph ->
+        val query = "MATCH (n:StringConstant) WHERE n.value CONTAINS 'build-never-present' " +
+            "RETURN n.value LIMIT 1"
+        CypherExecutor(graph).execute(query)
+        assertEquals(0, graph.stringPropertyIndexCount())
+
+        assertFailsWith<CypherBudgetExceededException> {
+            CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1)).execute(query)
+        }
+        assertEquals(0, graph.stringPropertyIndexCount())
+    }
+
+    @Test
+    fun `mapped existing string index charges internal candidate scans`() = withMappedStrings { graph ->
+        val admissionQuery = "MATCH (n:StringConstant) WHERE n.value CONTAINS 'index-never-present' " +
+            "RETURN n.value LIMIT 1"
+        val cachedLateMatchQuery = "MATCH (n:StringConstant) WHERE n.value STARTS WITH 'value-299' " +
+            "RETURN n.value LIMIT 1"
+        val unbudgeted = CypherExecutor(graph)
+        unbudgeted.execute(admissionQuery)
+        unbudgeted.execute(admissionQuery)
+        assertEquals(1, graph.stringPropertyIndexCount())
+
+        assertFailsWith<CypherBudgetExceededException> {
+            CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1)).execute(
+                "MATCH (n:StringConstant) WHERE n.value STARTS WITH 'other-never-present' " +
+                "RETURN n.value LIMIT 1"
+            )
+        }
+
+        assertEquals("value-299", unbudgeted.execute(cachedLateMatchQuery).rows.single()["n.value"])
+        assertFailsWith<CypherBudgetExceededException> {
+            CypherExecutor(graph, CypherExecutionBudget(maxWorkUnits = 1)).execute(cachedLateMatchQuery)
+        }
+    }
+
+    private fun withMappedStrings(block: (MappedWebGraphBackedGraph) -> Unit) {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(300) { index -> addNode(StringConstant(NodeId(index), "value-$index")) }
+        }.build()
+        val directory = Files.createTempDirectory("mapped-cypher-budget")
+        try {
+            GraphStore.save(graph, directory)
+            val mapped = GraphStore.loadMapped(directory) as MappedWebGraphBackedGraph
+            try {
+                block(mapped)
+            } finally {
+                mapped.close()
+            }
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- answer `MATCH (n) UNWIND labels(n) ... count(*)` from node-type metadata instead of scanning millions of nodes
- bound HTTP Cypher requests with concurrency and graph-work budgets across single-graph, cross-graph, UNION, variable-path, mapped-string, and fanout execution
- preserve the released `CrossGraphCypherExecutor(List)` JVM constructor and safely handle integer `LIMIT` values above `Int.MAX_VALUE`
- expose the limits as `--max-concurrent-cypher` and `--cypher-work-budget`, returning HTTP 429 when either limit is exceeded

## Optimization gains

Measured on the persisted 5,938,826-node Android JAR fixture, using the same benchmark source on `main` and this branch:

| Production query shape | `main` | PR | Improvement |
|------------------------|-------:|---:|------------:|
| six-property broad keyword discovery, cold | `7,426.015 ms/op` | `207.392 ms/op` | `35.81x` faster |
| six-property broad keyword discovery, repeated | `7,433.167 ms/op` | `204.300 ms/op` | `36.38x` faster |
| `UNWIND labels(n) ... count(*)` | `8,733.299 ms/op`, `11,211,740,267 B/op` | `0.010 ms/op`, `35,768 B/op` | `873,330x` faster, `313,456x` less allocation |

The already bounded `labels(n), keys(n) LIMIT 20` sample remains effectively unchanged (`0.018` to `0.014 ms/op`). These numbers describe the verified 5.9-million-node fixture; no linear extrapolation is claimed for the 80-million-node deployment. Unsupported broad query shapes are controlled by the request concurrency and work budgets instead of being presented as optimized.

## Review fixes

- variable-length paths now charge source-node, edge-candidate, and target-node reads
- variable-length traversal stores parent links, streams matches into `LIMIT`, and charges concrete path materialization instead of retaining copied path prefixes
- single-hop traversal charges untyped edge candidates before filtering and charges direct target-node loads in both fast and generic paths
- unbudgeted typed traversal relies on the graph's typed edge API without applying a duplicate relationship-type filter
- direct unqualified/qualified `elementId` seeks consume the shared request budget, including across UNION segments
- nested execution restores the outer thread-local tracker instead of disabling the remainder of its accounting
- mapped string lookups charge raw scans, index construction, unique strings/postings, and indexed node IDs
- fanout uses one request-scoped tracker instead of fresh or fixed-share per-graph budgets
- the one-argument cross-graph constructor is restored and verified through JVM reflection and `javap`
- the previous `QueryPipeline(List)` constructor and two-argument `MappedStringPropertyIndex.matchingNodeIds` method are restored and reflection-tested
- oversized positive LIMIT values saturate safely and are still replaced by the HTTP row cap
- Android benchmark setup validates the exact 5,938,826-node fixture; allocation and GC are reported as environment-sensitive observations
- the variable-path budget benchmark returns its relationship variable so it measures concrete path materialization

## Performance

The required same-runner base/PR method and large-corpus comparison is maintained in the [benchmark regression comment](https://github.com/johnsonlee/graphite/pull/95#issuecomment-5451597613). The workflow's configured regression threshold is 15%. Separately, the final one-fork local `CypherBenchmark` comparison stays below 15%; a focused five-fork base/head confirmation measured `aggregationCountGroupBy` at `+2.7%` and `countStar` at `+0.8%`, with overlapping 99.9% confidence intervals. The full Hive, Kotlin compiler, and Tika `JAR -> build -> save -> mapped load -> Cypher query` gates also pass locally.

HTTP creates a budget-enabled executor. `BudgetedCypherBenchmark` isolates that executor cost from Jetty and network time:

```shell
./gradlew :cypher:jmhJar --no-daemon
for pair in NodeScan Relationship VariableLengthPath; do
  java -jar graphite-cypher/build/libs/cypher-1.0.0-SNAPSHOT-jmh.jar \
    "BudgetedCypherBenchmark.(budgeted${pair}|unbudgeted${pair})$" \
    -wi 3 -i 5 -w 1s -r 1s -f 5 -foe true
done
```

Apple M3 Max, 64 GiB RAM, macOS 14.3 arm64, OpenJDK 17.0.18, JMH 1.37, one benchmark thread, five forks, and 25 measurement iterations per benchmark. Values are `us/op` with 99.9% confidence errors.

| Successful query | Unbudgeted | Budgeted | Cost |
|------------------|-----------:|---------:|-----:|
| 500-node scan | `48.613 +/- 0.240` | `49.312 +/- 0.666` | `+1.4%` |
| 500 single-hop relationships | `148.846 +/- 0.731` | `157.375 +/- 4.496` | `+5.7%` |
| 500 materialized two-hop paths | `231.380 +/- 2.436` | `233.829 +/- 4.377` | `+1.1%` |

The relationship result is the highest at 5.7%, and its 99.9% confidence interval does not overlap the unbudgeted result. The unbudgeted path now relies on the graph's typed traversal without a duplicate filter; the budgeted path still reads untyped candidates so every rejected edge is charged before filtering. The materialized path row binds and returns `r`, exercising path-container materialization and its budget charge. The budget path has a measurable cost and is not described as free.

The corrected Android rejection run uses `org.robolectric:android-all:14-robolectric-10818077`, validates exactly 5,938,826 persisted nodes, and rejects at 250,000 units in `116.334 ms/op`. Its `363,221,955 B/op` and approximately zero local collections differ from an independent `298,504,171 B/op` run with one or two collections, so the invariant is the 250,000-unit rejection boundary, not an allocation or no-GC guarantee.

## Verification

- `./gradlew check -S --no-daemon`
- application line coverage: Core `98.2569%`, Cypher `98.1846%`, WebGraph `98.0213%`, Explore `98.1046%`
- exact JVM descriptors: `CrossGraphCypherExecutor(java.util.List)`, `QueryPipeline(java.util.List)`, and `matchingNodeIds(StringMatchMode, String)`
- paired budget-enabled JMH plus final `CypherBenchmark` on branch and `origin/main`
- Android schema-discovery rejection JMH with GC profiler

The complete commands, raw conclusions, superseded claims, and design history are recorded in `docs/cross-graph-cypher-optimization-attempts.md`.
