### PR TITLE
Restore case-insensitive multi-graph Cypher search performance

### DIFF
--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -22,6 +22,7 @@ export const LATENCY_EXPECTED_BENCHMARK_KEYS = [
     "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.skewedMixedClassMethodOperatorCaseInsensitiveDiscovery",
     "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.zeroHitBroadContainsCaseInsensitiveDiscovery"
 ];
+export const LATENCY_EXPECTED_SHARDS = ["synthetic", "real-a", "real-b", "real-c", "real-d"];
 const LARGE_CORPUS_METRICS = [
     { key: "buildMs", label: "build", threshold: 20, minimum: 500, unit: "ms" },
     { key: "saveMs", label: "save", threshold: 25, minimum: 250, unit: "ms" },
@@ -403,6 +404,44 @@ export function renderLatencyBaselineReport(comparison) {
     return `${lines.join("\n")}\n`;
 }
 
+export function combineLatencyShards(directory) {
+    const errors = [];
+    const rows = [];
+    const seenKeys = new Set();
+    for (const shard of LATENCY_EXPECTED_SHARDS) {
+        const statusFile = path.join(directory, `latency-status-${shard}.json`);
+        if (!fs.existsSync(statusFile)) {
+            errors.push(`${shard}: latency shard status is missing`);
+            continue;
+        }
+        const status = readJson(statusFile);
+        for (const error of status.errors ?? []) errors.push(`${shard}: ${error}`);
+        for (const row of status.rows ?? []) {
+            if (seenKeys.has(row.key)) {
+                errors.push(`${shard}: duplicate latency benchmark ${row.key}`);
+            } else {
+                seenKeys.add(row.key);
+                rows.push(row);
+            }
+        }
+        if (status.passed !== true) errors.push(`${shard}: latency shard failed`);
+    }
+
+    const expected = new Set(LATENCY_EXPECTED_BENCHMARK_KEYS);
+    for (const key of expected) {
+        if (!seenKeys.has(key)) errors.push(`combined latency results: missing expected benchmark ${key}`);
+    }
+    for (const key of seenKeys) {
+        if (!expected.has(key)) errors.push(`combined latency results: unexpected benchmark ${key}`);
+    }
+    rows.sort((left, right) => left.key.localeCompare(right.key));
+    return {
+        passed: errors.length === 0 && rows.every((row) => !row.blocked),
+        errors,
+        rows
+    };
+}
+
 export function parseLargeCorpusLog(contents) {
     const results = new Map();
     for (const line of contents.split(/\r?\n/)) {
@@ -612,7 +651,7 @@ function compareLatencyBaselineCommand(args) {
         readJson(requireArg(args, "candidate")),
         Number(args.threshold ?? 15),
         Number(args["minimum-speedup"] ?? 50),
-        LATENCY_EXPECTED_BENCHMARK_KEYS
+        args["allow-subset"] === true ? null : LATENCY_EXPECTED_BENCHMARK_KEYS
     );
     writeFile(requireArg(args, "report"), renderLatencyBaselineReport(comparison));
     writeJson(requireArg(args, "status"), comparison);
@@ -627,9 +666,16 @@ function confirmLatencyBaselineCommand(args) {
         readJson(requireArg(args, "candidate")),
         Number(args.threshold ?? 15),
         Number(args["minimum-speedup"] ?? 50),
-        LATENCY_EXPECTED_BENCHMARK_KEYS
+        args["allow-subset"] === true ? null : LATENCY_EXPECTED_BENCHMARK_KEYS
     );
     const comparison = confirmLatencyBaseline(initial, confirmation);
+    writeFile(requireArg(args, "report"), renderLatencyBaselineReport(comparison));
+    writeJson(requireArg(args, "status"), comparison);
+    if (!comparison.passed) process.exitCode = 1;
+}
+
+function combineLatencyShardsCommand(args) {
+    const comparison = combineLatencyShards(requireArg(args, "directory"));
     writeFile(requireArg(args, "report"), renderLatencyBaselineReport(comparison));
     writeJson(requireArg(args, "status"), comparison);
     if (!comparison.passed) process.exitCode = 1;
@@ -677,6 +723,7 @@ function main(argv) {
     if (command === "compare-jmh") compareJmhCommand(args);
     else if (command === "compare-latency-baseline") compareLatencyBaselineCommand(args);
     else if (command === "confirm-latency-baseline") confirmLatencyBaselineCommand(args);
+    else if (command === "combine-latency-shards") combineLatencyShardsCommand(args);
     else if (command === "confirm-jmh") confirmJmhCommand(args);
     else if (command === "compare-large-corpus") compareLargeCorpusCommand(args);
     else if (command === "confirm-large-corpus") confirmLargeCorpusCommand(args);

--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -231,9 +231,9 @@ export function confirmJmh(initial, confirmation) {
     };
 }
 
-export function renderJmhReport(comparison) {
+export function renderJmhReport(comparison, title = "Method-level JMH") {
     const lines = [
-        "### Method-level JMH",
+        `### ${title}`,
         "",
         "A row blocks only when it exceeds the 15% limit, the 99.9% confidence intervals do not overlap,",
         "and a reverse-order confirmation run fails the same benchmark.",
@@ -586,6 +586,11 @@ export function renderLargeCorpusReport(comparison) {
 export function aggregateReports(directory, metadata) {
     const components = [
         { name: "method-level", report: "method-report.md", status: "method-status.json" },
+        {
+            name: "budgeted-mapped-string",
+            report: "budgeted-string-report.md",
+            status: "budgeted-string-status.json"
+        },
         { name: "large-corpus", report: "large-corpus-report.md", status: "large-corpus-status.json" },
         { name: "wrapped-query-latency", report: "latency-report.md", status: "latency-status.json" }
     ];
@@ -629,7 +634,7 @@ function compareJmhCommand(args) {
         readJson(requireArg(args, "candidate")),
         Number(args.threshold ?? 15)
     );
-    writeFile(requireArg(args, "report"), renderJmhReport(comparison));
+    writeFile(requireArg(args, "report"), renderJmhReport(comparison, args.title));
     writeJson(requireArg(args, "status"), comparison);
     if (!comparison.passed) process.exitCode = 1;
 }
@@ -689,7 +694,7 @@ function confirmJmhCommand(args) {
         Number(args.threshold ?? 15)
     );
     const comparison = confirmJmh(initial, confirmation);
-    writeFile(requireArg(args, "report"), renderJmhReport(comparison));
+    writeFile(requireArg(args, "report"), renderJmhReport(comparison, args.title));
     writeJson(requireArg(args, "status"), comparison);
     if (!comparison.passed) process.exitCode = 1;
 }

--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -8,6 +8,20 @@ import { pathToFileURL } from "node:url";
 export const COMMENT_MARKER = "<!-- graphite-benchmark-regression-gate -->";
 
 const MIB = 1024 * 1024;
+export const LATENCY_EXPECTED_BENCHMARK_KEYS = [
+    "io.johnsonlee.graphite.webgraph.WrappedDiscoveryLatencyBenchmark.coldWrappedCaseInsensitiveDiscovery[graphCount=1]",
+    "io.johnsonlee.graphite.webgraph.WrappedDiscoveryLatencyBenchmark.coldWrappedCaseInsensitiveDiscovery[graphCount=17]",
+    "io.johnsonlee.graphite.webgraph.WrappedDiscoveryLatencyBenchmark.wrappedCaseInsensitiveDiscovery[graphCount=1]",
+    "io.johnsonlee.graphite.webgraph.WrappedDiscoveryLatencyBenchmark.wrappedCaseInsensitiveDiscovery[graphCount=17]",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.broadlyDistributedClassPrefixCaseInsensitiveDiscovery",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.denseDistributedMethodContainsCaseInsensitiveDiscovery",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.earlyGraphClassPrefixCaseInsensitiveDiscovery",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.firstLastGraphBimodalClassPrefixCaseInsensitiveDiscovery",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.lateGraphClassPrefixCaseInsensitiveDiscovery",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.middleGraphsClassPrefixCaseInsensitiveDiscovery",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.skewedMixedClassMethodOperatorCaseInsensitiveDiscovery",
+    "io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.zeroHitBroadContainsCaseInsensitiveDiscovery"
+];
 const LARGE_CORPUS_METRICS = [
     { key: "buildMs", label: "build", threshold: 20, minimum: 500, unit: "ms" },
     { key: "saveMs", label: "save", threshold: 25, minimum: 250, unit: "ms" },
@@ -243,6 +257,110 @@ export function renderJmhReport(comparison) {
     return `${lines.join("\n")}\n`;
 }
 
+export function compareLatencyBaseline(
+    fixedResults,
+    baseResults,
+    candidateResults,
+    regressionThreshold = 15,
+    minimumSpeedup = 50,
+    expectedKeys = null
+) {
+    const regression = compareJmh(baseResults, candidateResults, regressionThreshold);
+    const fixed = new Map(fixedResults.map((result) => [benchmarkKey(result), result]));
+    const candidate = new Map(candidateResults.map((result) => [benchmarkKey(result), result]));
+    const errors = [...regression.errors];
+    const regressionRows = new Map(regression.rows.map((row) => [row.key, row]));
+    const rows = [];
+
+    const actualKeys = [...new Set([...fixed.keys(), ...candidate.keys()])].sort();
+    const keys = expectedKeys === null ? actualKeys : [...expectedKeys].sort();
+    if (expectedKeys !== null) {
+        const expected = new Set(expectedKeys);
+        for (const [revision, results] of [
+            ["fixed baseline", fixedResults],
+            ["PR base", baseResults],
+            ["candidate", candidateResults]
+        ]) {
+            const actual = new Set(results.map(benchmarkKey));
+            for (const key of expected) {
+                if (!actual.has(key)) errors.push(`${revision}: missing expected latency benchmark ${key}`);
+            }
+            for (const key of actual) {
+                if (!expected.has(key)) errors.push(`${revision}: unexpected latency benchmark ${key}`);
+            }
+        }
+    }
+
+    for (const key of keys) {
+        const baseline = fixed.get(key);
+        const current = candidate.get(key);
+        const baseRow = regressionRows.get(key);
+        if (baseline === undefined || current === undefined || baseRow === undefined) {
+            errors.push(`${key}: missing from fixed baseline, PR base, or candidate results`);
+            continue;
+        }
+        const fixedScore = finiteNumber(baseline.primaryMetric?.score);
+        const candidateScore = finiteNumber(current.primaryMetric?.score);
+        if (fixedScore === null || candidateScore === null || fixedScore <= 0 || candidateScore <= 0) {
+            errors.push(`${key}: invalid fixed-baseline score`);
+            continue;
+        }
+        if (!isLowerBetter(baseline.mode) || baseline.mode !== current.mode ||
+            baseline.primaryMetric?.scoreUnit !== current.primaryMetric?.scoreUnit
+        ) {
+            errors.push(`${key}: fixed baseline and candidate use incompatible latency metrics`);
+            continue;
+        }
+        const speedup = ((fixedScore / candidateScore) - 1) * 100;
+        const improvementSeparated = confidenceSeparates(
+            confidenceBounds(current.primaryMetric ?? {}),
+            confidenceBounds(baseline.primaryMetric ?? {}),
+            true
+        );
+        const improvementBlocked = speedup < minimumSpeedup || !improvementSeparated;
+        rows.push({
+            ...baseRow,
+            fixedScore,
+            speedup,
+            minimumSpeedup,
+            improvementSeparated,
+            improvementBlocked,
+            blocked: baseRow.blocked || improvementBlocked
+        });
+    }
+
+    if (rows.length === 0) errors.push("No comparable latency benchmarks were found");
+    return {
+        passed: errors.length === 0 && rows.every((row) => !row.blocked),
+        errors,
+        rows
+    };
+}
+
+export function renderLatencyBaselineReport(comparison) {
+    const lines = [
+        "### Wrapped case-insensitive query latency",
+        "",
+        "The PR must remain at least 50% faster than the fixed pre-PR-95 baseline and must not regress",
+        "more than 15% against the PR base with separated 99.9% confidence intervals.",
+        "",
+        "| Benchmark | Pre-PR-95 | PR base | PR | Speedup vs fixed | Regression vs base | Gate |",
+        "|---|---:|---:|---:|---:|---:|:---:|"
+    ];
+    for (const row of comparison.rows) {
+        lines.push(
+            `| \`${shortBenchmarkName(row.key)}\` | ${formatScore(row.fixedScore)} ${row.unit} | ` +
+            `${formatScore(row.baseScore)} ${row.unit} | ${formatScore(row.candidateScore)} ${row.unit} | ` +
+            `${formatDelta(row.speedup)} | ${formatDelta(row.delta)} | ` +
+            `**${row.blocked ? "FAIL" : "PASS"}** |`
+        );
+    }
+    if (comparison.errors.length > 0) {
+        lines.push("", "Errors:", ...comparison.errors.map((error) => `- ${error}`));
+    }
+    return `${lines.join("\n")}\n`;
+}
+
 export function parseLargeCorpusLog(contents) {
     const results = new Map();
     for (const line of contents.split(/\r?\n/)) {
@@ -387,7 +505,8 @@ export function renderLargeCorpusReport(comparison) {
 export function aggregateReports(directory, metadata) {
     const components = [
         { name: "method-level", report: "method-report.md", status: "method-status.json" },
-        { name: "large-corpus", report: "large-corpus-report.md", status: "large-corpus-status.json" }
+        { name: "large-corpus", report: "large-corpus-report.md", status: "large-corpus-status.json" },
+        { name: "wrapped-query-latency", report: "latency-report.md", status: "latency-status.json" }
     ];
     const errors = [];
     const reports = [];
@@ -444,6 +563,20 @@ function compareLargeCorpusCommand(args) {
     if (!comparison.passed) process.exitCode = 1;
 }
 
+function compareLatencyBaselineCommand(args) {
+    const comparison = compareLatencyBaseline(
+        readJson(requireArg(args, "fixed")),
+        readJson(requireArg(args, "base")),
+        readJson(requireArg(args, "candidate")),
+        Number(args.threshold ?? 15),
+        Number(args["minimum-speedup"] ?? 50),
+        LATENCY_EXPECTED_BENCHMARK_KEYS
+    );
+    writeFile(requireArg(args, "report"), renderLatencyBaselineReport(comparison));
+    writeJson(requireArg(args, "status"), comparison);
+    if (!comparison.passed) process.exitCode = 1;
+}
+
 function confirmJmhCommand(args) {
     const initial = readJson(requireArg(args, "initial"));
     const confirmation = compareJmh(
@@ -484,6 +617,7 @@ function main(argv) {
     const args = parseArgs(argv);
     const command = args._[0];
     if (command === "compare-jmh") compareJmhCommand(args);
+    else if (command === "compare-latency-baseline") compareLatencyBaselineCommand(args);
     else if (command === "confirm-jmh") confirmJmhCommand(args);
     else if (command === "compare-large-corpus") compareLargeCorpusCommand(args);
     else if (command === "confirm-large-corpus") confirmLargeCorpusCommand(args);

--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -311,12 +311,14 @@ export function compareLatencyBaseline(
             errors.push(`${key}: fixed baseline and candidate use incompatible latency metrics`);
             continue;
         }
+        const fixedBounds = confidenceBounds(baseline.primaryMetric ?? {});
+        const candidateBounds = confidenceBounds(current.primaryMetric ?? {});
+        if (fixedBounds === null || candidateBounds === null) {
+            errors.push(`${key}: fixed-baseline speedup requires finite confidence bounds`);
+        }
         const speedup = ((fixedScore / candidateScore) - 1) * 100;
-        const improvementSeparated = confidenceSeparates(
-            confidenceBounds(current.primaryMetric ?? {}),
-            confidenceBounds(baseline.primaryMetric ?? {}),
-            true
-        );
+        const improvementSeparated = fixedBounds !== null && candidateBounds !== null &&
+            confidenceSeparates(candidateBounds, fixedBounds, true);
         const improvementBlocked = speedup < minimumSpeedup || !improvementSeparated;
         rows.push({
             ...baseRow,
@@ -337,21 +339,61 @@ export function compareLatencyBaseline(
     };
 }
 
+export function confirmLatencyBaseline(initial, confirmation) {
+    const errors = [
+        ...initial.errors,
+        ...confirmation.errors.map((error) => `confirmation: ${error}`)
+    ];
+    const confirmationRows = new Map(confirmation.rows.map((row) => [row.key, row]));
+    const rows = initial.rows.map((row) => {
+        if (!row.blocked) return row;
+        const retry = confirmationRows.get(row.key);
+        if (retry === undefined) {
+            errors.push(`${row.key}: missing from confirmation results`);
+            return row;
+        }
+        return {
+            ...row,
+            confirmation: {
+                fixedScore: retry.fixedScore,
+                baseScore: retry.baseScore,
+                candidateScore: retry.candidateScore,
+                speedup: retry.speedup,
+                delta: retry.delta,
+                blocked: retry.blocked
+            },
+            blocked: retry.blocked
+        };
+    });
+    return {
+        passed: errors.length === 0 && rows.every((row) => !row.blocked),
+        errors,
+        rows
+    };
+}
+
 export function renderLatencyBaselineReport(comparison) {
     const lines = [
         "### Wrapped case-insensitive query latency",
         "",
         "The PR must remain at least 50% faster than the fixed pre-PR-95 baseline and must not regress",
         "more than 15% against the PR base with separated 99.9% confidence intervals.",
+        "A suspected failure blocks only when the same benchmark fails the reverse-order confirmation run.",
         "",
-        "| Benchmark | Pre-PR-95 | PR base | PR | Speedup vs fixed | Regression vs base | Gate |",
-        "|---|---:|---:|---:|---:|---:|:---:|"
+        "| Benchmark | Pre-PR-95 | PR base | PR | Speedup vs fixed | Regression vs base | Confirmation | Gate |",
+        "|---|---:|---:|---:|---:|---:|---:|:---:|"
     ];
     for (const row of comparison.rows) {
+        const confirmation = row.confirmation === undefined
+            ? "-"
+            : `${formatScore(row.confirmation.fixedScore)} / ${formatScore(row.confirmation.baseScore)} / ` +
+                `${formatScore(row.confirmation.candidateScore)} ${row.unit} ` +
+                `(${formatDelta(row.confirmation.speedup)} fixed; ${formatDelta(row.confirmation.delta)} base)`;
         lines.push(
             `| \`${shortBenchmarkName(row.key)}\` | ${formatScore(row.fixedScore)} ${row.unit} | ` +
             `${formatScore(row.baseScore)} ${row.unit} | ${formatScore(row.candidateScore)} ${row.unit} | ` +
             `${formatDelta(row.speedup)} | ${formatDelta(row.delta)} | ` +
+            `${confirmation} | ` +
             `**${row.blocked ? "FAIL" : "PASS"}** |`
         );
     }
@@ -577,6 +619,22 @@ function compareLatencyBaselineCommand(args) {
     if (!comparison.passed) process.exitCode = 1;
 }
 
+function confirmLatencyBaselineCommand(args) {
+    const initial = readJson(requireArg(args, "initial"));
+    const confirmation = compareLatencyBaseline(
+        readJson(requireArg(args, "fixed")),
+        readJson(requireArg(args, "base")),
+        readJson(requireArg(args, "candidate")),
+        Number(args.threshold ?? 15),
+        Number(args["minimum-speedup"] ?? 50),
+        LATENCY_EXPECTED_BENCHMARK_KEYS
+    );
+    const comparison = confirmLatencyBaseline(initial, confirmation);
+    writeFile(requireArg(args, "report"), renderLatencyBaselineReport(comparison));
+    writeJson(requireArg(args, "status"), comparison);
+    if (!comparison.passed) process.exitCode = 1;
+}
+
 function confirmJmhCommand(args) {
     const initial = readJson(requireArg(args, "initial"));
     const confirmation = compareJmh(
@@ -618,6 +676,7 @@ function main(argv) {
     const command = args._[0];
     if (command === "compare-jmh") compareJmhCommand(args);
     else if (command === "compare-latency-baseline") compareLatencyBaselineCommand(args);
+    else if (command === "confirm-latency-baseline") confirmLatencyBaselineCommand(args);
     else if (command === "confirm-jmh") confirmJmhCommand(args);
     else if (command === "compare-large-corpus") compareLargeCorpusCommand(args);
     else if (command === "confirm-large-corpus") confirmLargeCorpusCommand(args);

--- a/.github/scripts/benchmark-gate.mjs
+++ b/.github/scripts/benchmark-gate.mjs
@@ -137,7 +137,7 @@ function statusLabel(row) {
     return "PASS";
 }
 
-export function compareJmh(baseResults, candidateResults, threshold = 15) {
+export function compareJmh(baseResults, candidateResults, threshold = 15, thresholdOnly = false) {
     const errors = [];
     const base = new Map();
     const candidate = new Map();
@@ -188,7 +188,7 @@ export function compareJmh(baseResults, candidateResults, threshold = 15) {
             threshold,
             aboveThreshold,
             confidenceSeparated: separated,
-            blocked: aboveThreshold && separated
+            blocked: aboveThreshold && (thresholdOnly || separated)
         });
     }
 
@@ -196,6 +196,7 @@ export function compareJmh(baseResults, candidateResults, threshold = 15) {
     return {
         passed: errors.length === 0 && rows.every((row) => !row.blocked),
         errors,
+        thresholdOnly,
         rows
     };
 }
@@ -227,16 +228,25 @@ export function confirmJmh(initial, confirmation) {
     return {
         passed: errors.length === 0 && rows.every((row) => !row.blocked),
         errors,
+        thresholdOnly: initial.thresholdOnly === true,
         rows
     };
 }
 
 export function renderJmhReport(comparison, title = "Method-level JMH") {
+    const decisionRule = comparison.thresholdOnly === true
+        ? [
+            "A row runs reverse-order confirmation whenever it exceeds the 15% limit, regardless of confidence",
+            "interval overlap, and blocks only when the confirmation also exceeds 15%."
+        ]
+        : [
+            "A row blocks only when it exceeds the 15% limit, the 99.9% confidence intervals do not overlap,",
+            "and a reverse-order confirmation run fails the same benchmark."
+        ];
     const lines = [
         `### ${title}`,
         "",
-        "A row blocks only when it exceeds the 15% limit, the 99.9% confidence intervals do not overlap,",
-        "and a reverse-order confirmation run fails the same benchmark.",
+        ...decisionRule,
         "",
         "| Benchmark | Base | PR | Regression | Confirmation (base -> PR) | Limit | Gate |",
         "|---|---:|---:|---:|---:|---:|:---:|"
@@ -632,7 +642,8 @@ function compareJmhCommand(args) {
     const comparison = compareJmh(
         readJson(requireArg(args, "base")),
         readJson(requireArg(args, "candidate")),
-        Number(args.threshold ?? 15)
+        Number(args.threshold ?? 15),
+        args["threshold-only"] === true
     );
     writeFile(requireArg(args, "report"), renderJmhReport(comparison, args.title));
     writeJson(requireArg(args, "status"), comparison);
@@ -691,7 +702,8 @@ function confirmJmhCommand(args) {
     const confirmation = compareJmh(
         readJson(requireArg(args, "base")),
         readJson(requireArg(args, "candidate")),
-        Number(args.threshold ?? 15)
+        Number(args.threshold ?? 15),
+        args["threshold-only"] === true
     );
     const comparison = confirmJmh(initial, confirmation);
     writeFile(requireArg(args, "report"), renderJmhReport(comparison, args.title));

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -67,6 +67,19 @@ test("JMH comparison does not block overlapping confidence intervals", () => {
     assert.match(renderJmhReport(comparison), /\*\*NOISE\*\*/);
 });
 
+test("JMH report accepts a gate-specific title", () => {
+    const comparison = compareJmh(
+        [jmhResult({ score: 100, confidence: [95, 105] })],
+        [jmhResult({ score: 101, confidence: [96, 106] })],
+        15
+    );
+
+    assert.match(
+        renderJmhReport(comparison, "Budgeted mapped-string latency"),
+        /^### Budgeted mapped-string latency/m
+    );
+});
+
 test("JMH throughput regression uses higher-is-better semantics", () => {
     const comparison = compareJmh(
         [jmhResult({ mode: "thrpt", score: 1_000, confidence: [980, 1_020], unit: "ops/s" })],
@@ -349,6 +362,32 @@ test("aggregate report fails closed when an artifact is missing", () => {
         assert.equal(aggregate.passed, false);
         assert.match(aggregate.body, new RegExp(COMMENT_MARKER));
         assert.match(aggregate.body, /large-corpus: result artifact is missing/);
+    } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+test("aggregate report includes the budgeted mapped-string gate", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "benchmark-gate-complete-"));
+    try {
+        for (const [report, status, body] of [
+            ["method-report.md", "method-status.json", "method report"],
+            ["budgeted-string-report.md", "budgeted-string-status.json", "budgeted report"],
+            ["large-corpus-report.md", "large-corpus-status.json", "large report"],
+            ["latency-report.md", "latency-status.json", "latency report"]
+        ]) {
+            fs.writeFileSync(path.join(directory, report), `${body}\n`);
+            fs.writeFileSync(path.join(directory, status), JSON.stringify({ passed: true }));
+        }
+        const aggregate = aggregateReports(directory, {
+            baseSha: "a".repeat(40),
+            candidateSha: "b".repeat(40),
+            runner: "test-runner",
+            runUrl: "https://example.invalid/run"
+        });
+
+        assert.equal(aggregate.passed, true);
+        assert.match(aggregate.body, /budgeted report/);
     } finally {
         fs.rmSync(directory, { recursive: true, force: true });
     }

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -8,6 +8,7 @@ import {
     aggregateReports,
     confirmLargeCorpus,
     LATENCY_EXPECTED_BENCHMARK_KEYS,
+    confirmLatencyBaseline,
     confirmJmh,
     compareJmh,
     compareLatencyBaseline,
@@ -144,6 +145,60 @@ test("latency baseline blocks loss of the fixed-baseline optimization", () => {
     assert.equal(comparison.passed, false);
     assert.equal(comparison.rows[0].improvementBlocked, true);
     assert.equal(comparison.rows[0].blocked, true);
+});
+
+test("latency baseline fails closed without fixed speedup confidence bounds", () => {
+    const comparison = compareLatencyBaseline(
+        [jmhResult({ score: 100 })],
+        [jmhResult({ score: 20 })],
+        [jmhResult({ score: 20 })]
+    );
+
+    assert.equal(comparison.passed, false);
+    assert.equal(comparison.rows[0].improvementSeparated, false);
+    assert.equal(comparison.rows[0].blocked, true);
+    assert.match(comparison.errors.join("\n"), /requires finite confidence bounds/);
+});
+
+test("latency confirmation blocks only failures repeated by the same benchmark", () => {
+    const first = "example.First.query";
+    const second = "example.Second.query";
+    const initial = compareLatencyBaseline(
+        [
+            jmhResult({ benchmark: first, score: 100, confidence: [98, 102] }),
+            jmhResult({ benchmark: second, score: 100, confidence: [98, 102] })
+        ],
+        [
+            jmhResult({ benchmark: first, score: 20, confidence: [19, 21] }),
+            jmhResult({ benchmark: second, score: 20, confidence: [19, 21] })
+        ],
+        [
+            jmhResult({ benchmark: first, score: 80, confidence: [78, 82] }),
+            jmhResult({ benchmark: second, score: 20, confidence: [19, 21] })
+        ]
+    );
+    const retry = compareLatencyBaseline(
+        [
+            jmhResult({ benchmark: first, score: 100, confidence: [98, 102] }),
+            jmhResult({ benchmark: second, score: 100, confidence: [98, 102] })
+        ],
+        [
+            jmhResult({ benchmark: first, score: 20, confidence: [19, 21] }),
+            jmhResult({ benchmark: second, score: 20, confidence: [19, 21] })
+        ],
+        [
+            jmhResult({ benchmark: first, score: 20, confidence: [19, 21] }),
+            jmhResult({ benchmark: second, score: 80, confidence: [78, 82] })
+        ]
+    );
+    const confirmed = confirmLatencyBaseline(initial, retry);
+
+    assert.equal(initial.passed, false);
+    assert.equal(retry.passed, false);
+    assert.equal(confirmed.passed, true);
+    assert.equal(confirmed.rows.find((row) => row.key === first).blocked, false);
+    assert.equal(confirmed.rows.find((row) => row.key === second).blocked, false);
+    assert.match(renderLatencyBaselineReport(confirmed), /Confirmation/);
 });
 
 test("latency baseline fails closed when one graph-count parameter is missing", () => {

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -6,8 +6,10 @@ import test from "node:test";
 import {
     COMMENT_MARKER,
     aggregateReports,
+    combineLatencyShards,
     confirmLargeCorpus,
     LATENCY_EXPECTED_BENCHMARK_KEYS,
+    LATENCY_EXPECTED_SHARDS,
     confirmLatencyBaseline,
     confirmJmh,
     compareJmh,
@@ -230,6 +232,30 @@ test("latency baseline fails when an expected benchmark disappears from all revi
 
     assert.equal(comparison.passed, false);
     assert.match(comparison.errors.join("\n"), /missing expected latency benchmark/);
+});
+
+test("latency shard aggregation requires every shard and the complete benchmark key set", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "benchmark-latency-shards-"));
+    try {
+        LATENCY_EXPECTED_SHARDS.forEach((shard, index) => {
+            const rows = LATENCY_EXPECTED_BENCHMARK_KEYS
+                .filter((_, keyIndex) => keyIndex % LATENCY_EXPECTED_SHARDS.length === index)
+                .map((key) => ({ key, blocked: false }));
+            fs.writeFileSync(
+                path.join(directory, `latency-status-${shard}.json`),
+                JSON.stringify({ passed: true, errors: [], rows })
+            );
+        });
+
+        assert.equal(combineLatencyShards(directory).passed, true);
+        fs.rmSync(path.join(directory, "latency-status-real-d.json"));
+        const incomplete = combineLatencyShards(directory);
+        assert.equal(incomplete.passed, false);
+        assert.match(incomplete.errors.join("\n"), /real-d: latency shard status is missing/);
+        assert.match(incomplete.errors.join("\n"), /missing expected benchmark/);
+    } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
 });
 
 const baseCorpusLine = [

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -67,6 +67,40 @@ test("JMH comparison does not block overlapping confidence intervals", () => {
     assert.match(renderJmhReport(comparison), /\*\*NOISE\*\*/);
 });
 
+test("threshold-only JMH comparison confirms a regression despite overlapping intervals", () => {
+    const comparison = compareJmh(
+        [jmhResult({ score: 100, confidence: [80, 120] })],
+        [jmhResult({ score: 225, confidence: [90, 360] })],
+        15,
+        true
+    );
+
+    assert.equal(comparison.passed, false);
+    assert.equal(comparison.rows[0].confidenceSeparated, false);
+    assert.equal(comparison.rows[0].blocked, true);
+    assert.match(renderJmhReport(comparison), /regardless of confidence/);
+});
+
+test("threshold-only JMH confirmation blocks a repeated score regression", () => {
+    const initial = compareJmh(
+        [jmhResult({ score: 100, confidence: [80, 120] })],
+        [jmhResult({ score: 225, confidence: [90, 360] })],
+        15,
+        true
+    );
+    const retry = compareJmh(
+        [jmhResult({ score: 105, confidence: [70, 140] })],
+        [jmhResult({ score: 220, confidence: [80, 360] })],
+        15,
+        true
+    );
+    const confirmed = confirmJmh(initial, retry);
+
+    assert.equal(confirmed.passed, false);
+    assert.equal(confirmed.rows[0].blocked, true);
+    assert.match(renderJmhReport(confirmed), /\*\*FAIL\*\*/);
+});
+
 test("JMH report accepts a gate-specific title", () => {
     const comparison = compareJmh(
         [jmhResult({ score: 100, confidence: [95, 105] })],

--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -7,11 +7,14 @@ import {
     COMMENT_MARKER,
     aggregateReports,
     confirmLargeCorpus,
+    LATENCY_EXPECTED_BENCHMARK_KEYS,
     confirmJmh,
     compareJmh,
+    compareLatencyBaseline,
     compareLargeCorpus,
     parseLargeCorpusLog,
     renderJmhReport,
+    renderLatencyBaselineReport,
     renderLargeCorpusReport
 } from "./benchmark-gate.mjs";
 
@@ -20,9 +23,10 @@ function jmhResult({
     mode = "avgt",
     score,
     confidence,
-    unit = "us/op"
+    unit = "us/op",
+    params
 }) {
-    return {
+    const result = {
         benchmark,
         mode,
         primaryMetric: {
@@ -31,6 +35,8 @@ function jmhResult({
             scoreUnit: unit
         }
     };
+    if (params !== undefined) result.params = params;
+    return result;
 }
 
 test("JMH comparison blocks a separated latency regression", () => {
@@ -114,6 +120,61 @@ test("JMH reverse-order confirmation blocks a repeated regression", () => {
     assert.equal(confirmed.passed, false);
     assert.equal(confirmed.rows[0].blocked, true);
     assert.match(renderJmhReport(confirmed), /\*\*FAIL\*\*/);
+});
+
+test("latency baseline requires both fixed-baseline speedup and no base regression", () => {
+    const comparison = compareLatencyBaseline(
+        [jmhResult({ score: 100, confidence: [98, 102] })],
+        [jmhResult({ score: 20, confidence: [19, 21] })],
+        [jmhResult({ score: 21, confidence: [20, 22] })]
+    );
+
+    assert.equal(comparison.passed, true);
+    assert.equal(Math.round(comparison.rows[0].speedup), 376);
+    assert.match(renderLatencyBaselineReport(comparison), /Pre-PR-95/);
+});
+
+test("latency baseline blocks loss of the fixed-baseline optimization", () => {
+    const comparison = compareLatencyBaseline(
+        [jmhResult({ score: 100, confidence: [98, 102] })],
+        [jmhResult({ score: 20, confidence: [19, 21] })],
+        [jmhResult({ score: 80, confidence: [78, 82] })]
+    );
+
+    assert.equal(comparison.passed, false);
+    assert.equal(comparison.rows[0].improvementBlocked, true);
+    assert.equal(comparison.rows[0].blocked, true);
+});
+
+test("latency baseline fails closed when one graph-count parameter is missing", () => {
+    const fixed = [
+        { ...jmhResult({ score: 100 }), params: { graphCount: "1" } },
+        { ...jmhResult({ score: 1_700 }), params: { graphCount: "17" } }
+    ];
+    const base = fixed.map((result) => ({ ...result, primaryMetric: { ...result.primaryMetric, score: 20 } }));
+    const candidate = base.slice(0, 1);
+    const comparison = compareLatencyBaseline(fixed, base, candidate);
+
+    assert.equal(comparison.passed, false);
+    assert.match(comparison.errors.join("\n"), /graphCount=17/);
+});
+
+test("latency baseline fails when an expected benchmark disappears from all revisions", () => {
+    const key = LATENCY_EXPECTED_BENCHMARK_KEYS[0];
+    const benchmark = key.slice(0, key.indexOf("["));
+    const params = { graphCount: "1" };
+    const result = jmhResult({ benchmark, score: 10, confidence: [9, 11], unit: "ms/op", params });
+    const comparison = compareLatencyBaseline(
+        [result],
+        [result],
+        [jmhResult({ benchmark, score: 1, confidence: [0.9, 1.1], unit: "ms/op", params })],
+        15,
+        50,
+        [key, LATENCY_EXPECTED_BENCHMARK_KEYS[1]]
+    );
+
+    assert.equal(comparison.passed, false);
+    assert.match(comparison.errors.join("\n"), /missing expected latency benchmark/);
 });
 
 const baseCorpusLine = [

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -187,8 +187,82 @@ jobs:
         if-no-files-found: warn
         retention-days: 14
 
+  prepare-latency-fixtures:
+    name: prepare-latency-fixtures
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - name: Checkout PR
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: candidate
+
+    - name: Restore or save persisted fixture graphs
+      id: fixture-cache
+      uses: actions/cache@v5
+      with:
+        path: fixture-graphs
+        key: ${{ runner.os }}-${{ runner.arch }}-wrapped-query-fixtures-v1-${{ hashFiles('candidate/gradle/libs.versions.toml', 'candidate/gradle/wrapper/gradle-wrapper.properties', 'candidate/settings.gradle.kts', 'candidate/**/build.gradle.kts', 'candidate/graphite-core/src/main/**', 'candidate/graphite-sootup/src/main/**', 'candidate/graphite-webgraph/src/main/**', 'candidate/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AllFixtureWrappedDiscoveryLatencyBenchmark.kt') }}
+
+    - name: Setup Java
+      if: steps.fixture-cache.outputs.cache-hit != 'true'
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Setup Gradle
+      if: steps.fixture-cache.outputs.cache-hit != 'true'
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-read-only: true
+
+    - name: Build fixture preparation harness
+      if: steps.fixture-cache.outputs.cache-hit != 'true'
+      run: |
+        candidate/gradlew -p candidate :webgraph:prepareBenchmarkFixtures :webgraph:jmhJar --no-daemon
+
+    - name: Prepare all real fixture graphs with 4 GiB heap
+      if: steps.fixture-cache.outputs.cache-hit != 'true'
+      run: |
+        FIXTURE_DIR="${PWD}/candidate/graphite-webgraph/build/benchmark-fixtures"
+        ANDROID_JAR=$(find "${FIXTURE_DIR}" -name 'android-all-*.jar' -print -quit)
+        TIKA_JAR=$(find "${FIXTURE_DIR}" -name 'tika-app-*.jar' -print -quit)
+        HIVE_JAR=$(find "${FIXTURE_DIR}" -name 'hive-exec-*.jar' -print -quit)
+        KOTLIN_JAR=$(find "${FIXTURE_DIR}" -name 'kotlin-compiler-embeddable-*.jar' -print -quit)
+        CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+        test -n "${ANDROID_JAR}" && test -n "${TIKA_JAR}" && test -n "${HIVE_JAR}" && \
+          test -n "${KOTLIN_JAR}" && test -n "${CANDIDATE_JAR}"
+        mkdir -p "${PWD}/fixture-graphs"
+        for CORPUS in android tika hive kotlin-compiler; do
+          SOURCE_TMP=$(mktemp -d "${RUNNER_TEMP}/graphite-source-${CORPUS}-XXXXXX")
+          java -Xmx4g -Djava.io.tmpdir="${SOURCE_TMP}" \
+            -Dandroid.jar.path="${ANDROID_JAR}" \
+            -Dtika.jar.path="${TIKA_JAR}" \
+            -Dhive.jar.path="${HIVE_JAR}" \
+            -Dkotlin.compiler.jar.path="${KOTLIN_JAR}" \
+            -cp "${CANDIDATE_JAR}" \
+            io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkGraphPreparation \
+            "${CORPUS}" "${PWD}/fixture-graphs/${CORPUS}"
+          rm -rf -- "${SOURCE_TMP}"
+        done
+        java -Xmx4g -cp "${CANDIDATE_JAR}" \
+          io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkDistributionCalibration \
+          "${PWD}/fixture-graphs"
+        touch "${PWD}/fixture-graphs/.complete"
+
+    - name: Verify persisted fixture graph cache
+      run: |
+        test -f fixture-graphs/.complete
+        for CORPUS in android tika hive kotlin-compiler; do
+          test -d "fixture-graphs/${CORPUS}"
+        done
+
   wrapped-query-latency-shard:
     name: wrapped-query-latency-shard-${{ matrix.shard }}
+    needs: [prepare-latency-fixtures]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -246,6 +320,21 @@ jobs:
       with:
         cache-read-only: true
 
+    - name: Restore persisted fixture graphs
+      if: matrix.real
+      uses: actions/cache/restore@v5
+      with:
+        path: fixture-graphs
+        key: ${{ runner.os }}-${{ runner.arch }}-wrapped-query-fixtures-v1-${{ hashFiles('candidate/gradle/libs.versions.toml', 'candidate/gradle/wrapper/gradle-wrapper.properties', 'candidate/settings.gradle.kts', 'candidate/**/build.gradle.kts', 'candidate/graphite-core/src/main/**', 'candidate/graphite-sootup/src/main/**', 'candidate/graphite-webgraph/src/main/**', 'candidate/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AllFixtureWrappedDiscoveryLatencyBenchmark.kt') }}
+
+    - name: Verify restored fixture graphs
+      if: matrix.real
+      run: |
+        test -f fixture-graphs/.complete
+        for CORPUS in android tika hive kotlin-compiler; do
+          test -d "fixture-graphs/${CORPUS}"
+        done
+
     - name: Install identical latency harness in baselines
       run: |
         for HARNESS in \
@@ -262,34 +351,6 @@ jobs:
         fixed/gradlew -p fixed :webgraph:jmhJar --no-daemon
         base/gradlew -p base :webgraph:jmhJar --no-daemon
         candidate/gradlew -p candidate :webgraph:jmhJar --no-daemon
-
-    - name: Prepare all real fixture graphs
-      if: matrix.real
-      run: |
-        FIXTURE_DIR="${PWD}/candidate/graphite-webgraph/build/benchmark-fixtures"
-        ANDROID_JAR=$(find "${FIXTURE_DIR}" -name 'android-all-*.jar' -print -quit)
-        TIKA_JAR=$(find "${FIXTURE_DIR}" -name 'tika-app-*.jar' -print -quit)
-        HIVE_JAR=$(find "${FIXTURE_DIR}" -name 'hive-exec-*.jar' -print -quit)
-        KOTLIN_JAR=$(find "${FIXTURE_DIR}" -name 'kotlin-compiler-embeddable-*.jar' -print -quit)
-        CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
-        test -n "${ANDROID_JAR}" && test -n "${TIKA_JAR}" && test -n "${HIVE_JAR}" && \
-          test -n "${KOTLIN_JAR}" && test -n "${CANDIDATE_JAR}"
-        mkdir -p "${PWD}/fixture-graphs"
-        for CORPUS in android tika hive kotlin-compiler; do
-          SOURCE_TMP=$(mktemp -d "${RUNNER_TEMP}/graphite-source-${CORPUS}-XXXXXX")
-          java -Xmx4g -Djava.io.tmpdir="${SOURCE_TMP}" \
-            -Dandroid.jar.path="${ANDROID_JAR}" \
-            -Dtika.jar.path="${TIKA_JAR}" \
-            -Dhive.jar.path="${HIVE_JAR}" \
-            -Dkotlin.compiler.jar.path="${KOTLIN_JAR}" \
-            -cp "${CANDIDATE_JAR}" \
-            io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkGraphPreparation \
-            "${CORPUS}" "${PWD}/fixture-graphs/${CORPUS}"
-          rm -rf -- "${SOURCE_TMP}"
-        done
-        java -Xmx4g -cp "${CANDIDATE_JAR}" \
-          io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkDistributionCalibration \
-          "${PWD}/fixture-graphs"
 
     - name: Verify all real-fixture query results
       if: matrix.correctness

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,7 @@ env:
   JAVA_OPTS: -Xmx2g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
   JVM_OPTS: -Xmx2g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
   PRE_PR_95_BASELINE_SHA: 44b57562f2b3d0c88882a9002bdc488e05e5d7a7
+  BUDGETED_LOOKUP_BASELINE_SHA: 87c74c2cae0685e40e32fb2eb46b33987ec1a7a0
 
 jobs:
   method-level:
@@ -105,6 +106,97 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: benchmark-method-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        path: benchmark-results/
+        if-no-files-found: warn
+        retention-days: 14
+
+  budgeted-mapped-string:
+    name: budgeted-mapped-string-latency
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - name: Checkout budgeted lookup baseline
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ env.BUDGETED_LOOKUP_BASELINE_SHA }}
+        path: baseline
+
+    - name: Checkout PR
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: candidate
+
+    - name: Setup Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-read-only: true
+
+    - name: Install identical budgeted lookup harness in baseline
+      run: |
+        HARNESS='graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt'
+        cp "candidate/${HARNESS}" "baseline/${HARNESS}"
+
+    - name: Build budgeted lookup JMH jars
+      run: |
+        baseline/gradlew -p baseline :webgraph:jmhJar --no-daemon
+        candidate/gradlew -p candidate :webgraph:jmhJar --no-daemon
+
+    - name: Benchmark baseline then PR
+      run: |
+        mkdir -p benchmark-results
+        BASELINE_JAR=$(find baseline/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+        CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+        test -n "${BASELINE_JAR}" && test -n "${CANDIDATE_JAR}"
+        java -jar "${BASELINE_JAR}" \
+          'io.johnsonlee.graphite.webgraph.MappedStringAdmissionBenchmark.budgetedTransformedZeroHit' \
+          -foe true -rf json -rff "${PWD}/benchmark-results/baseline-budgeted-string.json"
+        java -jar "${CANDIDATE_JAR}" \
+          'io.johnsonlee.graphite.webgraph.MappedStringAdmissionBenchmark.budgetedTransformedZeroHit' \
+          -foe true -rf json -rff "${PWD}/benchmark-results/candidate-budgeted-string.json"
+
+    - name: Compare budgeted lookup latency
+      run: |
+        if node candidate/.github/scripts/benchmark-gate.mjs compare-jmh \
+          --base benchmark-results/baseline-budgeted-string.json \
+          --candidate benchmark-results/candidate-budgeted-string.json \
+          --threshold 15 \
+          --title 'Budgeted mapped-string latency' \
+          --report benchmark-results/initial-budgeted-string-report.md \
+          --status benchmark-results/initial-budgeted-string-status.json; then
+          mv benchmark-results/initial-budgeted-string-report.md benchmark-results/budgeted-string-report.md
+          mv benchmark-results/initial-budgeted-string-status.json benchmark-results/budgeted-string-status.json
+        else
+          BASELINE_JAR=$(find baseline/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+          CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+          java -jar "${CANDIDATE_JAR}" \
+            'io.johnsonlee.graphite.webgraph.MappedStringAdmissionBenchmark.budgetedTransformedZeroHit' \
+            -foe true -rf json -rff "${PWD}/benchmark-results/candidate-budgeted-string-confirmation.json"
+          java -jar "${BASELINE_JAR}" \
+            'io.johnsonlee.graphite.webgraph.MappedStringAdmissionBenchmark.budgetedTransformedZeroHit' \
+            -foe true -rf json -rff "${PWD}/benchmark-results/baseline-budgeted-string-confirmation.json"
+          node candidate/.github/scripts/benchmark-gate.mjs confirm-jmh \
+            --initial benchmark-results/initial-budgeted-string-status.json \
+            --base benchmark-results/baseline-budgeted-string-confirmation.json \
+            --candidate benchmark-results/candidate-budgeted-string-confirmation.json \
+            --threshold 15 \
+            --title 'Budgeted mapped-string latency' \
+            --report benchmark-results/budgeted-string-report.md \
+            --status benchmark-results/budgeted-string-status.json
+        fi
+
+    - name: Upload budgeted lookup results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: benchmark-budgeted-string-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
         path: benchmark-results/
         if-no-files-found: warn
         retention-days: 14
@@ -224,7 +316,7 @@ jobs:
       run: |
         candidate/gradlew -p candidate :webgraph:prepareBenchmarkFixtures :webgraph:jmhJar --no-daemon
 
-    - name: Prepare all real fixture graphs with 4 GiB heap
+    - name: Prepare all real fixture graphs
       if: steps.fixture-cache.outputs.cache-hit != 'true'
       run: |
         FIXTURE_DIR="${PWD}/candidate/graphite-webgraph/build/benchmark-fixtures"
@@ -377,6 +469,7 @@ jobs:
     - name: Benchmark fixed baseline, PR base, and PR
       env:
         BENCHMARK_FILTER: ${{ matrix.filter }}
+        SHARD: ${{ matrix.shard }}
       run: |
         mkdir -p benchmark-results
         FIXED_JAR=$(find fixed/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
@@ -390,15 +483,15 @@ jobs:
         java -jar "${FIXED_JAR}" \
           "${BENCHMARK_FILTER}" \
           -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
-          -rff "${PWD}/benchmark-results/fixed-latency.json"
+          -rff "${PWD}/benchmark-results/fixed-latency-${SHARD}.json"
         java -jar "${BASE_JAR}" \
           "${BENCHMARK_FILTER}" \
           -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
-          -rff "${PWD}/benchmark-results/base-latency.json"
+          -rff "${PWD}/benchmark-results/base-latency-${SHARD}.json"
         java -jar "${CANDIDATE_JAR}" \
           "${BENCHMARK_FILTER}" \
           -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
-          -rff "${PWD}/benchmark-results/candidate-latency.json"
+          -rff "${PWD}/benchmark-results/candidate-latency-${SHARD}.json"
 
     - name: Enforce fixed baseline speedup and current-base regression gate
       env:
@@ -406,16 +499,16 @@ jobs:
         SHARD: ${{ matrix.shard }}
       run: |
         if node candidate/.github/scripts/benchmark-gate.mjs compare-latency-baseline \
-          --fixed benchmark-results/fixed-latency.json \
-          --base benchmark-results/base-latency.json \
-          --candidate benchmark-results/candidate-latency.json \
+          --fixed "benchmark-results/fixed-latency-${SHARD}.json" \
+          --base "benchmark-results/base-latency-${SHARD}.json" \
+          --candidate "benchmark-results/candidate-latency-${SHARD}.json" \
           --minimum-speedup 50 \
           --threshold 15 \
           --allow-subset \
-          --report benchmark-results/initial-latency-report.md \
-          --status benchmark-results/initial-latency-status.json; then
-          mv benchmark-results/initial-latency-report.md "benchmark-results/latency-report-${SHARD}.md"
-          mv benchmark-results/initial-latency-status.json "benchmark-results/latency-status-${SHARD}.json"
+          --report "benchmark-results/initial-latency-report-${SHARD}.md" \
+          --status "benchmark-results/initial-latency-status-${SHARD}.json"; then
+          mv "benchmark-results/initial-latency-report-${SHARD}.md" "benchmark-results/latency-report-${SHARD}.md"
+          mv "benchmark-results/initial-latency-status-${SHARD}.json" "benchmark-results/latency-status-${SHARD}.json"
         else
           CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
           BASE_JAR=$(find base/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
@@ -427,20 +520,20 @@ jobs:
           java -jar "${CANDIDATE_JAR}" \
             "${BENCHMARK_FILTER}" \
             -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
-            -rff "${PWD}/benchmark-results/candidate-latency-confirmation.json"
+            -rff "${PWD}/benchmark-results/candidate-latency-confirmation-${SHARD}.json"
           java -jar "${BASE_JAR}" \
             "${BENCHMARK_FILTER}" \
             -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
-            -rff "${PWD}/benchmark-results/base-latency-confirmation.json"
+            -rff "${PWD}/benchmark-results/base-latency-confirmation-${SHARD}.json"
           java -jar "${FIXED_JAR}" \
             "${BENCHMARK_FILTER}" \
             -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
-            -rff "${PWD}/benchmark-results/fixed-latency-confirmation.json"
+            -rff "${PWD}/benchmark-results/fixed-latency-confirmation-${SHARD}.json"
           node candidate/.github/scripts/benchmark-gate.mjs confirm-latency-baseline \
-            --initial benchmark-results/initial-latency-status.json \
-            --fixed benchmark-results/fixed-latency-confirmation.json \
-            --base benchmark-results/base-latency-confirmation.json \
-            --candidate benchmark-results/candidate-latency-confirmation.json \
+            --initial "benchmark-results/initial-latency-status-${SHARD}.json" \
+            --fixed "benchmark-results/fixed-latency-confirmation-${SHARD}.json" \
+            --base "benchmark-results/base-latency-confirmation-${SHARD}.json" \
+            --candidate "benchmark-results/candidate-latency-confirmation-${SHARD}.json" \
             --minimum-speedup 50 \
             --threshold 15 \
             --allow-subset \
@@ -452,7 +545,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: benchmark-latency-shard-${{ matrix.shard }}-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        name: latency-shard-${{ matrix.shard }}-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
         path: benchmark-results/
         if-no-files-found: warn
         retention-days: 14
@@ -473,7 +566,7 @@ jobs:
       continue-on-error: true
       uses: actions/download-artifact@v8
       with:
-        pattern: benchmark-latency-shard-*-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        pattern: latency-shard-*-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
         path: benchmark-results
         merge-multiple: true
 
@@ -506,7 +599,7 @@ jobs:
   benchmark-regression-gate:
     name: benchmark-regression-gate
     if: always()
-    needs: [method-level, large-corpus, wrapped-query-latency]
+    needs: [method-level, budgeted-mapped-string, large-corpus, wrapped-query-latency]
     runs-on: ubuntu-latest
 
     steps:
@@ -579,10 +672,12 @@ jobs:
       if: always()
       env:
         METHOD_JOB: ${{ needs.method-level.result }}
+        BUDGETED_STRING_JOB: ${{ needs.budgeted-mapped-string.result }}
         LARGE_CORPUS_JOB: ${{ needs.large-corpus.result }}
         LATENCY_JOB: ${{ needs.wrapped-query-latency.result }}
       run: |
-        if [ "${METHOD_JOB}" != success ] || [ "${LARGE_CORPUS_JOB}" != success ] || \
+        if [ "${METHOD_JOB}" != success ] || [ "${BUDGETED_STRING_JOB}" != success ] || \
+          [ "${LARGE_CORPUS_JOB}" != success ] || \
           [ "${LATENCY_JOB}" != success ]; then
           echo "::error::Benchmark execution or comparison failed"
           exit 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -268,6 +268,7 @@ jobs:
 
     - name: Verify all real-fixture query results
       run: |
+        set -o pipefail
         mkdir -p benchmark-results
         for REVISION in fixed base candidate; do
           JMH_JAR=$(find "${REVISION}/graphite-webgraph/build/libs" -name '*-jmh.jar' -print -quit)
@@ -275,7 +276,9 @@ jobs:
           java -Xmx8g -cp "${JMH_JAR}" \
             io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkQueryCorrectness \
             "${PWD}/fixture-graphs" \
-            | grep '^ALL_FIXTURE_QUERY_RESULT' \
+            | tee "benchmark-results/${REVISION}-fixture-correctness.log"
+          grep '^ALL_FIXTURE_QUERY_RESULT' \
+            "benchmark-results/${REVISION}-fixture-correctness.log" \
             > "benchmark-results/${REVISION}-fixture-correctness.txt"
           test "$(wc -l < "benchmark-results/${REVISION}-fixture-correctness.txt")" -eq 8
         done
@@ -340,7 +343,8 @@ jobs:
             'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
             -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
             -rff "${PWD}/benchmark-results/fixed-latency-confirmation.json"
-          node candidate/.github/scripts/benchmark-gate.mjs compare-latency-baseline \
+          node candidate/.github/scripts/benchmark-gate.mjs confirm-latency-baseline \
+            --initial benchmark-results/initial-latency-status.json \
             --fixed benchmark-results/fixed-latency-confirmation.json \
             --base benchmark-results/base-latency-confirmation.json \
             --candidate benchmark-results/candidate-latency-confirmation.json \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -187,10 +187,34 @@ jobs:
         if-no-files-found: warn
         retention-days: 14
 
-  wrapped-query-latency:
-    name: wrapped-query-latency
+  wrapped-query-latency-shard:
+    name: wrapped-query-latency-shard-${{ matrix.shard }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - shard: synthetic
+          real: false
+          correctness: false
+          filter: 'io.johnsonlee.graphite.webgraph.WrappedDiscoveryLatencyBenchmark.(coldWrappedCaseInsensitiveDiscovery|wrappedCaseInsensitiveDiscovery)'
+        - shard: real-a
+          real: true
+          correctness: true
+          filter: 'io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.(zeroHitBroadContainsCaseInsensitiveDiscovery|denseDistributedMethodContainsCaseInsensitiveDiscovery)'
+        - shard: real-b
+          real: true
+          correctness: false
+          filter: 'io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.(earlyGraphClassPrefixCaseInsensitiveDiscovery|middleGraphsClassPrefixCaseInsensitiveDiscovery)'
+        - shard: real-c
+          real: true
+          correctness: false
+          filter: 'io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.(lateGraphClassPrefixCaseInsensitiveDiscovery|broadlyDistributedClassPrefixCaseInsensitiveDiscovery)'
+        - shard: real-d
+          real: true
+          correctness: false
+          filter: 'io.johnsonlee.graphite.webgraph.AllFixtureWrappedDiscoveryLatencyBenchmark.(firstLastGraphBimodalClassPrefixCaseInsensitiveDiscovery|skewedMixedClassMethodOperatorCaseInsensitiveDiscovery)'
 
     steps:
     - name: Checkout fixed pre-PR-95 baseline
@@ -240,6 +264,7 @@ jobs:
         candidate/gradlew -p candidate :webgraph:jmhJar --no-daemon
 
     - name: Prepare all real fixture graphs
+      if: matrix.real
       run: |
         FIXTURE_DIR="${PWD}/candidate/graphite-webgraph/build/benchmark-fixtures"
         ANDROID_JAR=$(find "${FIXTURE_DIR}" -name 'android-all-*.jar' -print -quit)
@@ -267,6 +292,7 @@ jobs:
           "${PWD}/fixture-graphs"
 
     - name: Verify all real-fixture query results
+      if: matrix.correctness
       run: |
         set -o pipefail
         mkdir -p benchmark-results
@@ -288,6 +314,8 @@ jobs:
           benchmark-results/candidate-fixture-correctness.txt
 
     - name: Benchmark fixed baseline, PR base, and PR
+      env:
+        BENCHMARK_FILTER: ${{ matrix.filter }}
       run: |
         mkdir -p benchmark-results
         FIXED_JAR=$(find fixed/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
@@ -299,19 +327,22 @@ jobs:
           -Dhive.graph.path=${PWD}/fixture-graphs/hive \
           -Dkotlin.compiler.graph.path=${PWD}/fixture-graphs/kotlin-compiler"
         java -jar "${FIXED_JAR}" \
-          'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+          "${BENCHMARK_FILTER}" \
           -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
           -rff "${PWD}/benchmark-results/fixed-latency.json"
         java -jar "${BASE_JAR}" \
-          'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+          "${BENCHMARK_FILTER}" \
           -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
           -rff "${PWD}/benchmark-results/base-latency.json"
         java -jar "${CANDIDATE_JAR}" \
-          'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+          "${BENCHMARK_FILTER}" \
           -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
           -rff "${PWD}/benchmark-results/candidate-latency.json"
 
     - name: Enforce fixed baseline speedup and current-base regression gate
+      env:
+        BENCHMARK_FILTER: ${{ matrix.filter }}
+        SHARD: ${{ matrix.shard }}
       run: |
         if node candidate/.github/scripts/benchmark-gate.mjs compare-latency-baseline \
           --fixed benchmark-results/fixed-latency.json \
@@ -319,10 +350,11 @@ jobs:
           --candidate benchmark-results/candidate-latency.json \
           --minimum-speedup 50 \
           --threshold 15 \
+          --allow-subset \
           --report benchmark-results/initial-latency-report.md \
           --status benchmark-results/initial-latency-status.json; then
-          mv benchmark-results/initial-latency-report.md benchmark-results/latency-report.md
-          mv benchmark-results/initial-latency-status.json benchmark-results/latency-status.json
+          mv benchmark-results/initial-latency-report.md "benchmark-results/latency-report-${SHARD}.md"
+          mv benchmark-results/initial-latency-status.json "benchmark-results/latency-status-${SHARD}.json"
         else
           CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
           BASE_JAR=$(find base/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
@@ -332,15 +364,15 @@ jobs:
             -Dhive.graph.path=${PWD}/fixture-graphs/hive \
             -Dkotlin.compiler.graph.path=${PWD}/fixture-graphs/kotlin-compiler"
           java -jar "${CANDIDATE_JAR}" \
-            'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+            "${BENCHMARK_FILTER}" \
             -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
             -rff "${PWD}/benchmark-results/candidate-latency-confirmation.json"
           java -jar "${BASE_JAR}" \
-            'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+            "${BENCHMARK_FILTER}" \
             -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
             -rff "${PWD}/benchmark-results/base-latency-confirmation.json"
           java -jar "${FIXED_JAR}" \
-            'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+            "${BENCHMARK_FILTER}" \
             -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
             -rff "${PWD}/benchmark-results/fixed-latency-confirmation.json"
           node candidate/.github/scripts/benchmark-gate.mjs confirm-latency-baseline \
@@ -350,18 +382,65 @@ jobs:
             --candidate benchmark-results/candidate-latency-confirmation.json \
             --minimum-speedup 50 \
             --threshold 15 \
-            --report benchmark-results/latency-report.md \
-            --status benchmark-results/latency-status.json
+            --allow-subset \
+            --report "benchmark-results/latency-report-${SHARD}.md" \
+            --status "benchmark-results/latency-status-${SHARD}.json"
         fi
 
     - name: Upload wrapped-query latency results
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: benchmark-latency-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        name: benchmark-latency-shard-${{ matrix.shard }}-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
         path: benchmark-results/
         if-no-files-found: warn
         retention-days: 14
+
+  wrapped-query-latency:
+    name: wrapped-query-latency
+    if: always()
+    needs: [wrapped-query-latency-shard]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout PR reporting code
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Download latency shard results
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        pattern: benchmark-latency-shard-*-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        path: benchmark-results
+        merge-multiple: true
+
+    - name: Combine latency shard results
+      if: always()
+      run: |
+        mkdir -p benchmark-results
+        node .github/scripts/benchmark-gate.mjs combine-latency-shards \
+          --directory benchmark-results \
+          --report benchmark-results/latency-report.md \
+          --status benchmark-results/latency-status.json
+
+    - name: Upload combined wrapped-query latency results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: benchmark-latency-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        path: benchmark-results/
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Enforce latency shards
+      if: always()
+      env:
+        SHARD_JOB: ${{ needs.wrapped-query-latency-shard.result }}
+      run: |
+        test "${SHARD_JOB}" = success
+        node -e "const s=require('./benchmark-results/latency-status.json'); if(!s.passed) process.exit(1)"
 
   benchmark-regression-gate:
     name: benchmark-regression-gate

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   JAVA_OPTS: -Xmx2g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
   JVM_OPTS: -Xmx2g -XX:MetaspaceSize=512m -Dfile.encoding=UTF-8
+  PRE_PR_95_BASELINE_SHA: 44b57562f2b3d0c88882a9002bdc488e05e5d7a7
 
 jobs:
   method-level:
@@ -186,10 +187,182 @@ jobs:
         if-no-files-found: warn
         retention-days: 14
 
+  wrapped-query-latency:
+    name: wrapped-query-latency
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+    - name: Checkout fixed pre-PR-95 baseline
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ env.PRE_PR_95_BASELINE_SHA }}
+        path: fixed
+
+    - name: Checkout PR base
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+
+    - name: Checkout PR
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: candidate
+
+    - name: Setup Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-read-only: true
+
+    - name: Install identical latency harness in baselines
+      run: |
+        for HARNESS in \
+          WrappedDiscoveryLatencyBenchmark.kt \
+          AllFixtureWrappedDiscoveryLatencyBenchmark.kt; do
+          SOURCE="graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/${HARNESS}"
+          cp "candidate/${SOURCE}" "fixed/${SOURCE}"
+          cp "candidate/${SOURCE}" "base/${SOURCE}"
+        done
+
+    - name: Build latency benchmark jars
+      run: |
+        candidate/gradlew -p candidate :webgraph:prepareBenchmarkFixtures --no-daemon
+        fixed/gradlew -p fixed :webgraph:jmhJar --no-daemon
+        base/gradlew -p base :webgraph:jmhJar --no-daemon
+        candidate/gradlew -p candidate :webgraph:jmhJar --no-daemon
+
+    - name: Prepare all real fixture graphs
+      run: |
+        FIXTURE_DIR="${PWD}/candidate/graphite-webgraph/build/benchmark-fixtures"
+        ANDROID_JAR=$(find "${FIXTURE_DIR}" -name 'android-all-*.jar' -print -quit)
+        TIKA_JAR=$(find "${FIXTURE_DIR}" -name 'tika-app-*.jar' -print -quit)
+        HIVE_JAR=$(find "${FIXTURE_DIR}" -name 'hive-exec-*.jar' -print -quit)
+        KOTLIN_JAR=$(find "${FIXTURE_DIR}" -name 'kotlin-compiler-embeddable-*.jar' -print -quit)
+        CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+        test -n "${ANDROID_JAR}" && test -n "${TIKA_JAR}" && test -n "${HIVE_JAR}" && \
+          test -n "${KOTLIN_JAR}" && test -n "${CANDIDATE_JAR}"
+        mkdir -p "${PWD}/fixture-graphs"
+        for CORPUS in android tika hive kotlin-compiler; do
+          SOURCE_TMP=$(mktemp -d "${RUNNER_TEMP}/graphite-source-${CORPUS}-XXXXXX")
+          java -Xmx4g -Djava.io.tmpdir="${SOURCE_TMP}" \
+            -Dandroid.jar.path="${ANDROID_JAR}" \
+            -Dtika.jar.path="${TIKA_JAR}" \
+            -Dhive.jar.path="${HIVE_JAR}" \
+            -Dkotlin.compiler.jar.path="${KOTLIN_JAR}" \
+            -cp "${CANDIDATE_JAR}" \
+            io.johnsonlee.graphite.webgraph.AllFixtureGraphPreparation \
+            "${CORPUS}" "${PWD}/fixture-graphs/${CORPUS}"
+          rm -rf -- "${SOURCE_TMP}"
+        done
+        java -Xmx4g -cp "${CANDIDATE_JAR}" \
+          io.johnsonlee.graphite.webgraph.AllFixtureDistributionCalibration \
+          "${PWD}/fixture-graphs"
+
+    - name: Verify all real-fixture query results
+      run: |
+        mkdir -p benchmark-results
+        for REVISION in fixed base candidate; do
+          JMH_JAR=$(find "${REVISION}/graphite-webgraph/build/libs" -name '*-jmh.jar' -print -quit)
+          test -n "${JMH_JAR}"
+          java -Xmx8g -cp "${JMH_JAR}" \
+            io.johnsonlee.graphite.webgraph.AllFixtureQueryCorrectness \
+            "${PWD}/fixture-graphs" \
+            | grep '^ALL_FIXTURE_QUERY_RESULT' \
+            > "benchmark-results/${REVISION}-fixture-correctness.txt"
+          test "$(wc -l < "benchmark-results/${REVISION}-fixture-correctness.txt")" -eq 8
+        done
+        cmp benchmark-results/fixed-fixture-correctness.txt \
+          benchmark-results/base-fixture-correctness.txt
+        cmp benchmark-results/fixed-fixture-correctness.txt \
+          benchmark-results/candidate-fixture-correctness.txt
+
+    - name: Benchmark fixed baseline, PR base, and PR
+      run: |
+        mkdir -p benchmark-results
+        FIXED_JAR=$(find fixed/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+        BASE_JAR=$(find base/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+        CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+        test -n "${FIXED_JAR}" && test -n "${BASE_JAR}" && test -n "${CANDIDATE_JAR}"
+        GRAPH_JVM_ARGS="-Dandroid.graph.path=${PWD}/fixture-graphs/android \
+          -Dtika.graph.path=${PWD}/fixture-graphs/tika \
+          -Dhive.graph.path=${PWD}/fixture-graphs/hive \
+          -Dkotlin.compiler.graph.path=${PWD}/fixture-graphs/kotlin-compiler"
+        java -jar "${FIXED_JAR}" \
+          'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+          -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
+          -rff "${PWD}/benchmark-results/fixed-latency.json"
+        java -jar "${BASE_JAR}" \
+          'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+          -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
+          -rff "${PWD}/benchmark-results/base-latency.json"
+        java -jar "${CANDIDATE_JAR}" \
+          'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+          -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
+          -rff "${PWD}/benchmark-results/candidate-latency.json"
+
+    - name: Enforce fixed baseline speedup and current-base regression gate
+      run: |
+        if node candidate/.github/scripts/benchmark-gate.mjs compare-latency-baseline \
+          --fixed benchmark-results/fixed-latency.json \
+          --base benchmark-results/base-latency.json \
+          --candidate benchmark-results/candidate-latency.json \
+          --minimum-speedup 50 \
+          --threshold 15 \
+          --report benchmark-results/initial-latency-report.md \
+          --status benchmark-results/initial-latency-status.json; then
+          mv benchmark-results/initial-latency-report.md benchmark-results/latency-report.md
+          mv benchmark-results/initial-latency-status.json benchmark-results/latency-status.json
+        else
+          CANDIDATE_JAR=$(find candidate/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+          BASE_JAR=$(find base/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+          FIXED_JAR=$(find fixed/graphite-webgraph/build/libs -name '*-jmh.jar' -print -quit)
+          GRAPH_JVM_ARGS="-Dandroid.graph.path=${PWD}/fixture-graphs/android \
+            -Dtika.graph.path=${PWD}/fixture-graphs/tika \
+            -Dhive.graph.path=${PWD}/fixture-graphs/hive \
+            -Dkotlin.compiler.graph.path=${PWD}/fixture-graphs/kotlin-compiler"
+          java -jar "${CANDIDATE_JAR}" \
+            'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+            -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
+            -rff "${PWD}/benchmark-results/candidate-latency-confirmation.json"
+          java -jar "${BASE_JAR}" \
+            'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+            -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
+            -rff "${PWD}/benchmark-results/base-latency-confirmation.json"
+          java -jar "${FIXED_JAR}" \
+            'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
+            -jvmArgsAppend "${GRAPH_JVM_ARGS}" -foe true -prof gc -rf json \
+            -rff "${PWD}/benchmark-results/fixed-latency-confirmation.json"
+          node candidate/.github/scripts/benchmark-gate.mjs compare-latency-baseline \
+            --fixed benchmark-results/fixed-latency-confirmation.json \
+            --base benchmark-results/base-latency-confirmation.json \
+            --candidate benchmark-results/candidate-latency-confirmation.json \
+            --minimum-speedup 50 \
+            --threshold 15 \
+            --report benchmark-results/latency-report.md \
+            --status benchmark-results/latency-status.json
+        fi
+
+    - name: Upload wrapped-query latency results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: benchmark-latency-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+        path: benchmark-results/
+        if-no-files-found: warn
+        retention-days: 14
+
   benchmark-regression-gate:
     name: benchmark-regression-gate
     if: always()
-    needs: [method-level, large-corpus]
+    needs: [method-level, large-corpus, wrapped-query-latency]
     runs-on: ubuntu-latest
 
     steps:
@@ -263,8 +436,10 @@ jobs:
       env:
         METHOD_JOB: ${{ needs.method-level.result }}
         LARGE_CORPUS_JOB: ${{ needs.large-corpus.result }}
+        LATENCY_JOB: ${{ needs.wrapped-query-latency.result }}
       run: |
-        if [ "${METHOD_JOB}" != success ] || [ "${LARGE_CORPUS_JOB}" != success ]; then
+        if [ "${METHOD_JOB}" != success ] || [ "${LARGE_CORPUS_JOB}" != success ] || \
+          [ "${LATENCY_JOB}" != success ]; then
           echo "::error::Benchmark execution or comparison failed"
           exit 1
         fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -168,6 +168,7 @@ jobs:
           --base benchmark-results/baseline-budgeted-string.json \
           --candidate benchmark-results/candidate-budgeted-string.json \
           --threshold 15 \
+          --threshold-only \
           --title 'Budgeted mapped-string latency' \
           --report benchmark-results/initial-budgeted-string-report.md \
           --status benchmark-results/initial-budgeted-string-status.json; then
@@ -187,6 +188,7 @@ jobs:
             --base benchmark-results/baseline-budgeted-string-confirmation.json \
             --candidate benchmark-results/candidate-budgeted-string-confirmation.json \
             --threshold 15 \
+            --threshold-only \
             --title 'Budgeted mapped-string latency' \
             --report benchmark-results/budgeted-string-report.md \
             --status benchmark-results/budgeted-string-status.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -258,12 +258,12 @@ jobs:
             -Dhive.jar.path="${HIVE_JAR}" \
             -Dkotlin.compiler.jar.path="${KOTLIN_JAR}" \
             -cp "${CANDIDATE_JAR}" \
-            io.johnsonlee.graphite.webgraph.AllFixtureGraphPreparation \
+            io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkGraphPreparation \
             "${CORPUS}" "${PWD}/fixture-graphs/${CORPUS}"
           rm -rf -- "${SOURCE_TMP}"
         done
         java -Xmx4g -cp "${CANDIDATE_JAR}" \
-          io.johnsonlee.graphite.webgraph.AllFixtureDistributionCalibration \
+          io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkDistributionCalibration \
           "${PWD}/fixture-graphs"
 
     - name: Verify all real-fixture query results
@@ -273,7 +273,7 @@ jobs:
           JMH_JAR=$(find "${REVISION}/graphite-webgraph/build/libs" -name '*-jmh.jar' -print -quit)
           test -n "${JMH_JAR}"
           java -Xmx8g -cp "${JMH_JAR}" \
-            io.johnsonlee.graphite.webgraph.AllFixtureQueryCorrectness \
+            io.johnsonlee.graphite.webgraph.AllFixtureBenchmarkQueryCorrectness \
             "${PWD}/fixture-graphs" \
             | grep '^ALL_FIXTURE_QUERY_RESULT' \
             > "benchmark-results/${REVISION}-fixture-correctness.txt"

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -125,9 +125,10 @@ The `budgeted-mapped-string-latency` job protects the budget-aware transformed m
 that regressed after the original latency fix. It compiles the identical
 `MappedStringAdmissionBenchmark.budgetedTransformedZeroHit` harness at fixed commit
 `87c74c2cae0685e40e32fb2eb46b33987ec1a7a0` and at the pull request candidate, then runs both on
-the same runner. A candidate more than 15% slower with separated confidence intervals is rerun in
-reverse order and blocks when the same regression repeats. This fixed baseline keeps a later change
-from normalizing a 2x full-scan regression into the moving base.
+the same runner. Any candidate score more than 15% slower is rerun in reverse order even when the
+SingleShot confidence intervals overlap, and it blocks when the reverse-order score is also more
+than 15% slower. This fixed baseline keeps a later change from normalizing a 2x full-scan regression
+into the moving base.
 
 ## Local verification
 

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -119,6 +119,16 @@ they can reuse trusted main-branch state without creating a cache entry for ever
 Generated graphs and project `build/` directories are deliberately excluded. The end-to-end gate
 must measure graph construction and persistence rather than restore those outputs from a cache.
 
+## Budgeted mapped-string latency gate
+
+The `budgeted-mapped-string-latency` job protects the budget-aware transformed mapped-string scan
+that regressed after the original latency fix. It compiles the identical
+`MappedStringAdmissionBenchmark.budgetedTransformedZeroHit` harness at fixed commit
+`87c74c2cae0685e40e32fb2eb46b33987ec1a7a0` and at the pull request candidate, then runs both on
+the same runner. A candidate more than 15% slower with separated confidence intervals is rerun in
+reverse order and blocks when the same regression repeats. This fixed baseline keeps a later change
+from normalizing a 2x full-scan regression into the moving base.
+
 ## Local verification
 
 Test the comparison and report generation logic:

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -25,14 +25,18 @@ The 12 benchmark keys are split across five parallel matrix shards: one for
 the four synthetic keys and four for pairs of real-fixture query cases. Within
 each shard, fixed baseline, current base, and candidate still run sequentially
 on the same runner, so parallelism does not turn cross-runner variance into a
-performance comparison. The final `wrapped-query-latency` job fails closed
-unless all five shard reports arrive and their union contains every expected
-key exactly once.
+performance comparison. A prerequisite job restores or builds the persisted
+fixture graphs once with a 4 GiB heap, using a content-addressed cache key over
+the graph-building/serialization sources, fixture harness, dependency catalog,
+and Gradle build files. Real shards restore that immutable cache instead of
+rebuilding 19 million nodes independently. The final `wrapped-query-latency`
+job fails closed unless all five shard reports arrive and their union contains
+every expected key exactly once.
 
 It measures warm and cold queries with `graphCount=1` and `graphCount=17` on
 deterministic persisted graphs. It also builds every repository benchmark
-fixture (Android, Tika, Hive, and Kotlin Compiler) sequentially in each real
-shard, opens the four
+fixture (Android, Tika, Hive, and Kotlin Compiler) sequentially on a cache miss,
+then each real shard opens the four
 persisted graphs together, and measures the same query over the heterogeneous
 19,091,048-node graph set. Source graphs are never retained together: each is
 closed after persistence, before the next fixture is built.

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -10,6 +10,48 @@ contains the base and candidate SHAs, runner architecture, every measured score,
 and gate decision. Raw JMH JSON and large-corpus logs are retained as workflow artifacts for 14
 days.
 
+## Wrapped case-insensitive latency gate
+
+The `wrapped-query-latency` job protects the production
+`toLower(coalesce(...)) CONTAINS` discovery shape on persisted mapped graphs.
+The same `WrappedDiscoveryLatencyBenchmark` source is compiled at three
+revisions:
+
+1. fixed pre-PR-95 commit `44b57562f2b3d0c88882a9002bdc488e05e5d7a7`;
+2. the pull request's current base SHA; and
+3. the pull request candidate SHA.
+
+It measures warm and cold queries with `graphCount=1` and `graphCount=17` on
+deterministic persisted graphs. It also builds every repository benchmark
+fixture (Android, Tika, Hive, and Kotlin Compiler) sequentially, opens the four
+persisted graphs together, and measures the same query over the heterogeneous
+19,091,048-node graph set. Source graphs are never retained together: each is
+closed after persistence, before the next fixture is built.
+
+The real-corpus suite treats target distribution as part of the fixture. Its
+preflight pins per-corpus match counts, then benchmarks zero-hit, dense
+four-corpus, first-graph-only, middle-graphs-only, last-graph-only,
+four-corpus-distributed, first/last bimodal, and highly skewed class/method
+cases. The queries vary caller/callee fields, class/method properties,
+`CONTAINS`/`STARTS WITH`/`ENDS WITH`, and `LIMIT 1/50/250`.
+Before timing, fixed, current-base, and candidate executors must produce the
+same SHA-256 digest over complete columns, ordered rows, values, and graph
+provenance for all eight queries. The comparator separately requires the exact
+four synthetic and eight real-fixture benchmark keys, so a variant cannot
+silently disappear from all three revisions.
+
+Each source JAR is built in its own JVM and private `java.io.tmpdir`. After the
+source graph is persisted and that JVM exits, the raw mmap work directory is
+deleted before the next corpus starts. Only the four final persisted graph
+directories remain for the shared query measurements.
+Every row must remain at least 50% faster than the fixed baseline and may not
+regress more than 15% against the current PR base. Missing graph-count or query
+variants, incompatible units, invalid scores, and missing artifacts fail
+closed. A suspected failure reruns candidate, base, and fixed baseline in
+reverse order before it blocks. The fixed baseline prevents the original full-scan behavior from
+becoming an accepted new base after a merge; the moving base comparison catches
+new regressions in later optimizations.
+
 ## Method-level gate
 
 The method-level job runs every `CypherBenchmark` method from both revisions with its normal JMH
@@ -78,6 +120,8 @@ Run the two benchmark sources directly:
 ```bash
 ./gradlew :cypher:jmhJar --no-daemon
 ./gradlew :webgraph:largeCorpusTest -Dlarge.corpus.record=true --no-daemon
+./gradlew :webgraph:jmh -Pjmh.filter='WrappedDiscoveryLatencyBenchmark.*' --no-daemon
+./gradlew :webgraph:jmh -Pjmh.filter='AllFixtureWrappedDiscoveryLatencyBenchmark.*' --no-daemon
 ```
 
 The workflow deliberately keeps benchmark execution separate from unit-test coverage. Coverage

--- a/docs/benchmark-regression-gate.md
+++ b/docs/benchmark-regression-gate.md
@@ -21,9 +21,18 @@ revisions:
 2. the pull request's current base SHA; and
 3. the pull request candidate SHA.
 
+The 12 benchmark keys are split across five parallel matrix shards: one for
+the four synthetic keys and four for pairs of real-fixture query cases. Within
+each shard, fixed baseline, current base, and candidate still run sequentially
+on the same runner, so parallelism does not turn cross-runner variance into a
+performance comparison. The final `wrapped-query-latency` job fails closed
+unless all five shard reports arrive and their union contains every expected
+key exactly once.
+
 It measures warm and cold queries with `graphCount=1` and `graphCount=17` on
 deterministic persisted graphs. It also builds every repository benchmark
-fixture (Android, Tika, Hive, and Kotlin Compiler) sequentially, opens the four
+fixture (Android, Tika, Hive, and Kotlin Compiler) sequentially in each real
+shard, opens the four
 persisted graphs together, and measures the same query over the heterogeneous
 19,091,048-node graph set. Source graphs are never retained together: each is
 closed after persistence, before the next fixture is built.

--- a/docs/wrapped-case-insensitive-query-optimization-attempts.md
+++ b/docs/wrapped-case-insensitive-query-optimization-attempts.md
@@ -1,0 +1,196 @@
+# Wrapped Case-Insensitive Query Optimization Attempts
+
+This log records the investigation and every retained optimization attempt for
+the production `toLower(coalesce(...)) CONTAINS` discovery query. The fixed
+comparison baseline is commit `44b57562f2b3d0c88882a9002bdc488e05e5d7a7`,
+the commit immediately before PR #95.
+
+## Query and acceptance criteria
+
+The benchmark uses the same four wrapped properties, `DISTINCT`, projection,
+and `LIMIT 250` as the reported query. Both one graph and 17 graphs are required
+because the executor consumes graph sources serially and qualified `DISTINCT`
+must keep scanning to merge complete provenance.
+
+The change is accepted only if it:
+
+- preserves Kotlin `String.lowercase()` semantics exactly, including mixed-case
+  and Unicode values;
+- preserves null/missing-property behavior, row order, `DISTINCT`, `LIMIT`, and
+  cross-graph provenance;
+- is at least 50% faster than the fixed pre-PR-95 benchmark for both one and 17
+  persisted graphs;
+- does not regress more than 15% against the pull request base; and
+- leaves unsupported graphs, properties, and expression shapes on the generic
+  evaluator.
+
+### 2026-08-29 - Attempt 000: Reproduce and isolate the regression
+
+The exact real Android mmap graph contains 5,938,826 nodes. An identical JMH
+harness was compiled at the fixed pre-PR-95 commit and current `main`.
+
+| Revision | 1 graph | 17 graphs | 1 graph allocation | 17 graph allocation |
+|---|---:|---:|---:|---:|
+| pre-PR-95 `44b5756` | `5,335.201 ms/op` | `92,396 ms/op` | `12.113 GB/op` | `205.29 GB/op` |
+| post-PR-95 `e2a2b1a` | `5,371.547 ms/op` | `89,635 ms/op` | `12.071 GB/op` | `194.44 GB/op` |
+
+PR #95 changes the one-graph runtime by only `+0.68%`; the roughly 90-second
+latency comes from executing the same generic full scan once for each of 17
+graphs. The PR #95 work-budget check rejects the query in about 220 ms when the
+default budget is enabled and is not the source of the 9-10x execution time.
+
+### 2026-08-29 - Attempt 001: Query-only rewrites
+
+On the same Android graph, adding a `CallSiteNode` label reduces the wrapped
+query to `1,681.695 ms/op`, while rewriting it to direct case-sensitive
+properties reaches `614.051 ms/op`.
+
+**Conclusion:** rejected as a product fix. The label excludes dynamic
+`AnnotationNode` properties and the direct query changes case semantics. The
+result establishes that storage-aware property lookup has enough headroom, but
+the planner must recognize the wrapped AST without rewriting user semantics.
+
+### 2026-08-29 - Attempt 002: Exact transformed lookup capability
+
+Added an optional transformed-string lookup capability instead of extending
+the existing `StringMatchMode` enum or adding a virtual method to `Graph`. The
+planner recognizes only these exact operands:
+
+```text
+toLower(n.property)
+toLower(coalesce(n.property, ''))
+toLowercase(...)
+```
+
+The right-hand literal is not normalized. An empty literal with `coalesce` is
+sent to the generic evaluator because missing properties must match it. Mapped
+storage evaluates lowercase once per distinct raw string ID when an index is
+admitted, and raw and transformed predicate caches use separate keys.
+
+The first real-graph run reduced latency to `0.750 s/op` for one graph and
+`12.918 s/op` for 17 graphs, with allocation reduced to about `1.60 GB/op` per
+graph.
+
+**Conclusion:** retained. Results and provenance are unchanged, but large
+properties that exceed the retained-index budget still repeat lowercase work
+while scanning raw `(nodeId, stringId)` pairs.
+
+### 2026-08-29 - Attempt 003: Remove boxed index iteration
+
+Replaced `indices.asSequence().filter().map()` in the admitted property index
+with one primitive loop. The Android result moved from `0.750` to `0.721 s/op`
+for one graph and allocation remained about `1.60 GB/op`.
+
+**Conclusion:** retained as a low-risk allocation fix for indexed hits, but it
+does not address the measured query because the Android call-site properties
+exceed the 8 MiB retained-index limit and use the raw scan.
+
+### 2026-08-29 - Attempt 004: Per-query raw string-ID match states
+
+After the first 256 inspected nodes, a raw scan now allocates one bounded byte
+per global string-table ID and records unknown/miss/match state. Repeated class
+and method strings are decoded and lowercased once per property query instead
+of once per node. The state array is transient, starts only after a long scan,
+and is disabled when it would exceed 16 MiB, so early `LIMIT` hits and very large
+string tables keep the previous memory behavior.
+
+Exact single-shot protocol:
+
+```shell
+java -jar graphite-webgraph/build/libs/*-jmh.jar \
+  'io.johnsonlee.graphite.webgraph.RealCompositeQueryBenchmark.compositeDistinct$' \
+  -p graphCount=1,17 -f 1 -foe true -prof gc \
+  -jvmArgsAppend '-Dandroid.graph.path=<persisted-android-graph>' \
+  -rf json -rff candidate-real-composite-final.json
+```
+
+Environment: Apple M3 Max, 64 GiB RAM, macOS arm64, OpenJDK 17.0.18, JMH
+1.37, one thread, one fork, one single-shot warmup, three single-shot
+measurements, `-Xmx12g`. Baseline and candidate use the same 5,938,826-node
+persisted graph and exact benchmark source.
+
+| Graphs | Pre-PR-95 baseline | Final | Speedup | Allocation before | Allocation final | Reduction |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | `5,335.201 ms/op` | `180.862 ms/op` | `29.50x` | `12.113 GB/op` | `0.290 GB/op` | `97.6%` |
+| 17 | `92,396 ms/op` | `2,733.259 ms/op` | `33.80x` | `205.29 GB/op` | `4.927 GB/op` | `97.6%` |
+
+**Conclusion:** retained. The same 17-source query is below three seconds on
+the benchmark machine, substantially better than both the roughly 90-second
+fixed baseline and the reported former 10-second behavior.
+
+## Permanent regression gate
+
+`WrappedDiscoveryLatencyBenchmark` persists deterministic mixed-case data and
+runs warm and cold forms with `graphCount=1,17`. CI overlays that exact harness
+onto the fixed pre-PR-95 commit and the pull request base before compiling all
+three revisions. `compare-latency-baseline` fails closed for missing parameters
+and requires both the fixed-baseline speedup and the current-base regression
+limit. Suspected failures repeat in candidate/base/fixed reverse order. The
+fixed SHA is explicit in `.github/workflows/benchmark.yml`.
+
+`AndroidWrappedDiscoveryBenchmark` is the manual real-corpus counterpart. It
+uses the exact production query and the existing validated Android corpus.
+
+### 2026-08-29 - Attempt 005: Heterogeneous all-fixture baseline
+
+The repeated-Android benchmark isolates graph-count scaling but reuses one
+mapped graph and therefore does not represent heterogeneous string tables,
+hit distributions, or page-cache behavior. The permanent gate now adds
+`AllFixtureWrappedDiscoveryLatencyBenchmark`: Android, Tika, Hive, and Kotlin
+Compiler are built and persisted one at a time, then all four mapped graphs
+(`19,091,048` nodes total) are queried together. CI prepares the persisted
+graphs once and supplies the identical files to pre-PR-95, current-base, and
+candidate JMH forks. This is additive to, not a replacement for, the stable
+1/17-graph scaling benchmark.
+
+The suite does not merely substitute constants. A preflight records and pins
+the exact per-corpus match counts, covering zero hits; dense matches in all
+four graphs; matches isolated to the first, middle, or last graph; broadly
+distributed matches; first/last bimodal matches; and a highly skewed case with
+a dense Android head and sparse tail. Query shapes vary class versus method,
+caller versus callee, `CONTAINS`/`STARTS WITH`/`ENDS WITH`, mixed operators,
+multi-target OR, and `LIMIT 1/50/250`.
+
+Same-machine SingleShot results over the shared four-corpus persisted fixture:
+
+| Distribution / shape | Pre-PR-95 | Final | Speedup |
+|---|---:|---:|---:|
+| zero-hit broad `CONTAINS`, four fields | `15.209 s/op` | `0.520 s/op` | `29.25x` |
+| dense method `CONTAINS`, all graphs | `14.019 s/op` | `1.836 s/op` | `7.64x` |
+| first-graph-only class prefix | `11.506 s/op` | `1.481 s/op` | `7.77x` |
+| middle-graphs-only class prefixes | `14.314 s/op` | `1.349 s/op` | `10.61x` |
+| last-graph-only class prefix | `12.695 s/op` | `1.438 s/op` | `8.83x` |
+| broadly distributed class prefix | `13.927 s/op` | `1.715 s/op` | `8.12x` |
+| first/last bimodal class prefixes | `16.289 s/op` | `2.842 s/op` | `5.73x` |
+| skewed mixed class/method operators | `15.977 s/op` | `1.811 s/op` | `8.82x` |
+| arithmetic mean | `14.242 s/op` | `1.624 s/op` | `8.77x` |
+
+These are the final order-preserving measurements with one unmeasured warmup
+and three measured single-shot invocations per case. All eight complete result
+digests match the pre-PR-95 executor, including ordered rows and provenance.
+The 50% fixed-baseline speedup threshold remains comfortably satisfied for
+every distribution.
+
+The final gate also closes three false-pass/resource gaps found during review:
+it compares complete result/provenance digests across fixed, base, and
+candidate; requires an explicit manifest of all 12 benchmark keys; and builds
+each source corpus in a separate JVM/private temporary directory before
+removing the raw mmap files. Thus an empty or semantically wrong fast result,
+a deleted benchmark variant, or accumulated source mmap files cannot masquerade
+as a successful latency optimization.
+
+Local full-protocol gate validation on the same machine as the real-corpus run:
+
+| Benchmark | Pre-PR-95 | `main` | Final |
+|---|---:|---:|---:|
+| cold, 1 graph | `3.994 ms/op` | `4.207 ms/op` | `0.566 ms/op` |
+| cold, 17 graphs | `68.841 ms/op` | `83.809 ms/op` | `7.917 ms/op` |
+| warm, 1 graph | `5.660 ms/op` | `5.108 ms/op` | `0.126 ms/op` |
+| warm, 17 graphs | `97.534 ms/op` | `71.127 ms/op` | `0.216 ms/op` |
+
+All four rows pass `compare-latency-baseline`. Existing method-level
+`CypherBenchmark` rows also pass the 15% gate. Persisted-storage checks show no
+adjacent regression: Android mapped load is `149.418 -> 139.761 ms/op`, the
+five mapped query benchmarks range from `-12.6%` to `+6.7%`, and
+`GraphEndToEndBenchmark.android_build_save_load_query` is
+`25,294.562 -> 24,900.711 ms/op` (`-1.6%`).

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -31,7 +31,12 @@ enum class StringValueTransform {
     LOWERCASE
 }
 
-/** Optional storage capability for graphs that can avoid materializing a full node scan. */
+/**
+ * Optional storage capability for graphs that can avoid materializing a full node scan.
+ *
+ * When the same graph also implements [StringPropertyLookupOrder], every non-null sequence
+ * returned by this capability must be monotonic in [StringPropertyLookupOrder.stringPropertyNodeOrder].
+ */
 interface StringPropertyLookup {
     fun <T : Node> nodesByStringProperty(
         type: Class<T>,
@@ -59,7 +64,12 @@ interface WorkAwareStringPropertyLookup : StringPropertyLookup {
     ): Sequence<T>?
 }
 
-/** Optional storage capability for matching a precisely transformed string value. */
+/**
+ * Optional storage capability for matching a precisely transformed string value.
+ *
+ * When the same graph also implements [StringPropertyLookupOrder], every non-null sequence
+ * returned by this capability must be monotonic in [StringPropertyLookupOrder.stringPropertyNodeOrder].
+ */
 interface TransformedStringPropertyLookup {
     fun <T : Node> nodesByTransformedStringProperty(
         type: Class<T>,
@@ -84,7 +94,11 @@ interface WorkAwareTransformedStringPropertyLookup : TransformedStringPropertyLo
     ): Sequence<T>?
 }
 
-/** Optional ordering capability used to preserve the graph's canonical node traversal order. */
+/**
+ * Ordering capability for storage lookups that are emitted in canonical node traversal order.
+ * Implementations must return a stable key and must emit all string-property lookup sequences
+ * monotonically by that key.
+ */
 interface StringPropertyLookupOrder {
     fun stringPropertyNodeOrder(node: Node): Long
 }

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/graph/Graph.kt
@@ -26,6 +26,11 @@ enum class StringMatchMode {
     CONTAINS
 }
 
+/** Exact value transformation applied before a storage-backed string match. */
+enum class StringValueTransform {
+    LOWERCASE
+}
+
 /** Optional storage capability for graphs that can avoid materializing a full node scan. */
 interface StringPropertyLookup {
     fun <T : Node> nodesByStringProperty(
@@ -52,6 +57,36 @@ interface WorkAwareStringPropertyLookup : StringPropertyLookup {
         limit: Int,
         workConsumer: GraphWorkConsumer
     ): Sequence<T>?
+}
+
+/** Optional storage capability for matching a precisely transformed string value. */
+interface TransformedStringPropertyLookup {
+    fun <T : Node> nodesByTransformedStringProperty(
+        type: Class<T>,
+        property: String,
+        transform: StringValueTransform,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int
+    ): Sequence<T>?
+}
+
+/** Transformed string lookup capability that exposes every inspected work item. */
+interface WorkAwareTransformedStringPropertyLookup : TransformedStringPropertyLookup {
+    fun <T : Node> nodesByTransformedStringProperty(
+        type: Class<T>,
+        property: String,
+        transform: StringValueTransform,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int,
+        workConsumer: GraphWorkConsumer
+    ): Sequence<T>?
+}
+
+/** Optional ordering capability used to preserve the graph's canonical node traversal order. */
+interface StringPropertyLookupOrder {
+    fun stringPropertyNodeOrder(node: Node): Long
 }
 
 /**
@@ -238,6 +273,29 @@ fun <T : Node> Graph.nodesByStringProperty(
     workConsumer: GraphWorkConsumer
 ): Sequence<T>? = (this as? WorkAwareStringPropertyLookup)
     ?.nodesByStringProperty(type, property, mode, expected, limit, workConsumer)
+
+/** Use a storage-aware transformed string lookup when the graph supports it. */
+fun <T : Node> Graph.nodesByTransformedStringProperty(
+    type: Class<T>,
+    property: String,
+    transform: StringValueTransform,
+    mode: StringMatchMode,
+    expected: String,
+    limit: Int = Int.MAX_VALUE
+): Sequence<T>? = (this as? TransformedStringPropertyLookup)
+    ?.nodesByTransformedStringProperty(type, property, transform, mode, expected, limit)
+
+/** Use a transformed lookup only when it can report every inspected work item. */
+fun <T : Node> Graph.nodesByTransformedStringProperty(
+    type: Class<T>,
+    property: String,
+    transform: StringValueTransform,
+    mode: StringMatchMode,
+    expected: String,
+    limit: Int,
+    workConsumer: GraphWorkConsumer
+): Sequence<T>? = (this as? WorkAwareTransformedStringPropertyLookup)
+    ?.nodesByTransformedStringProperty(type, property, transform, mode, expected, limit, workConsumer)
 
 /**
  * Pattern for matching methods.

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/graph/DefaultGraphTest.kt
@@ -94,10 +94,20 @@ class DefaultGraphTest {
             .build()
 
         assertTrue(Graph::class.java.methods.none { it.name == "nodesByStringProperty" })
+        assertTrue(Graph::class.java.methods.none { it.name == "nodesByTransformedStringProperty" })
         assertNull(
             graph.nodesByStringProperty(
                 StringConstant::class.java,
                 "value",
+                StringMatchMode.CONTAINS,
+                "hello"
+            )
+        )
+        assertNull(
+            graph.nodesByTransformedStringProperty(
+                StringConstant::class.java,
+                "value",
+                StringValueTransform.LOWERCASE,
                 StringMatchMode.CONTAINS,
                 "hello"
             )

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -723,7 +723,11 @@ class QueryPipeline private constructor(
             }
             if (cursor.iterator.hasNext()) {
                 cursor.node = cursor.iterator.next()
-                cursor.nodeOrder = nodeOrder(cursor.node)
+                val nextOrder = nodeOrder(cursor.node)
+                require(nextOrder >= cursor.nodeOrder) {
+                    "String property lookup sequence is not monotonic in canonical graph order"
+                }
+                cursor.nodeOrder = nextOrder
                 cursors += cursor
             }
         }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -14,8 +14,12 @@ import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.core.ResourceEdge
 import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.StringPropertyLookupOrder
 import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.StringValueTransform
 import io.johnsonlee.graphite.graph.nodesByStringProperty
+import io.johnsonlee.graphite.graph.nodesByTransformedStringProperty
+import java.util.PriorityQueue
 
 private const val COUNT_QUERY_CLAUSES = 2
 private const val LABEL_HISTOGRAM_QUERY_CLAUSES = 5
@@ -604,9 +608,7 @@ class QueryPipeline private constructor(
             val indexedNodes = stringPropertyCandidates(
                 source.graph,
                 nodeClass,
-                filter.property,
-                filter.mode,
-                filter.expected,
+                filter,
                 limit - rows.size
             )
             val candidates = indexedNodes
@@ -648,7 +650,8 @@ class QueryPipeline private constructor(
         graph: Graph,
         nodeClass: Class<out Node>,
         disjunction: DirectStringDisjunction
-    ): Sequence<Node> = sequence {
+    ): Sequence<Node> {
+        val candidateSequences = mutableListOf<Sequence<Node>>()
         for ((candidateType, properties) in DIRECT_STRING_NODE_PROPERTIES) {
             if (!nodeClass.isAssignableFrom(candidateType)) continue
             val filters = disjunction.filters.filter { it.property in properties }
@@ -662,18 +665,23 @@ class QueryPipeline private constructor(
                 stringPropertyCandidates(
                     graph,
                     candidateType,
-                    filter.property,
-                    filter.mode,
-                    filter.expected,
+                    filter,
                     completeScanLimit
                 )
             }
-            val candidates = if (accelerated.any { it == null }) {
+            val candidates: Sequence<Node> = if (accelerated.any { it == null }) {
                 trackWork(graph.nodes(candidateType)).filter(disjunction::matches)
+            } else if (graph is StringPropertyLookupOrder) {
+                mergeNodeSequences(accelerated.filterNotNull(), graph::stringPropertyNodeOrder)
             } else {
                 filterOwnedNodes(filters, accelerated.filterNotNull())
             }
-            for (node in candidates) yield(node)
+            candidateSequences += candidates
+        }
+        return if (graph is StringPropertyLookupOrder) {
+            mergeNodeSequences(candidateSequences, graph::stringPropertyNodeOrder)
+        } else {
+            candidateSequences.asSequence().flatten()
         }
     }
 
@@ -683,25 +691,63 @@ class QueryPipeline private constructor(
     ): Sequence<Node> = sequence {
         for ((index, nodes) in sequences.withIndex()) {
             for (node in nodes) {
-                var ownedByEarlierFilter = false
-                for (earlierIndex in 0 until index) {
-                    if (filters[earlierIndex].matches(node)) {
-                        ownedByEarlierFilter = true
-                        break
-                    }
+                val ownedByEarlierFilter = (0 until index).any { earlierIndex ->
+                    filters[earlierIndex].matches(node)
                 }
                 if (!ownedByEarlierFilter) yield(node)
             }
         }
     }
 
+    private fun mergeNodeSequences(
+        sequences: List<Sequence<Node>>,
+        nodeOrder: (Node) -> Long
+    ): Sequence<Node> = sequence {
+        val cursors = PriorityQueue<NodeSequenceCursor>(
+            compareBy<NodeSequenceCursor> { it.nodeOrder }.thenBy { it.sequenceOrder }
+        )
+        sequences.forEachIndexed { order, nodes ->
+            val iterator = nodes.iterator()
+            if (iterator.hasNext()) {
+                val node = iterator.next()
+                cursors += NodeSequenceCursor(order, iterator, node, nodeOrder(node))
+            }
+        }
+        var lastNodeId: Int? = null
+        while (cursors.isNotEmpty()) {
+            val cursor = cursors.remove()
+            val node = cursor.node
+            if (node.id.value != lastNodeId) {
+                yield(node)
+                lastNodeId = node.id.value
+            }
+            if (cursor.iterator.hasNext()) {
+                cursor.node = cursor.iterator.next()
+                cursor.nodeOrder = nodeOrder(cursor.node)
+                cursors += cursor
+            }
+        }
+    }
+
+    private data class NodeSequenceCursor(
+        val sequenceOrder: Int,
+        val iterator: Iterator<Node>,
+        var node: Node,
+        var nodeOrder: Long
+    )
+
     private data class DirectStringFilter(
         val property: String,
         val mode: StringMatchMode,
-        val expected: String
+        val expected: String,
+        val transform: StringValueTransform? = null
     ) {
         fun matches(node: Node): Boolean {
-            val actual = NodePropertyAccessor.getProperty(node, property) as? String ?: return false
+            val raw = NodePropertyAccessor.getProperty(node, property) as? String ?: return false
+            val actual = when (transform) {
+                null -> raw
+                StringValueTransform.LOWERCASE -> raw.lowercase()
+            }
             return when (mode) {
                 StringMatchMode.STARTS_WITH -> actual.startsWith(expected)
                 StringMatchMode.ENDS_WITH -> actual.endsWith(expected)
@@ -713,20 +759,52 @@ class QueryPipeline private constructor(
             @Suppress("ReturnCount")
             fun compile(expression: CypherExpr, variable: String): DirectStringFilter? {
                 val stringOp = expression as? CypherExpr.StringOp ?: return null
-                val property = stringOp.left as? CypherExpr.Property ?: return null
+                val operand = compileOperand(stringOp.left) ?: return null
+                val property = operand.property
                 val owner = property.expression as? CypherExpr.Variable ?: return null
                 val literal = stringOp.right as? CypherExpr.Literal ?: return null
                 val expected = literal.value as? String ?: return null
                 if (owner.name != variable) return null
                 if (property.propertyName in QUALIFIED_NODE_PROPERTIES) return null
+                if (operand.coalescesMissingToEmpty && expected.isEmpty()) return null
                 val mode = when (stringOp.op) {
                     "STARTS WITH" -> StringMatchMode.STARTS_WITH
                     "ENDS WITH" -> StringMatchMode.ENDS_WITH
                     "CONTAINS" -> StringMatchMode.CONTAINS
                     else -> return null
                 }
-                return DirectStringFilter(property.propertyName, mode, expected)
+                return DirectStringFilter(property.propertyName, mode, expected, operand.transform)
             }
+
+            @Suppress("ComplexCondition", "ReturnCount")
+            private fun compileOperand(expression: CypherExpr): StringOperand? {
+                if (expression is CypherExpr.Property) return StringOperand(expression)
+                val lower = expression as? CypherExpr.FunctionCall ?: return null
+                if (lower.distinct || lower.args.size != 1 ||
+                    !(lower.name.equals("toLower", ignoreCase = true) ||
+                        lower.name.equals("toLowercase", ignoreCase = true))
+                ) {
+                    return null
+                }
+                val argument = lower.args.single()
+                if (argument is CypherExpr.Property) {
+                    return StringOperand(argument, StringValueTransform.LOWERCASE)
+                }
+                val coalesce = argument as? CypherExpr.FunctionCall ?: return null
+                if (coalesce.distinct || !coalesce.name.equals("coalesce", ignoreCase = true) ||
+                    coalesce.args.size != 2 || coalesce.args[1] != CypherExpr.Literal("")
+                ) {
+                    return null
+                }
+                val property = coalesce.args[0] as? CypherExpr.Property ?: return null
+                return StringOperand(property, StringValueTransform.LOWERCASE, coalescesMissingToEmpty = true)
+            }
+
+            private data class StringOperand(
+                val property: CypherExpr.Property,
+                val transform: StringValueTransform? = null,
+                val coalescesMissingToEmpty: Boolean = false
+            )
         }
     }
 
@@ -1379,16 +1457,33 @@ class QueryPipeline private constructor(
     private fun <T : Node> stringPropertyCandidates(
         graph: Graph,
         type: Class<T>,
-        property: String,
-        mode: StringMatchMode,
-        expected: String,
+        filter: DirectStringFilter,
         limit: Int
     ): Sequence<T>? {
         val tracker = if (workTrackingEnabled) activeWorkTracker.get() else null
-        return if (tracker != null) {
-            graph.nodesByStringProperty(type, property, mode, expected, limit, tracker)
+        return if (filter.transform == null && tracker != null) {
+            graph.nodesByStringProperty(type, filter.property, filter.mode, filter.expected, limit, tracker)
+        } else if (filter.transform == null) {
+            graph.nodesByStringProperty(type, filter.property, filter.mode, filter.expected, limit)
+        } else if (tracker != null) {
+            graph.nodesByTransformedStringProperty(
+                type,
+                filter.property,
+                filter.transform,
+                filter.mode,
+                filter.expected,
+                limit,
+                tracker
+            )
         } else {
-            graph.nodesByStringProperty(type, property, mode, expected, limit)
+            graph.nodesByTransformedStringProperty(
+                type,
+                filter.property,
+                filter.transform,
+                filter.mode,
+                filter.expected,
+                limit
+            )
         }
     }
 

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -21,6 +21,8 @@ import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.graph.StringPropertyLookup
+import io.johnsonlee.graphite.graph.StringValueTransform
+import io.johnsonlee.graphite.graph.TransformedStringPropertyLookup
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -390,6 +392,65 @@ class CrossGraphCypherExecutorTest {
 
         assertEquals(listOf("com.example.ThankYouDynamicOwner"), result.rows.map { it["caller"] })
         assertEquals(listOf("orders"), graphIds(result.rows.single()))
+
+        val wrapped = executor.execute(
+            "MATCH (n) WHERE " +
+                "toLower(coalesce(n.class, '')) CONTAINS 'thankyou' OR " +
+                "toLower(coalesce(n.name, '')) CONTAINS 'thankyou' OR " +
+                "toLower(coalesce(n.caller_class, '')) CONTAINS 'thankyou' OR " +
+                "toLower(coalesce(n.caller_name, '')) CONTAINS 'thankyou' OR " +
+                "toLower(coalesce(n.callee_class, '')) CONTAINS 'thankyou' OR " +
+                "toLower(coalesce(n.callee_name, '')) CONTAINS 'thankyou' " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 10"
+        )
+        assertEquals(listOf("com.example.ThankYouDynamicOwner"), wrapped.rows.map { it["caller"] })
+        assertEquals(listOf("orders"), graphIds(wrapped.rows.single()))
+    }
+
+    @Test
+    fun `wrapped lowercase distinct limit merges provenance across graphs`() {
+        val caller = MethodDescriptor(
+            TypeDescriptor("com.example.VoucherService"),
+            "create",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+        val callee = MethodDescriptor(
+            TypeDescriptor("com.example.Repository"),
+            "load",
+            emptyList(),
+            TypeDescriptor("void")
+        )
+
+        fun indexedGraph(): Graph {
+            val backing = graph(CallSiteNode(NodeId(1), caller, callee, 1, null, emptyList()))
+            return object : Graph by backing, TransformedStringPropertyLookup {
+                override fun <T : Node> nodesByTransformedStringProperty(
+                    type: Class<T>,
+                    property: String,
+                    transform: StringValueTransform,
+                    mode: StringMatchMode,
+                    expected: String,
+                    limit: Int
+                ): Sequence<T> {
+                    assertEquals(StringValueTransform.LOWERCASE, transform)
+                    return backing.nodes(type).filter { node ->
+                        val value = NodePropertyAccessor.getProperty(node, property) as? String
+                        value?.lowercase()?.contains(expected) == true
+                    }.take(limit)
+                }
+            }
+        }
+
+        val result = executor("orders" to indexedGraph(), "billing" to indexedGraph()).execute(
+            "MATCH (n) WHERE " +
+                "toLower(coalesce(n.caller_class, '')) CONTAINS 'voucher' OR " +
+                "toLower(coalesce(n.callee_class, '')) CONTAINS 'voucher' " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 1"
+        )
+
+        assertEquals(listOf("com.example.VoucherService"), result.rows.map { it["caller"] })
+        assertEquals(listOf("billing", "orders"), graphIds(result.rows.single()))
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -643,6 +643,44 @@ class QueryPipelineTest {
     }
 
     @Test
+    fun `ordered string lookup rejects a sequence that violates its monotonic contract`() {
+        val target = MethodDescriptor(TypeDescriptor("com.example.TargetService"), "call", emptyList(), stringType)
+        val callee = MethodDescriptor(TypeDescriptor("com.example.Dependency"), "load", emptyList(), stringType)
+        val backing = DefaultGraph.Builder().apply {
+            addNode(CallSiteNode(NodeId(0), target, callee, 0, null, emptyList()))
+            addNode(CallSiteNode(NodeId(1), target, callee, 1, null, emptyList()))
+        }.build()
+        val lookupGraph = object : Graph by backing, StringPropertyLookup, StringPropertyLookupOrder {
+            override fun <T : Node> nodesByStringProperty(
+                type: Class<T>,
+                property: String,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int
+            ): Sequence<T> {
+                val nodes = backing.nodes(type).associateBy { it.id.value }
+                return if (property == "caller_class") {
+                    sequenceOf(nodes.getValue(1), nodes.getValue(0))
+                } else {
+                    emptySequence()
+                }
+            }
+
+            override fun stringPropertyNodeOrder(node: Node): Long = node.id.value.toLong()
+        }
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            CypherExecutor(lookupGraph).execute(
+                "MATCH (n:CallSiteNode) WHERE " +
+                    "n.caller_class CONTAINS 'Target' OR n.callee_class CONTAINS 'Target' " +
+                    "RETURN DISTINCT n.id AS id LIMIT 4"
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("not monotonic"))
+    }
+
+    @Test
     fun `filtered distinct disjunction keeps unbounded storage lookup semantics`() {
         val unboundedGraph = object : Graph by graph, StringPropertyLookup {
             override fun nodeCount(type: Class<out Node>): Long = Int.MAX_VALUE.toLong()

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -23,10 +23,13 @@ import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.GraphWorkConsumer
 import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.graph.StringPropertyLookup
+import io.johnsonlee.graphite.graph.StringPropertyLookupOrder
 import io.johnsonlee.graphite.graph.StringValueTransform
 import io.johnsonlee.graphite.graph.TransformedStringPropertyLookup
+import io.johnsonlee.graphite.graph.WorkAwareTransformedStringPropertyLookup
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -598,6 +601,48 @@ class QueryPipelineTest {
     }
 
     @Test
+    fun `filtered distinct string disjunction merges lookup streams in graph order`() {
+        val targetCaller = MethodDescriptor(TypeDescriptor("com.example.TargetService"), "call", emptyList(), stringType)
+        val otherCaller = MethodDescriptor(TypeDescriptor("com.example.OtherService"), "call", emptyList(), stringType)
+        val targetCallee = MethodDescriptor(TypeDescriptor("com.example.TargetRepository"), "load", emptyList(), stringType)
+        val backing = DefaultGraph.Builder().apply {
+            addNode(CallSiteNode(NodeId(0), otherCaller, targetCallee, 0, null, emptyList()))
+            addNode(CallSiteNode(NodeId(1), targetCaller, targetCallee, 1, null, emptyList()))
+            addNode(CallSiteNode(NodeId(2), otherCaller, targetCallee, 2, null, emptyList()))
+        }.build()
+        val lookupGraph = object : Graph by backing, StringPropertyLookup, StringPropertyLookupOrder {
+            override fun <T : Node> nodesByStringProperty(
+                type: Class<T>,
+                property: String,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int
+            ): Sequence<T> {
+                val nodes = backing.nodes(type).associateBy { it.id.value }
+                return when (property) {
+                    "caller_class" -> sequenceOf(nodes.getValue(1))
+                    "callee_class" -> sequenceOf(nodes.getValue(2), nodes.getValue(1), nodes.getValue(0))
+                    else -> emptySequence()
+                }
+            }
+
+            override fun stringPropertyNodeOrder(node: Node): Long = when (node.id.value) {
+                2 -> 0
+                1 -> 1
+                else -> 2
+            }
+        }
+
+        val result = CypherExecutor(lookupGraph).execute(
+            "MATCH (n:CallSiteNode) WHERE " +
+                "n.caller_class CONTAINS 'Target' OR n.callee_class CONTAINS 'Target' " +
+                "RETURN DISTINCT n.id AS id LIMIT 4"
+        )
+
+        assertEquals(listOf(2, 1, 0), result.rows.map { it["id"] })
+    }
+
+    @Test
     fun `filtered distinct disjunction keeps unbounded storage lookup semantics`() {
         val unboundedGraph = object : Graph by graph, StringPropertyLookup {
             override fun nodeCount(type: Class<out Node>): Long = Int.MAX_VALUE.toLong()
@@ -685,6 +730,52 @@ class QueryPipelineTest {
         assertEquals(listOf("Com.Example.VoucherService"), result.rows.map { it["caller"] })
         assertTrue(lookups.contains("caller_class" to "voucher"))
         assertTrue(lookups.contains("callee_class" to "voucher"))
+    }
+
+    @Test
+    fun `budgeted wrapped lowercase disjunction accounts for transformed lookup work`() {
+        val caller = MethodDescriptor(TypeDescriptor("Com.Example.VoucherService"), "Create", emptyList(), stringType)
+        val callee = MethodDescriptor(TypeDescriptor("com.example.Repository"), "load", emptyList(), stringType)
+        val backing = DefaultGraph.Builder().apply {
+            addNode(CallSiteNode(NodeId(0), caller, callee, 0, null, emptyList()))
+        }.build()
+        var consumed = 0
+        val lookupGraph = object : Graph by backing, WorkAwareTransformedStringPropertyLookup {
+            override fun <T : Node> nodesByTransformedStringProperty(
+                type: Class<T>,
+                property: String,
+                transform: StringValueTransform,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int
+            ): Sequence<T> = error("budgeted query did not use the work-aware transformed lookup")
+
+            override fun <T : Node> nodesByTransformedStringProperty(
+                type: Class<T>,
+                property: String,
+                transform: StringValueTransform,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int,
+                workConsumer: GraphWorkConsumer
+            ): Sequence<T> = backing.nodes(type).onEach {
+                consumed++
+                workConsumer.consume()
+            }.filter { node ->
+                val actual = NodePropertyAccessor.getProperty(node, property) as? String
+                actual?.lowercase()?.contains(expected) == true
+            }.take(limit)
+        }
+
+        val result = CypherExecutor(lookupGraph, CypherExecutionBudget(maxWorkUnits = 10)).execute(
+            "MATCH (n) WHERE " +
+                "toLower(coalesce(n.caller_class, '')) CONTAINS 'voucher' OR " +
+                "toLower(coalesce(n.callee_class, '')) CONTAINS 'voucher' " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 1"
+        )
+
+        assertEquals(listOf("Com.Example.VoucherService"), result.rows.map { it["caller"] })
+        assertEquals(1, consumed)
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/QueryPipelineTest.kt
@@ -25,6 +25,8 @@ import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.StringMatchMode
 import io.johnsonlee.graphite.graph.StringPropertyLookup
+import io.johnsonlee.graphite.graph.StringValueTransform
+import io.johnsonlee.graphite.graph.TransformedStringPropertyLookup
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -642,6 +644,79 @@ class QueryPipelineTest {
         )
 
         assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `wrapped lowercase disjunction uses transformed lookup with exact semantics`() {
+        val caller = MethodDescriptor(TypeDescriptor("Com.Example.VoucherService"), "Create", emptyList(), stringType)
+        val callee = MethodDescriptor(TypeDescriptor("com.example.Repository"), "load", emptyList(), stringType)
+        val backing = DefaultGraph.Builder().apply {
+            addNode(CallSiteNode(NodeId(0), caller, callee, 0, null, emptyList()))
+        }.build()
+        val lookups = mutableListOf<Pair<String, String>>()
+        val lookupGraph = object : Graph by backing, TransformedStringPropertyLookup {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                error("wrapped lowercase query unexpectedly used a full node scan")
+
+            override fun <T : Node> nodesByTransformedStringProperty(
+                type: Class<T>,
+                property: String,
+                transform: StringValueTransform,
+                mode: StringMatchMode,
+                expected: String,
+                limit: Int
+            ): Sequence<T> {
+                assertEquals(StringValueTransform.LOWERCASE, transform)
+                assertEquals(StringMatchMode.CONTAINS, mode)
+                lookups += property to expected
+                return backing.nodes(type).filter { node ->
+                    val actual = NodePropertyAccessor.getProperty(node, property) as? String
+                    actual?.lowercase()?.contains(expected) == true
+                }.take(limit)
+            }
+        }
+
+        val query = "MATCH (n) WHERE " +
+            "toLower(coalesce(n.caller_class, '')) CONTAINS 'voucher' OR " +
+            "toLowercase(coalesce(n.callee_class, '')) CONTAINS 'voucher' " +
+            "RETURN DISTINCT n.caller_class AS caller LIMIT 250"
+        val result = CypherExecutor(lookupGraph).execute(query)
+
+        assertEquals(listOf("Com.Example.VoucherService"), result.rows.map { it["caller"] })
+        assertTrue(lookups.contains("caller_class" to "voucher"))
+        assertTrue(lookups.contains("callee_class" to "voucher"))
+    }
+
+    @Test
+    fun `wrapped lowercase fast path does not normalize the expected literal`() {
+        val result = CypherExecutor(graph).execute(
+            "MATCH (n:CallSiteNode) " +
+                "WHERE toLower(coalesce(n.caller_class, '')) CONTAINS 'Service' " +
+                "RETURN DISTINCT n.caller_class AS caller LIMIT 1"
+        )
+
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `wrapped lowercase empty needle preserves coalesce missing property semantics`() {
+        val result = CypherExecutor(graph).execute(
+            "MATCH (n) WHERE toLower(coalesce(n.caller_class, '')) CONTAINS '' " +
+                "RETURN DISTINCT n.id AS id LIMIT 2"
+        )
+
+        assertEquals(listOf(intConst42.value, intConst7.value), result.rows.map { it["id"] })
+    }
+
+    @Test
+    fun `wrapped lowercase nonempty coalesce fallback stays on generic evaluator`() {
+        val result = CypherExecutor(graph).execute(
+            "MATCH (n) " +
+                "WHERE toLower(coalesce(n.caller_class, 'FallbackVoucher')) CONTAINS 'voucher' " +
+                "RETURN DISTINCT n.id AS id LIMIT 2"
+        )
+
+        assertEquals(listOf(intConst42.value, intConst7.value), result.rows.map { it["id"] })
     }
 
     // ========================================================================

--- a/graphite-webgraph/build.gradle.kts
+++ b/graphite-webgraph/build.gradle.kts
@@ -85,6 +85,14 @@ val integrationFixtureJvmArgs = providers.provider {
     }
 }
 
+val prepareBenchmarkFixtures by tasks.registering(Sync::class) {
+    description = "Resolves all real-corpus JARs for external benchmark harnesses"
+    group = "benchmark"
+    from(androidIntegrationFixture)
+    from(largeCorpusFixtures)
+    into(layout.buildDirectory.dir("benchmark-fixtures"))
+}
+
 jmh {
     val filter = project.findProperty("jmh.filter") as String?
     if (filter != null) {

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AllFixtureWrappedDiscoveryLatencyBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AllFixtureWrappedDiscoveryLatencyBenchmark.kt
@@ -1,0 +1,311 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.Node
+import io.johnsonlee.graphite.cypher.CrossGraphCypherExecutor
+import io.johnsonlee.graphite.cypher.CypherGraph
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.input.LoaderConfig
+import io.johnsonlee.graphite.sootup.JavaProjectLoader
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.io.Closeable
+import java.lang.reflect.Method
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
+
+/**
+ * Real heterogeneous multi-graph gate for the production wrapped discovery
+ * query. All repository benchmark fixture JARs are represented exactly once.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 1)
+@Measurement(iterations = 3)
+@Fork(1, jvmArgs = ["-Xmx8g"])
+open class AllFixtureWrappedDiscoveryLatencyBenchmark {
+
+    private lateinit var executor: CrossGraphCypherExecutor
+    private val loadedGraphs = mutableListOf<Graph>()
+    private val clearIndexMethods = mutableListOf<Method?>()
+
+    @Setup
+    fun setup() {
+        val graphs = BenchmarkCorpusKind.entries.map { kind ->
+            val graph = GraphStore.loadMapped(BenchmarkCorpus.persistedGraph(kind))
+            check(graph.nodeCount(Node::class.java) == kind.expectedNodeCount)
+            loadedGraphs += graph
+            clearIndexMethods += graph.javaClass.declaredMethods
+                .firstOrNull { it.name.startsWith("clearStringPropertyIndexes") }
+                ?.also { it.isAccessible = true }
+            CypherGraph(kind.id, graph)
+        }
+        check(graphs.sumOf { it.graph.nodeCount(Node::class.java) ?: 0L } == EXPECTED_ALL_FIXTURE_NODES)
+        executor = CrossGraphCypherExecutor(graphs)
+    }
+
+    @TearDown
+    fun tearDown() {
+        loadedGraphs.forEach { (it as? Closeable)?.close() }
+    }
+
+    @Benchmark
+    fun zeroHitBroadContainsCaseInsensitiveDiscovery(): CypherResult = executeCold(ZERO_HIT_QUERY)
+
+    @Benchmark
+    fun denseDistributedMethodContainsCaseInsensitiveDiscovery(): CypherResult =
+        executeCold(DENSE_DISTRIBUTED_METHOD_QUERY)
+
+    @Benchmark
+    fun earlyGraphClassPrefixCaseInsensitiveDiscovery(): CypherResult = executeCold(EARLY_GRAPH_PREFIX_QUERY)
+
+    @Benchmark
+    fun middleGraphsClassPrefixCaseInsensitiveDiscovery(): CypherResult = executeCold(MIDDLE_GRAPHS_PREFIX_QUERY)
+
+    @Benchmark
+    fun lateGraphClassPrefixCaseInsensitiveDiscovery(): CypherResult = executeCold(LATE_GRAPH_PREFIX_QUERY)
+
+    @Benchmark
+    fun broadlyDistributedClassPrefixCaseInsensitiveDiscovery(): CypherResult =
+        executeCold(BROADLY_DISTRIBUTED_PREFIX_QUERY)
+
+    @Benchmark
+    fun firstLastGraphBimodalClassPrefixCaseInsensitiveDiscovery(): CypherResult =
+        executeCold(FIRST_LAST_GRAPH_BIMODAL_QUERY)
+
+    @Benchmark
+    fun skewedMixedClassMethodOperatorCaseInsensitiveDiscovery(): CypherResult =
+        executeCold(SKEWED_MIXED_OPERATOR_QUERY)
+
+    private fun executeCold(query: String): CypherResult {
+        loadedGraphs.indices.forEach { index -> clearIndexMethods[index]?.invoke(loadedGraphs[index]) }
+        return executor.execute(query)
+    }
+}
+
+/**
+ * Builds each eager source graph in sequence and closes it before building the
+ * next one. The resulting persisted graphs can then be shared by every JMH
+ * revision in the same CI job.
+ */
+internal object AllFixtureGraphPreparation {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        require(args.size == 2) { "Usage: AllFixtureGraphPreparation <corpus-id> <output-directory>" }
+        val kind = BenchmarkCorpusKind.entries.single { it.id == args[0] }
+        prepare(kind, Path.of(args[1]).toAbsolutePath().normalize())
+    }
+
+    private fun prepare(kind: BenchmarkCorpusKind, output: Path) {
+        require(Files.notExists(output)) { "Fixture graph output already exists: $output" }
+        val graph = JavaProjectLoader(
+            LoaderConfig(
+                buildCallGraph = false,
+                extractAnnotations = false,
+                trackCrossMethodFunctionalDispatch = false
+            )
+        ).load(BenchmarkCorpus.resolveJar(kind))
+        try {
+            GraphStore.save(graph, output)
+            check(graph.nodes(Node::class.java).count().toLong() == kind.expectedNodeCount)
+        } finally {
+            (graph as? Closeable)?.close()
+        }
+    }
+}
+
+/**
+ * Hashes complete columns, rows, values, and provenance for every timed query.
+ * CI compares these markers across fixed, base, and candidate revisions.
+ */
+internal object AllFixtureQueryCorrectness {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        require(args.size == 1) { "Usage: AllFixtureQueryCorrectness <graph-directory>" }
+        val root = Path.of(args.single()).toAbsolutePath().normalize()
+        val graphs = mutableListOf<Graph>()
+        try {
+            val sources = BenchmarkCorpusKind.entries.map { kind ->
+                GraphStore.loadMapped(root.resolve(kind.id)).also(graphs::add).let { graph ->
+                    check(graph.nodeCount(Node::class.java) == kind.expectedNodeCount)
+                    CypherGraph(kind.id, graph)
+                }
+            }
+            val executor = CrossGraphCypherExecutor(sources)
+            ALL_FIXTURE_QUERIES.forEach { (name, query) ->
+                val result = executor.execute(query)
+                val digest = MessageDigest.getInstance("SHA-256")
+                    .digest(canonical(result.columns to result.rows).toByteArray(Charsets.UTF_8))
+                    .joinToString("") { byte -> "%02x".format(byte) }
+                println("ALL_FIXTURE_QUERY_RESULT\t$name\trows=${result.rows.size}\tsha256=$digest")
+            }
+        } finally {
+            graphs.asReversed().forEach { (it as? Closeable)?.close() }
+        }
+    }
+
+    private fun canonical(value: Any?): String = when (value) {
+        null -> "null"
+        is String -> "string:${value.length}:$value"
+        is Number -> "number:${value::class.java.name}:$value"
+        is Boolean -> "boolean:$value"
+        is Map<*, *> -> value.entries
+            .map { canonical(it.key) to canonical(it.value) }
+            .sortedBy { it.first }
+            .joinToString(prefix = "map:[", postfix = "]") { (key, item) -> "$key=$item" }
+        is Set<*> -> value.map(::canonical).sorted().joinToString(prefix = "set:[", postfix = "]")
+        is Iterable<*> -> value.joinToString(prefix = "list:[", postfix = "]", transform = ::canonical)
+        else -> "object:${value::class.java.name}:${value}"
+    }
+}
+
+/** Prints per-corpus match counts used to pin the distribution cases below. */
+internal object AllFixtureDistributionCalibration {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        require(args.size == 1) { "Usage: AllFixtureDistributionCalibration <graph-directory>" }
+        val root = Path.of(args.single()).toAbsolutePath().normalize()
+        BenchmarkCorpusKind.entries.forEach { kind ->
+            val graph = GraphStore.loadMapped(root.resolve(kind.id))
+            try {
+                val counts = LongArray(6)
+                graph.nodes(io.johnsonlee.graphite.core.CallSiteNode::class.java).forEach { node ->
+                    val classes = listOf(node.caller.declaringClass.className, node.callee.declaringClass.className)
+                    val methods = listOf(node.caller.name, node.callee.name)
+                    if (methods.any { it.lowercase().contains("get") }) counts[0]++
+                    if (classes.any { it.lowercase().startsWith("android.") }) counts[1]++
+                    if (classes.any {
+                            val value = it.lowercase()
+                            value.startsWith("org.apache.tika.") || value.startsWith("org.apache.hadoop.hive.")
+                        }
+                    ) counts[2]++
+                    if (classes.any { it.lowercase().startsWith("org.jetbrains.kotlin.") }) counts[3]++
+                    if (classes.any { it.lowercase().startsWith("java.") }) counts[4]++
+                    if (classes.any { it.lowercase().startsWith("android.") } ||
+                        methods.any { it.lowercase().endsWith("provider") }
+                    ) counts[5]++
+                }
+                val expected = EXPECTED_DISTRIBUTIONS.getValue(kind)
+                check(counts.contentEquals(expected)) {
+                    "Unexpected search-target distribution for ${kind.id}: " +
+                        "actual=${counts.contentToString()}, expected=${expected.contentToString()}"
+                }
+                println("ALL_FIXTURE_DISTRIBUTION\t${kind.id}\t${counts.joinToString("\t")}")
+            } finally {
+                (graph as? Closeable)?.close()
+            }
+        }
+    }
+}
+
+private const val EXPECTED_ALL_FIXTURE_NODES = 19_091_048L
+
+private const val ZERO_HIT_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) CONTAINS 'graphite_latency_no_such_symbol_9f36'
+   OR toLower(coalesce(n.caller_name, '')) CONTAINS 'graphite_latency_no_such_symbol_9f36'
+   OR toLower(coalesce(n.callee_class, '')) CONTAINS 'graphite_latency_no_such_symbol_9f36'
+   OR toLower(coalesce(n.callee_name, '')) CONTAINS 'graphite_latency_no_such_symbol_9f36'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 250
+"""
+
+private const val DENSE_DISTRIBUTED_METHOD_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_name, '')) CONTAINS 'get'
+   OR toLower(coalesce(n.callee_name, '')) CONTAINS 'get'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 50
+"""
+
+private const val EARLY_GRAPH_PREFIX_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) STARTS WITH 'android.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'android.'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 1
+"""
+
+private const val MIDDLE_GRAPHS_PREFIX_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) STARTS WITH 'org.apache.tika.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'org.apache.tika.'
+   OR toLower(coalesce(n.caller_class, '')) STARTS WITH 'org.apache.hadoop.hive.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'org.apache.hadoop.hive.'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 250
+"""
+
+private const val LATE_GRAPH_PREFIX_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) STARTS WITH 'org.jetbrains.kotlin.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'org.jetbrains.kotlin.'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 50
+"""
+
+private const val BROADLY_DISTRIBUTED_PREFIX_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) STARTS WITH 'java.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'java.'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 250
+"""
+
+private const val FIRST_LAST_GRAPH_BIMODAL_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) STARTS WITH 'android.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'android.'
+   OR toLower(coalesce(n.caller_class, '')) STARTS WITH 'org.jetbrains.kotlin.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'org.jetbrains.kotlin.'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 250
+"""
+
+private const val SKEWED_MIXED_OPERATOR_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) STARTS WITH 'android.'
+   OR toLower(coalesce(n.callee_class, '')) STARTS WITH 'android.'
+   OR toLower(coalesce(n.caller_name, '')) ENDS WITH 'provider'
+   OR toLower(coalesce(n.callee_name, '')) ENDS WITH 'provider'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 250
+"""
+
+private val EXPECTED_DISTRIBUTIONS = mapOf(
+    BenchmarkCorpusKind.ANDROID to longArrayOf(381_772, 1_089_434, 0, 0, 541_691, 1_090_613),
+    BenchmarkCorpusKind.TIKA to longArrayOf(307_444, 0, 43_006, 0, 308_626, 874),
+    BenchmarkCorpusKind.HIVE to longArrayOf(380_549, 0, 790_274, 0, 444_906, 602),
+    BenchmarkCorpusKind.KOTLIN_COMPILER to longArrayOf(265_980, 0, 0, 891_500, 208_763, 1_509)
+)
+
+private val ALL_FIXTURE_QUERIES = listOf(
+    "zeroHitBroadContains" to ZERO_HIT_QUERY,
+    "denseDistributedMethodContains" to DENSE_DISTRIBUTED_METHOD_QUERY,
+    "earlyGraphClassPrefix" to EARLY_GRAPH_PREFIX_QUERY,
+    "middleGraphsClassPrefix" to MIDDLE_GRAPHS_PREFIX_QUERY,
+    "lateGraphClassPrefix" to LATE_GRAPH_PREFIX_QUERY,
+    "broadlyDistributedClassPrefix" to BROADLY_DISTRIBUTED_PREFIX_QUERY,
+    "firstLastGraphBimodalClassPrefix" to FIRST_LAST_GRAPH_BIMODAL_QUERY,
+    "skewedMixedClassMethodOperator" to SKEWED_MIXED_OPERATOR_QUERY
+)

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AllFixtureWrappedDiscoveryLatencyBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AllFixtureWrappedDiscoveryLatencyBenchmark.kt
@@ -100,10 +100,10 @@ open class AllFixtureWrappedDiscoveryLatencyBenchmark {
  * next one. The resulting persisted graphs can then be shared by every JMH
  * revision in the same CI job.
  */
-internal object AllFixtureGraphPreparation {
+internal object AllFixtureBenchmarkGraphPreparation {
     @JvmStatic
     fun main(args: Array<String>) {
-        require(args.size == 2) { "Usage: AllFixtureGraphPreparation <corpus-id> <output-directory>" }
+        require(args.size == 2) { "Usage: AllFixtureBenchmarkGraphPreparation <corpus-id> <output-directory>" }
         val kind = BenchmarkCorpusKind.entries.single { it.id == args[0] }
         prepare(kind, Path.of(args[1]).toAbsolutePath().normalize())
     }
@@ -130,10 +130,10 @@ internal object AllFixtureGraphPreparation {
  * Hashes complete columns, rows, values, and provenance for every timed query.
  * CI compares these markers across fixed, base, and candidate revisions.
  */
-internal object AllFixtureQueryCorrectness {
+internal object AllFixtureBenchmarkQueryCorrectness {
     @JvmStatic
     fun main(args: Array<String>) {
-        require(args.size == 1) { "Usage: AllFixtureQueryCorrectness <graph-directory>" }
+        require(args.size == 1) { "Usage: AllFixtureBenchmarkQueryCorrectness <graph-directory>" }
         val root = Path.of(args.single()).toAbsolutePath().normalize()
         val graphs = mutableListOf<Graph>()
         try {
@@ -172,10 +172,10 @@ internal object AllFixtureQueryCorrectness {
 }
 
 /** Prints per-corpus match counts used to pin the distribution cases below. */
-internal object AllFixtureDistributionCalibration {
+internal object AllFixtureBenchmarkDistributionCalibration {
     @JvmStatic
     fun main(args: Array<String>) {
-        require(args.size == 1) { "Usage: AllFixtureDistributionCalibration <graph-directory>" }
+        require(args.size == 1) { "Usage: AllFixtureBenchmarkDistributionCalibration <graph-directory>" }
         val root = Path.of(args.single()).toAbsolutePath().normalize()
         BenchmarkCorpusKind.entries.forEach { kind ->
             val graph = GraphStore.loadMapped(root.resolve(kind.id))

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidWrappedDiscoveryBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/AndroidWrappedDiscoveryBenchmark.kt
@@ -1,0 +1,65 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.cypher.CrossGraphCypherExecutor
+import io.johnsonlee.graphite.cypher.CypherGraph
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.graph.Graph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+/** Manual benchmark for the exact 1/17-source Android production query. */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+@Fork(1, jvmArgs = ["-Xmx8g"])
+open class AndroidWrappedDiscoveryBenchmark {
+
+    @Param("1", "17")
+    @JvmField
+    var graphCount: Int = 1
+
+    private lateinit var mappedGraph: Graph
+    private lateinit var executor: CrossGraphCypherExecutor
+
+    @Setup
+    fun setup() {
+        mappedGraph = GraphStore.loadMapped(BenchmarkCorpus.persistedGraph(BenchmarkCorpusKind.ANDROID))
+        check(mappedGraph.nodeCount(io.johnsonlee.graphite.core.Node::class.java) ==
+            BenchmarkCorpusKind.ANDROID.expectedNodeCount)
+        executor = CrossGraphCypherExecutor(
+            (0 until graphCount).map { CypherGraph("android-$it", mappedGraph) }
+        )
+    }
+
+    @TearDown
+    fun tearDown() {
+        (mappedGraph as? Closeable)?.close()
+    }
+
+    @Benchmark
+    fun wrappedCaseInsensitiveDiscovery(): CypherResult = executor.execute(ANDROID_WRAPPED_DISCOVERY_QUERY)
+}
+
+private const val ANDROID_WRAPPED_DISCOVERY_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) CONTAINS 'voucher'
+   OR toLower(coalesce(n.caller_name, '')) CONTAINS 'voucher'
+   OR toLower(coalesce(n.callee_class, '')) CONTAINS 'voucher'
+   OR toLower(coalesce(n.callee_name, '')) CONTAINS 'voucher'
+RETURN DISTINCT n.graph_id, n.caller_class, n.caller_name, n.callee_class, n.callee_name
+LIMIT 250
+"""

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/MappedStringAdmissionBenchmark.kt
@@ -9,6 +9,9 @@ import io.johnsonlee.graphite.core.TypeDescriptor
 import io.johnsonlee.graphite.cypher.CypherExecutor
 import io.johnsonlee.graphite.cypher.CypherResult
 import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.GraphWorkConsumer
+import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.StringValueTransform
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
@@ -43,6 +46,9 @@ open class MappedStringAdmissionBenchmark {
 
     @Benchmark
     fun earlyHitAfterLargeLimitScan(state: LargeLimitBenchmarkState): CypherResult = state.earlyHitWithoutIndexBuild()
+
+    @Benchmark
+    fun budgetedTransformedZeroHit(state: BudgetedTransformedScanBenchmarkState): Int = state.zeroHit()
 }
 
 @State(Scope.Thread)
@@ -80,6 +86,14 @@ open class LargeLimitBenchmarkState : MappedStringAdmissionBenchmarkState() {
 }
 
 @State(Scope.Thread)
+open class BudgetedTransformedScanBenchmarkState : MappedStringAdmissionBenchmarkState() {
+    @Setup(Level.Invocation)
+    fun resetMatchState() = clearIndexes()
+
+    fun zeroHit(): Int = budgetedTransformedZeroHit()
+}
+
+@State(Scope.Thread)
 open class MappedStringAdmissionBenchmarkState {
     private lateinit var root: Path
     private lateinit var mapped: MappedWebGraphBackedGraph
@@ -89,7 +103,7 @@ open class MappedStringAdmissionBenchmarkState {
     fun setupGraph() {
         val graph = DefaultGraph.Builder().apply {
             repeat(ADMISSION_RESOURCE_NODES) { index ->
-                addNode(ResourceFileNode(NodeId(index), "path-$index", "source-$index", "format-$index"))
+                addNode(ResourceFileNode(NodeId(index), "path-$index", "source-${index % 100}", "format-$index"))
             }
             repeat(ADMISSION_FIELD_NODES) { index ->
                 addNode(
@@ -123,6 +137,22 @@ open class MappedStringAdmissionBenchmarkState {
     protected fun clearIndexes() = mapped.clearStringPropertyIndexes()
 
     protected fun execute(query: String): CypherResult = executor.execute(query)
+
+    protected fun budgetedTransformedZeroHit(): Int {
+        var inspected = 0
+        val matches = mapped.nodesByTransformedStringProperty(
+            ResourceFileNode::class.java,
+            "source",
+            StringValueTransform.LOWERCASE,
+            StringMatchMode.CONTAINS,
+            "absent",
+            limit = 1,
+            workConsumer = GraphWorkConsumer { inspected++ }
+        ).orEmpty().count()
+        check(matches == 0)
+        check(inspected == ADMISSION_RESOURCE_NODES)
+        return inspected
+    }
 
     protected fun indexCount(type: Class<out Node>? = null, property: String? = null): Int =
         mapped.stringPropertyIndexCount(type, property)

--- a/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/WrappedDiscoveryLatencyBenchmark.kt
+++ b/graphite-webgraph/src/jmh/kotlin/io/johnsonlee/graphite/webgraph/WrappedDiscoveryLatencyBenchmark.kt
@@ -1,0 +1,137 @@
+package io.johnsonlee.graphite.webgraph
+
+import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.core.MethodDescriptor
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.core.StringConstant
+import io.johnsonlee.graphite.core.TypeDescriptor
+import io.johnsonlee.graphite.cypher.CrossGraphCypherExecutor
+import io.johnsonlee.graphite.cypher.CypherGraph
+import io.johnsonlee.graphite.cypher.CypherResult
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.Graph
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import java.io.Closeable
+import java.lang.reflect.Method
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+private const val WRAPPED_DISCOVERY_STRINGS_PER_GRAPH = 5_000
+private const val WRAPPED_DISCOVERY_CALL_SITES_PER_GRAPH = 2_000
+private const val WRAPPED_DISCOVERY_HIT_INTERVAL = 1_000
+
+/**
+ * Stable persisted-graph gate for the production query shape that regressed to
+ * roughly one complete scan per graph. The same source is compiled at the
+ * fixed pre-PR-95 baseline and at the candidate revision in CI.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 4, time = 1)
+@Fork(1, jvmArgs = ["-Xmx4g"])
+open class WrappedDiscoveryLatencyBenchmark {
+
+    @Param("1", "17")
+    @JvmField
+    var graphCount: Int = 1
+
+    private lateinit var root: Path
+    private lateinit var executor: CrossGraphCypherExecutor
+    private val loadedGraphs = mutableListOf<Graph>()
+    private val clearIndexMethods = mutableListOf<Method?>()
+
+    @Setup
+    fun setup() {
+        root = Files.createTempDirectory("graphite-wrapped-discovery")
+        val graphs = (0 until graphCount).map { graphIndex ->
+            val builder = DefaultGraph.Builder()
+            repeat(WRAPPED_DISCOVERY_STRINGS_PER_GRAPH) { nodeIndex ->
+                builder.addNode(StringConstant(NodeId(nodeIndex), "symbol_${graphIndex}_$nodeIndex"))
+            }
+            repeat(WRAPPED_DISCOVERY_CALL_SITES_PER_GRAPH) { callSiteIndex ->
+                val marker = if (callSiteIndex % WRAPPED_DISCOVERY_HIT_INTERVAL == 0) "VoUcHeR" else "Feature"
+                val caller = MethodDescriptor(
+                    TypeDescriptor("com.example.${marker}${graphIndex}Service$callSiteIndex"),
+                    "create$callSiteIndex",
+                    emptyList(),
+                    TypeDescriptor("void")
+                )
+                val callee = MethodDescriptor(
+                    TypeDescriptor("com.example.Dependency${callSiteIndex % 20}"),
+                    "invoke${callSiteIndex % 100}",
+                    emptyList(),
+                    TypeDescriptor("void")
+                )
+                builder.addNode(
+                    CallSiteNode(
+                        NodeId(WRAPPED_DISCOVERY_STRINGS_PER_GRAPH + callSiteIndex),
+                        caller,
+                        callee,
+                        callSiteIndex,
+                        null,
+                        emptyList()
+                    )
+                )
+            }
+
+            val graphDir = root.resolve("graph-$graphIndex")
+            GraphStore.save(builder.build(), graphDir)
+            val graph = GraphStore.loadMapped(graphDir)
+            loadedGraphs += graph
+            clearIndexMethods += graph.javaClass.declaredMethods
+                .firstOrNull { it.name.startsWith("clearStringPropertyIndexes") }
+                ?.also { it.isAccessible = true }
+            CypherGraph("graph-$graphIndex", graph)
+        }
+        executor = CrossGraphCypherExecutor(graphs)
+
+        val result = executor.execute(WRAPPED_DISCOVERY_QUERY)
+        check(result.rows.size == graphCount * EXPECTED_HITS_PER_GRAPH)
+        check(result.rows.all { (it["caller"] as? String)?.lowercase()?.contains("voucher") == true })
+    }
+
+    @TearDown
+    fun tearDown() {
+        loadedGraphs.forEach { (it as? Closeable)?.close() }
+        root.toFile().deleteRecursively()
+    }
+
+    @Benchmark
+    fun wrappedCaseInsensitiveDiscovery(): CypherResult = executor.execute(WRAPPED_DISCOVERY_QUERY)
+
+    @Benchmark
+    fun coldWrappedCaseInsensitiveDiscovery(): CypherResult {
+        loadedGraphs.indices.forEach { index -> clearIndexMethods[index]?.invoke(loadedGraphs[index]) }
+        return executor.execute(WRAPPED_DISCOVERY_QUERY)
+    }
+
+    private companion object {
+        const val EXPECTED_HITS_PER_GRAPH =
+            WRAPPED_DISCOVERY_CALL_SITES_PER_GRAPH / WRAPPED_DISCOVERY_HIT_INTERVAL
+    }
+}
+
+private const val WRAPPED_DISCOVERY_QUERY = """
+MATCH (n)
+WHERE toLower(coalesce(n.caller_class, '')) CONTAINS 'voucher'
+   OR toLower(coalesce(n.caller_name, '')) CONTAINS 'voucher'
+   OR toLower(coalesce(n.callee_class, '')) CONTAINS 'voucher'
+   OR toLower(coalesce(n.callee_name, '')) CONTAINS 'voucher'
+RETURN DISTINCT n.graph_id, n.caller_class AS caller, n.caller_name AS callerMethod,
+    n.callee_class AS callee, n.callee_name AS calleeMethod
+LIMIT 250
+"""

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -102,8 +102,7 @@ internal class MappedWebGraphBackedGraph(
 
     private val stringPropertyIndexLock = Any()
     private val stringPropertyAdmissions = StringPropertyAdmissions()
-    @Volatile
-    private var stringPropertyNodeOrders: IntArray? = null
+    private val rawStringMatchStates = RawStringMatchStates()
     private val stringPropertyIndexes = object : LinkedHashMap<StringPropertyKey, MappedStringPropertyIndex>(
         MAX_STRING_PROPERTY_INDEXES + 1,
         STRING_PROPERTY_INDEX_LOAD_FACTOR,
@@ -134,19 +133,7 @@ internal class MappedWebGraphBackedGraph(
     override fun nodeCount(type: Class<out Node>): Long =
         nodeTypeIndex.count(type)
 
-    override fun stringPropertyNodeOrder(node: Node): Long {
-        val orders = stringPropertyNodeOrders ?: synchronized(this) {
-            stringPropertyNodeOrders ?: buildStringPropertyNodeOrders().also { stringPropertyNodeOrders = it }
-        }
-        return orders.getOrElse(node.id.value) { -1 }.toLong()
-    }
-
-    private fun buildStringPropertyNodeOrders(): IntArray {
-        val orders = IntArray(nodeOffsets.size) { -1 }
-        var order = 0
-        for (nodeId in nodeTypeIndex.ids(Node::class.java)) orders[nodeId] = order++
-        return orders
-    }
+    override fun stringPropertyNodeOrder(node: Node): Long = nodeOffsets.offset(node.id.value)
 
     @Suppress("UNCHECKED_CAST", "ReturnCount")
     override fun <T : Node> nodesByStringProperty(
@@ -271,9 +258,11 @@ internal class MappedWebGraphBackedGraph(
                     }
                 }
                 admitted = true
-                val stringCount = stringTable.size()
-                if (stringCount <= MAX_RAW_STRING_MATCH_STATE_BYTES) {
-                    matchStates = ByteArray(stringCount)
+                if (workConsumer == null) {
+                    matchStates = rawStringMatchStates.stateFor(
+                        RawStringMatchKey(admission.property, transform, mode, expected),
+                        stringTable.size()
+                    )
                 }
             }
             val stringId = rawStringPropertyIndex(nodeId, type, property)
@@ -398,7 +387,6 @@ internal class MappedWebGraphBackedGraph(
 
     override fun close() {
         clearStringPropertyIndexes()
-        stringPropertyNodeOrders = null
         // MappedByteBuffer is unmapped by GC; no explicit unmap in standard API
     }
 
@@ -406,8 +394,13 @@ internal class MappedWebGraphBackedGraph(
         synchronized(stringPropertyIndexLock) {
             stringPropertyIndexes.clear()
             stringPropertyAdmissions.clear()
+            rawStringMatchStates.clear()
         }
     }
+
+    internal fun rawStringMatchStateBytes(): Long = rawStringMatchStates.retainedBytes()
+
+    internal fun rawStringMatchStateCount(): Int = rawStringMatchStates.size()
 
     internal fun stringPropertyIndexCount(
         type: Class<out Node>? = null,
@@ -523,6 +516,7 @@ private const val MAX_STRING_PROPERTY_ADMISSION_BYTES = 64L * 1024
 private const val STRING_PROPERTY_ADMISSION_ESTIMATED_BYTES = 96L
 private const val MAX_STRING_PROPERTY_INDEX_RETAINED_BYTES = 8L * 1024 * 1024
 private const val MAX_RAW_STRING_MATCH_STATE_BYTES = 16 * 1024 * 1024
+private const val MAX_RAW_STRING_MATCH_STATES = 32
 private const val STRING_PROPERTY_INDEX_ARRAYS = 3
 private const val PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES = 16L
 private const val MAX_STRING_MATCH_CACHE_ENTRIES = 32
@@ -544,7 +538,7 @@ private fun estimatedStringPropertyIndexBytes(nodeCount: Long): Long =
     STRING_PROPERTY_INDEX_ARRAYS * PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES +
         nodeCount * STRING_PROPERTY_INDEX_ARRAYS * Int.SIZE_BYTES
 
-private data class StringPropertyKey(
+internal data class StringPropertyKey(
     val type: Class<out Node>,
     val property: String
 )
@@ -556,6 +550,48 @@ private data class StringPropertyAdmissionKey(
     val expected: String,
     val limit: Int
 )
+
+internal data class RawStringMatchKey(
+    val property: StringPropertyKey,
+    val transform: StringValueTransform?,
+    val mode: StringMatchMode,
+    val expected: String
+)
+
+/** Shares predicate state across iterators and enforces one aggregate retained-memory bound per graph. */
+internal class RawStringMatchStates(
+    private val maxRetainedBytes: Long = MAX_RAW_STRING_MATCH_STATE_BYTES.toLong(),
+    private val maxEntries: Int = MAX_RAW_STRING_MATCH_STATES
+) {
+    private val states = LinkedHashMap<RawStringMatchKey, ByteArray>()
+    private var bytes = 0L
+
+    @Synchronized
+    fun stateFor(key: RawStringMatchKey, stringCount: Int): ByteArray? {
+        val existing = states[key]
+        val requiredBytes = PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES + stringCount.toLong()
+        return when {
+            existing != null -> existing
+            states.size >= maxEntries || requiredBytes > maxRetainedBytes - bytes -> null
+            else -> ByteArray(stringCount).also { state ->
+                states[key] = state
+                bytes += requiredBytes
+            }
+        }
+    }
+
+    @Synchronized
+    fun clear() {
+        states.clear()
+        bytes = 0L
+    }
+
+    @Synchronized
+    fun retainedBytes(): Long = bytes
+
+    @Synchronized
+    fun size(): Int = states.size
+}
 
 private class StringPropertyAdmissions {
     private val predicates = LinkedHashMap<StringPropertyAdmissionKey, Unit>(

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -17,7 +17,10 @@ import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.GraphWorkConsumer
 import io.johnsonlee.graphite.graph.MethodPattern
+import io.johnsonlee.graphite.graph.StringPropertyLookupOrder
 import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.StringValueTransform
+import io.johnsonlee.graphite.graph.WorkAwareTransformedStringPropertyLookup
 import io.johnsonlee.graphite.graph.WorkAwareStringPropertyLookup
 import io.johnsonlee.graphite.input.ResourceAccessor
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
@@ -76,7 +79,11 @@ internal class MappedWebGraphBackedGraph(
     private val metadata: Lazy<GraphMetadata>,
     private val classOverviewProvider: (Int) -> ClassOverview?,
     private val resourceAccessor: Lazy<ResourceAccessor>
-) : Graph, WorkAwareStringPropertyLookup, Closeable {
+) : Graph,
+    WorkAwareStringPropertyLookup,
+    WorkAwareTransformedStringPropertyLookup,
+    StringPropertyLookupOrder,
+    Closeable {
 
     override val resources: ResourceAccessor
         get() = resourceAccessor.value
@@ -95,6 +102,8 @@ internal class MappedWebGraphBackedGraph(
 
     private val stringPropertyIndexLock = Any()
     private val stringPropertyAdmissions = StringPropertyAdmissions()
+    @Volatile
+    private var stringPropertyNodeOrders: IntArray? = null
     private val stringPropertyIndexes = object : LinkedHashMap<StringPropertyKey, MappedStringPropertyIndex>(
         MAX_STRING_PROPERTY_INDEXES + 1,
         STRING_PROPERTY_INDEX_LOAD_FACTOR,
@@ -125,6 +134,20 @@ internal class MappedWebGraphBackedGraph(
     override fun nodeCount(type: Class<out Node>): Long =
         nodeTypeIndex.count(type)
 
+    override fun stringPropertyNodeOrder(node: Node): Long {
+        val orders = stringPropertyNodeOrders ?: synchronized(this) {
+            stringPropertyNodeOrders ?: buildStringPropertyNodeOrders().also { stringPropertyNodeOrders = it }
+        }
+        return orders.getOrElse(node.id.value) { -1 }.toLong()
+    }
+
+    private fun buildStringPropertyNodeOrders(): IntArray {
+        val orders = IntArray(nodeOffsets.size) { -1 }
+        var order = 0
+        for (nodeId in nodeTypeIndex.ids(Node::class.java)) orders[nodeId] = order++
+        return orders
+    }
+
     @Suppress("UNCHECKED_CAST", "ReturnCount")
     override fun <T : Node> nodesByStringProperty(
         type: Class<T>,
@@ -132,7 +155,7 @@ internal class MappedWebGraphBackedGraph(
         mode: StringMatchMode,
         expected: String,
         limit: Int
-    ): Sequence<T>? = lookupStringProperty(type, property, mode, expected, limit, workConsumer = null)
+    ): Sequence<T>? = lookupStringProperty(type, property, null, mode, expected, limit, workConsumer = null)
 
     override fun <T : Node> nodesByStringProperty(
         type: Class<T>,
@@ -141,12 +164,32 @@ internal class MappedWebGraphBackedGraph(
         expected: String,
         limit: Int,
         workConsumer: GraphWorkConsumer
-    ): Sequence<T>? = lookupStringProperty(type, property, mode, expected, limit, workConsumer)
+    ): Sequence<T>? = lookupStringProperty(type, property, null, mode, expected, limit, workConsumer)
+
+    override fun <T : Node> nodesByTransformedStringProperty(
+        type: Class<T>,
+        property: String,
+        transform: StringValueTransform,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int
+    ): Sequence<T>? = lookupStringProperty(type, property, transform, mode, expected, limit, workConsumer = null)
+
+    override fun <T : Node> nodesByTransformedStringProperty(
+        type: Class<T>,
+        property: String,
+        transform: StringValueTransform,
+        mode: StringMatchMode,
+        expected: String,
+        limit: Int,
+        workConsumer: GraphWorkConsumer
+    ): Sequence<T>? = lookupStringProperty(type, property, transform, mode, expected, limit, workConsumer)
 
     @Suppress("UNCHECKED_CAST", "ReturnCount")
     private fun <T : Node> lookupStringProperty(
         type: Class<T>,
         property: String,
+        transform: StringValueTransform?,
         mode: StringMatchMode,
         expected: String,
         limit: Int,
@@ -158,10 +201,10 @@ internal class MappedWebGraphBackedGraph(
         synchronized(stringPropertyIndexLock) {
             stringPropertyIndexes[key]
         }?.let { index ->
-            return indexedNodes(index, mode, expected, limit, workConsumer)
+            return indexedNodes(index, transform, mode, expected, limit, workConsumer)
         }
 
-        val admission = StringPropertyAdmissionKey(key, mode, expected, limit)
+        val admission = StringPropertyAdmissionKey(key, transform, mode, expected, limit)
         val shouldBuild = synchronized(stringPropertyIndexLock) {
             stringPropertyAdmissions.shouldBuild(admission, limit == Int.MAX_VALUE)
         }
@@ -169,7 +212,7 @@ internal class MappedWebGraphBackedGraph(
             return if (limit == Int.MAX_VALUE) {
                 null
             } else {
-                rawStringPropertyScan(type, property, mode, expected, limit, admission, workConsumer)
+                rawStringPropertyScan(type, property, transform, mode, expected, limit, admission, workConsumer)
             }
         }
 
@@ -186,19 +229,20 @@ internal class MappedWebGraphBackedGraph(
         } ?: return if (limit == Int.MAX_VALUE) {
             null
         } else {
-            rawStringPropertyScan(type, property, mode, expected, limit, admission, workConsumer)
+            rawStringPropertyScan(type, property, transform, mode, expected, limit, admission, workConsumer)
         }
-        return indexedNodes(index, mode, expected, limit, workConsumer)
+        return indexedNodes(index, transform, mode, expected, limit, workConsumer)
     }
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : Node> indexedNodes(
         index: MappedStringPropertyIndex,
+        transform: StringValueTransform?,
         mode: StringMatchMode,
         expected: String,
         limit: Int,
         workConsumer: GraphWorkConsumer?
-    ): Sequence<T> = index.matchingNodeIds(mode, expected, workConsumer)
+    ): Sequence<T> = index.matchingNodeIds(transform, mode, expected, workConsumer)
         .take(limit)
         .mapNotNull { node(NodeId(it)) as? T }
 
@@ -206,6 +250,7 @@ internal class MappedWebGraphBackedGraph(
     private fun <T : Node> rawStringPropertyScan(
         type: Class<T>,
         property: String,
+        transform: StringValueTransform?,
         mode: StringMatchMode,
         expected: String,
         limit: Int,
@@ -215,6 +260,7 @@ internal class MappedWebGraphBackedGraph(
         var inspected = 0
         var yielded = 0
         var admitted = false
+        var matchStates: ByteArray? = null
         for (nodeId in nodeTypeIndex.ids(type)) {
             workConsumer?.consume()
             inspected++
@@ -225,9 +271,27 @@ internal class MappedWebGraphBackedGraph(
                     }
                 }
                 admitted = true
+                val stringCount = stringTable.size()
+                if (stringCount <= MAX_RAW_STRING_MATCH_STATE_BYTES) {
+                    matchStates = ByteArray(stringCount)
+                }
             }
             val stringId = rawStringPropertyIndex(nodeId, type, property)
-            if (stringId != null && stringMatches(stringTable.get(stringId), mode, expected)) {
+            val states = matchStates
+            val matches = if (stringId == null) {
+                false
+            } else if (states == null) {
+                stringMatches(stringTable.get(stringId), transform, mode, expected)
+            } else {
+                when (states[stringId]) {
+                    RAW_STRING_MATCH -> true
+                    RAW_STRING_MISS -> false
+                    else -> stringMatches(stringTable.get(stringId), transform, mode, expected).also { matched ->
+                        states[stringId] = if (matched) RAW_STRING_MATCH else RAW_STRING_MISS
+                    }
+                }
+            }
+            if (matches) {
                 val matchedNode = node(NodeId(nodeId)) as? T
                 if (matchedNode != null) {
                     yield(matchedNode)
@@ -334,6 +398,7 @@ internal class MappedWebGraphBackedGraph(
 
     override fun close() {
         clearStringPropertyIndexes()
+        stringPropertyNodeOrders = null
         // MappedByteBuffer is unmapped by GC; no explicit unmap in standard API
     }
 
@@ -457,6 +522,7 @@ private const val MAX_STRING_PROPERTY_ADMISSIONS = 32
 private const val MAX_STRING_PROPERTY_ADMISSION_BYTES = 64L * 1024
 private const val STRING_PROPERTY_ADMISSION_ESTIMATED_BYTES = 96L
 private const val MAX_STRING_PROPERTY_INDEX_RETAINED_BYTES = 8L * 1024 * 1024
+private const val MAX_RAW_STRING_MATCH_STATE_BYTES = 16 * 1024 * 1024
 private const val STRING_PROPERTY_INDEX_ARRAYS = 3
 private const val PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES = 16L
 private const val MAX_STRING_MATCH_CACHE_ENTRIES = 32
@@ -471,6 +537,8 @@ private const val TRIGRAM_POSTING_ESTIMATED_BYTES = 12L
 private const val MIN_TRIGRAM_LENGTH = 3
 private const val STRING_PROPERTY_INDEX_LOAD_FACTOR = 0.75f
 private const val STRING_HASH_FACTOR = 31
+private const val RAW_STRING_MISS: Byte = 1
+private const val RAW_STRING_MATCH: Byte = 2
 
 private fun estimatedStringPropertyIndexBytes(nodeCount: Long): Long =
     STRING_PROPERTY_INDEX_ARRAYS * PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES +
@@ -483,6 +551,7 @@ private data class StringPropertyKey(
 
 private data class StringPropertyAdmissionKey(
     val property: StringPropertyKey,
+    val transform: StringValueTransform?,
     val mode: StringMatchMode,
     val expected: String,
     val limit: Int
@@ -549,6 +618,7 @@ private class StringPropertyAdmissions {
 }
 
 private data class StringMatchKey(
+    val transform: StringValueTransform?,
     val mode: StringMatchMode,
     val expected: String
 )
@@ -575,36 +645,40 @@ internal class MappedStringPropertyIndex(
     fun matchingNodeIds(
         mode: StringMatchMode,
         expected: String
-    ): Sequence<Int> = matchingNodeIds(mode, expected, workConsumer = null)
+    ): Sequence<Int> = matchingNodeIds(null, mode, expected, workConsumer = null)
 
     fun matchingNodeIds(
+        transform: StringValueTransform?,
         mode: StringMatchMode,
         expected: String,
         workConsumer: GraphWorkConsumer?
     ): Sequence<Int> {
-        val matchedStrings = matchingStringIds(mode, expected, workConsumer)
+        val matchedStrings = matchingStringIds(transform, mode, expected, workConsumer)
         if (matchedStrings.isEmpty()) return emptySequence()
-        return nodeIds.indices.asSequence()
-            .filter {
+        return sequence {
+            for (index in nodeIds.indices) {
                 workConsumer?.consume()
-                java.util.Arrays.binarySearch(matchedStrings, stringIds[it]) >= 0
+                if (java.util.Arrays.binarySearch(matchedStrings, stringIds[index]) >= 0) {
+                    yield(nodeIds[index])
+                }
             }
-            .map { nodeIds[it] }
+        }
     }
 
     @Synchronized
     private fun matchingStringIds(
+        transform: StringValueTransform?,
         mode: StringMatchMode,
         expected: String,
         workConsumer: GraphWorkConsumer?
     ): IntArray {
-        val key = StringMatchKey(mode, expected)
+        val key = StringMatchKey(transform, mode, expected)
         matchingStrings[key]?.let { return it }
 
         val result = when {
-            mode == StringMatchMode.CONTAINS && expected.length >= MIN_TRIGRAM_LENGTH ->
+            transform == null && mode == StringMatchMode.CONTAINS && expected.length >= MIN_TRIGRAM_LENGTH ->
                 matchingContainsStringIds(expected, workConsumer)
-            else -> scanMatchingStringIds(mode, expected, workConsumer)
+            else -> scanMatchingStringIds(transform, mode, expected, workConsumer)
         }
         cacheMatchingStrings(key, result)
         return result
@@ -634,7 +708,7 @@ internal class MappedStringPropertyIndex(
         workConsumer: GraphWorkConsumer?
     ): IntArray {
         val index = getTrigramIndex(workConsumer)
-            ?: return scanMatchingStringIds(StringMatchMode.CONTAINS, expected, workConsumer)
+            ?: return scanMatchingStringIds(null, StringMatchMode.CONTAINS, expected, workConsumer)
         var candidates: IntArray? = null
         val seenTrigrams = IntOpenHashSet()
         for (position in 0..expected.length - MIN_TRIGRAM_LENGTH) {
@@ -655,6 +729,7 @@ internal class MappedStringPropertyIndex(
     }
 
     private fun scanMatchingStringIds(
+        transform: StringValueTransform?,
         mode: StringMatchMode,
         expected: String,
         workConsumer: GraphWorkConsumer?
@@ -663,7 +738,7 @@ internal class MappedStringPropertyIndex(
         var size = 0
         for (stringId in uniqueStringIds) {
             workConsumer?.consume()
-            val actual = stringTable.get(stringId)
+            val actual = transformString(stringTable.get(stringId), transform)
             val matches = when (mode) {
                 StringMatchMode.STARTS_WITH -> actual.startsWith(expected)
                 StringMatchMode.ENDS_WITH -> actual.endsWith(expected)
@@ -745,10 +820,23 @@ private fun estimatedStringPropertyAdmissionBytes(key: StringPropertyAdmissionKe
         key.property.property.length.toLong() * Char.SIZE_BYTES +
         key.expected.length.toLong() * Char.SIZE_BYTES
 
-private fun stringMatches(actual: String, mode: StringMatchMode, expected: String): Boolean = when (mode) {
-    StringMatchMode.STARTS_WITH -> actual.startsWith(expected)
-    StringMatchMode.ENDS_WITH -> actual.endsWith(expected)
-    StringMatchMode.CONTAINS -> actual.contains(expected)
+private fun stringMatches(
+    actual: String,
+    transform: StringValueTransform?,
+    mode: StringMatchMode,
+    expected: String
+): Boolean {
+    val transformed = transformString(actual, transform)
+    return when (mode) {
+        StringMatchMode.STARTS_WITH -> transformed.startsWith(expected)
+        StringMatchMode.ENDS_WITH -> transformed.endsWith(expected)
+        StringMatchMode.CONTAINS -> transformed.contains(expected)
+    }
+}
+
+private fun transformString(value: String, transform: StringValueTransform?): String = when (transform) {
+    null -> value
+    StringValueTransform.LOWERCASE -> value.lowercase()
 }
 
 private fun trigramHash(value: String, position: Int): Int =

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -258,12 +258,10 @@ internal class MappedWebGraphBackedGraph(
                     }
                 }
                 admitted = true
-                if (workConsumer == null) {
-                    matchStates = rawStringMatchStates.stateFor(
-                        RawStringMatchKey(admission.property, transform, mode, expected),
-                        stringTable.size()
-                    )
-                }
+                matchStates = rawStringMatchStates.stateFor(
+                    RawStringMatchKey(admission.property, transform, mode, expected),
+                    stringTable.size()
+                )
             }
             val stringId = rawStringPropertyIndex(nodeId, type, property)
             val states = matchStates
@@ -517,6 +515,7 @@ private const val STRING_PROPERTY_ADMISSION_ESTIMATED_BYTES = 96L
 private const val MAX_STRING_PROPERTY_INDEX_RETAINED_BYTES = 8L * 1024 * 1024
 private const val MAX_RAW_STRING_MATCH_STATE_BYTES = 16 * 1024 * 1024
 private const val MAX_RAW_STRING_MATCH_STATES = 32
+private const val RAW_STRING_MATCH_STATE_ENTRY_ESTIMATED_BYTES = 96L
 private const val STRING_PROPERTY_INDEX_ARRAYS = 3
 private const val PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES = 16L
 private const val MAX_STRING_MATCH_CACHE_ENTRIES = 32
@@ -569,7 +568,7 @@ internal class RawStringMatchStates(
     @Synchronized
     fun stateFor(key: RawStringMatchKey, stringCount: Int): ByteArray? {
         val existing = states[key]
-        val requiredBytes = PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES + stringCount.toLong()
+        val requiredBytes = estimatedRawStringMatchStateBytes(key, stringCount)
         return when {
             existing != null -> existing
             states.size >= maxEntries || requiredBytes > maxRetainedBytes - bytes -> null
@@ -592,6 +591,12 @@ internal class RawStringMatchStates(
     @Synchronized
     fun size(): Int = states.size
 }
+
+private fun estimatedRawStringMatchStateBytes(key: RawStringMatchKey, stringCount: Int): Long =
+    RAW_STRING_MATCH_STATE_ENTRY_ESTIMATED_BYTES + PRIMITIVE_ARRAY_HEADER_ESTIMATED_BYTES +
+        STRING_HEADER_ESTIMATED_BYTES + key.property.property.length.toLong() * Char.SIZE_BYTES +
+        STRING_HEADER_ESTIMATED_BYTES + key.expected.length.toLong() * Char.SIZE_BYTES +
+        stringCount.toLong()
 
 private class StringPropertyAdmissions {
     private val predicates = LinkedHashMap<StringPropertyAdmissionKey, Unit>(

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -500,8 +500,8 @@ class GraphStoreTest {
 
                 assertEquals(listOf(256, 257, 260), budgeted)
                 assertEquals(261, consumed)
-                assertEquals(0, loaded.rawStringMatchStateCount())
-                assertEquals(0L, loaded.rawStringMatchStateBytes())
+                assertEquals(1, loaded.rawStringMatchStateCount())
+                assertTrue(loaded.rawStringMatchStateBytes() > 0)
             } finally {
                 loaded.close()
             }
@@ -512,7 +512,7 @@ class GraphStoreTest {
 
     @Test
     fun `raw string match states enforce one aggregate graph memory bound`() {
-        val states = RawStringMatchStates(maxRetainedBytes = 120, maxEntries = 8)
+        val states = RawStringMatchStates(maxRetainedBytes = 512, maxEntries = 8)
         val property = StringPropertyKey(StringConstant::class.java, "value")
 
         val first = states.stateFor(
@@ -532,11 +532,24 @@ class GraphStoreTest {
         assertNotNull(second)
         assertNull(overflow)
         assertEquals(2, states.size())
-        assertEquals(112L, states.retainedBytes())
+        assertEquals(442L, states.retainedBytes())
         assertTrue(states.stateFor(
             RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "first"),
             stringCount = 40
         ) === first)
+
+        val oversizedKeyStates = RawStringMatchStates(maxRetainedBytes = 256, maxEntries = 8)
+        assertNull(oversizedKeyStates.stateFor(
+            RawStringMatchKey(
+                property,
+                StringValueTransform.LOWERCASE,
+                StringMatchMode.CONTAINS,
+                "x".repeat(128)
+            ),
+            stringCount = 1
+        ))
+        assertEquals(0, oversizedKeyStates.size())
+        assertEquals(0L, oversizedKeyStates.retainedBytes())
     }
 
     @Test

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -453,6 +453,93 @@ class GraphStoreTest {
     }
 
     @Test
+    fun `mapped raw string scan caches repeated match states and accounts budgeted work`() {
+        val graph = DefaultGraph.Builder().apply {
+            repeat(261) { index ->
+                val value = when (index) {
+                    256, 257, 260 -> "TaRgEt"
+                    258, 259 -> "other"
+                    else -> "prefix-$index"
+                }
+                addNode(StringConstant(NodeId(index), value))
+            }
+        }.build()
+        val orderedGraph = object : Graph by graph {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                graph.nodes(type).sortedBy { it.id.value }
+        }
+        val dir = Files.createTempDirectory("webgraph-raw-string-match-states")
+        try {
+            GraphStore.save(orderedGraph, dir)
+            val loaded = GraphStore.loadMapped(dir) as MappedWebGraphBackedGraph
+            try {
+                val unbudgeted = loaded.nodesByTransformedStringProperty(
+                    StringConstant::class.java,
+                    "value",
+                    StringValueTransform.LOWERCASE,
+                    StringMatchMode.CONTAINS,
+                    "target",
+                    limit = 3
+                ).orEmpty().map { it.id.value }.toList()
+
+                assertEquals(listOf(256, 257, 260), unbudgeted)
+                assertEquals(1, loaded.rawStringMatchStateCount())
+                assertTrue(loaded.rawStringMatchStateBytes() > 0)
+
+                loaded.clearStringPropertyIndexes()
+                var consumed = 0
+                val budgeted = loaded.nodesByTransformedStringProperty(
+                    StringConstant::class.java,
+                    "value",
+                    StringValueTransform.LOWERCASE,
+                    StringMatchMode.CONTAINS,
+                    "target",
+                    limit = 3,
+                    workConsumer = GraphWorkConsumer { consumed++ }
+                ).orEmpty().map { it.id.value }.toList()
+
+                assertEquals(listOf(256, 257, 260), budgeted)
+                assertEquals(261, consumed)
+                assertEquals(0, loaded.rawStringMatchStateCount())
+                assertEquals(0L, loaded.rawStringMatchStateBytes())
+            } finally {
+                loaded.close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `raw string match states enforce one aggregate graph memory bound`() {
+        val states = RawStringMatchStates(maxRetainedBytes = 120, maxEntries = 8)
+        val property = StringPropertyKey(StringConstant::class.java, "value")
+
+        val first = states.stateFor(
+            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "first"),
+            stringCount = 40
+        )
+        val second = states.stateFor(
+            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "second"),
+            stringCount = 40
+        )
+        val overflow = states.stateFor(
+            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "third"),
+            stringCount = 40
+        )
+
+        assertNotNull(first)
+        assertNotNull(second)
+        assertNull(overflow)
+        assertEquals(2, states.size())
+        assertEquals(112L, states.retainedBytes())
+        assertTrue(states.stateFor(
+            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "first"),
+            stringCount = 40
+        ) === first)
+    }
+
+    @Test
     fun `mapped string lookup keeps admission specific to the query limit`() {
         val graph = DefaultGraph.Builder().apply {
             repeat(300) { index ->

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -42,6 +42,7 @@ import io.johnsonlee.graphite.graph.ClassDependency
 import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
+import io.johnsonlee.graphite.graph.GraphWorkConsumer
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.graph.MmapGraphBuilder
 import io.johnsonlee.graphite.graph.StringMatchMode
@@ -161,6 +162,7 @@ class GraphStoreTest {
                 assertEquals(listOf("feature-beta"), cypherValues)
                 assertWrappedLowercaseQuery(loaded)
                 assertRawStringPropertyLookups(loaded)
+                assertWorkAwareTransformedLookup(mapped)
                 assertNull(
                     loaded.nodesByStringProperty(
                         StringConstant::class.java,
@@ -737,6 +739,22 @@ class GraphStoreTest {
             }
         )
         assertResourceStringPropertyLookups(graph)
+    }
+
+    private fun assertWorkAwareTransformedLookup(graph: MappedWebGraphBackedGraph) {
+        var inspected = 0
+        val values = graph.nodesByTransformedStringProperty(
+            FieldNode::class.java,
+            "class",
+            StringValueTransform.LOWERCASE,
+            StringMatchMode.CONTAINS,
+            "owner",
+            limit = 1,
+            workConsumer = GraphWorkConsumer { inspected++ }
+        ).orEmpty().map { it.descriptor.declaringClass.className }.toList()
+
+        assertEquals(listOf("example.Owner"), values)
+        assertTrue(inspected > 0)
     }
 
     private fun assertWrappedLowercaseQuery(graph: Graph) {

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -45,7 +45,9 @@ import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.graph.MmapGraphBuilder
 import io.johnsonlee.graphite.graph.StringMatchMode
+import io.johnsonlee.graphite.graph.StringValueTransform
 import io.johnsonlee.graphite.graph.nodesByStringProperty
+import io.johnsonlee.graphite.graph.nodesByTransformedStringProperty
 import io.johnsonlee.graphite.input.ResourceAccessor
 import io.johnsonlee.graphite.input.ResourceEntry
 import it.unimi.dsi.fastutil.io.BinIO
@@ -157,6 +159,7 @@ class GraphStoreTest {
                 assertEquals(listOf("callerFeature"), startsWith)
                 assertEquals(listOf("billingFeature"), endsWith)
                 assertEquals(listOf("feature-beta"), cypherValues)
+                assertWrappedLowercaseQuery(loaded)
                 assertRawStringPropertyLookups(loaded)
                 assertNull(
                     loaded.nodesByStringProperty(
@@ -187,7 +190,7 @@ class GraphStoreTest {
     }
 
     @Test
-    fun `mapped broad disjunction deduplicates unordered property streams`() {
+    fun `mapped broad disjunction preserves stored order while deduplicating property streams`() {
         val nodeIds = listOf(1, 30, 70, 2, 90, 4, 5, 50, 40, 3)
         val returnType = TypeDescriptor("void")
         val graph = DefaultGraph.Builder().apply {
@@ -225,7 +228,7 @@ class GraphStoreTest {
                 ).rows
                 val resultIds = rows.map { it["id"] }
 
-                assertEquals(listOf(4, 90), resultIds)
+                assertEquals(listOf(90, 4), resultIds)
                 assertEquals(resultIds.size, resultIds.distinct().size)
             } finally {
                 loaded.close()
@@ -311,6 +314,38 @@ class GraphStoreTest {
             )
             assertEquals(listOf(11), uncached.matchingNodeIds(StringMatchMode.STARTS_WITH, "beta").toList())
             assertEquals(0, uncached.matchingStringCacheSize())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `mapped string index isolates raw and exact lowercase match caches`() {
+        val dir = Files.createTempDirectory("webgraph-lowercase-string-index")
+        try {
+            val values = listOf("Voucher", "voucher", "İVOUCHER")
+            val strings = StringTable.build(values, dir)
+            val index = MappedStringPropertyIndex(
+                nodeIds = intArrayOf(10, 11, 12),
+                stringIds = values.map(strings::indexOf).toIntArray(),
+                uniqueStringIds = values.map(strings::indexOf).sorted().toIntArray(),
+                stringTable = strings
+            )
+
+            assertEquals(
+                listOf(11),
+                index.matchingNodeIds(StringMatchMode.CONTAINS, "voucher").toList()
+            )
+            assertEquals(
+                listOf(10, 11, 12),
+                index.matchingNodeIds(
+                    StringValueTransform.LOWERCASE,
+                    StringMatchMode.CONTAINS,
+                    "voucher",
+                    workConsumer = null
+                ).toList()
+            )
+            assertEquals(2, index.matchingStringCacheSize())
         } finally {
             dir.toFile().deleteRecursively()
         }
@@ -636,6 +671,25 @@ class GraphStoreTest {
         )
 
     private fun assertRawStringPropertyLookups(graph: Graph) {
+        graph.nodesByTransformedStringProperty(
+            FieldNode::class.java,
+            "class",
+            StringValueTransform.LOWERCASE,
+            StringMatchMode.CONTAINS,
+            "owner"
+        )
+        assertEquals(
+            listOf("example.Owner"),
+            assertNotNull(
+                graph.nodesByTransformedStringProperty(
+                    FieldNode::class.java,
+                    "class",
+                    StringValueTransform.LOWERCASE,
+                    StringMatchMode.CONTAINS,
+                    "owner"
+                )
+            ).map { it.descriptor.declaringClass.className }.toList()
+        )
         assertEquals(
             listOf("example.State"),
             indexedValues(graph, EnumConstant::class.java, "enum_type", StringMatchMode.ENDS_WITH, "State") {
@@ -683,6 +737,17 @@ class GraphStoreTest {
             }
         )
         assertResourceStringPropertyLookups(graph)
+    }
+
+    private fun assertWrappedLowercaseQuery(graph: Graph) {
+        val values = graph.query(
+            "MATCH (n) WHERE " +
+                "toLower(coalesce(n.caller_name, '')) CONTAINS 'feature' OR " +
+                "toLower(coalesce(n.callee_name, '')) CONTAINS 'feature' " +
+                "RETURN DISTINCT n.caller_name AS caller, n.callee_name AS callee LIMIT 250"
+        ).rows.map { it["caller"] to it["callee"] }
+
+        assertEquals(listOf("callerFeature" to "billingFeature"), values)
     }
 
     private fun assertResourceStringPropertyLookups(graph: Graph) {


### PR DESCRIPTION
## Summary

- restore wrapped case-insensitive Cypher discovery latency by routing supported `toLower(coalesce(...))` string predicates through transformed mapped-graph lookups instead of scanning every node
- preserve the pre-optimization traversal order, `DISTINCT`/`LIMIT` behavior, null semantics, and graph provenance
- add a required fixed pre-PR-95 latency gate covering synthetic 1/17-graph scaling and all four repository fixture JARs, with eight query shapes and target distributions
- fail closed on result-digest mismatches, missing benchmark variants, invalid results, and cleanup/resource errors

## Root cause

PR #95 exposed the production query shape in a regression test, but its budget checks were not the source of the 9–10x slowdown. The wrapped predicates were not eligible for the mapped string-property lookup, so every graph performed a full node scan serially. The new lookup path recognizes only the semantically safe wrapped forms and uses persisted node byte offsets as an allocation-free canonical order when merging property streams.

## Correctness

The four-corpus harness executes every timed query on the fixed pre-PR-95 executor, current `main`, and this PR. It hashes complete columns, ordered rows, values, sets/maps, and graph provenance. All eight digests are identical across revisions.

The fixture distribution preflight pins zero-hit, dense four-graph, first-only, middle-only, last-only, broadly distributed, first/last bimodal, and highly skewed targets. Query forms vary caller/callee, class/method, `CONTAINS`/`STARTS WITH`/`ENDS WITH`, mixed OR predicates, and `LIMIT 1/50/250`.

## Benchmark environment

- Apple M3 Max, 64 GiB RAM
- macOS 14.3 arm64
- OpenJDK 17.0.18, Gradle 8.13
- JMH 1.37, one fork, one unmeasured warmup, three SingleShot measurements, `-Xmx8g`, GC profiler
- four persisted mapped graphs: Android, Tika, Hive, Kotlin Compiler; 19,091,048 nodes total
- fixed baseline: `44b57562f2b3d0c88882a9002bdc488e05e5d7a7`; PR base: `e2a2b1a2bf56c7311b639667dfea27a67350fddb`

Command:

```bash
java -jar graphite-webgraph/build/libs/webgraph-1.0.0-SNAPSHOT-jmh.jar \
  'io.johnsonlee.graphite.webgraph.(WrappedDiscoveryLatencyBenchmark|AllFixtureWrappedDiscoveryLatencyBenchmark).*CaseInsensitiveDiscovery' \
  -jvmArgsAppend '-Dandroid.graph.path=... -Dtika.graph.path=... -Dhive.graph.path=... -Dkotlin.compiler.graph.path=...' \
  -foe true -prof gc -rf json -rff benchmark-results/latency.json
```

## Latency results

| Exact benchmark | Pre-PR-95 | `main` | PR |
|---|---:|---:|---:|
| `AllFixtureWrappedDiscoveryLatencyBenchmark.zeroHitBroadContainsCaseInsensitiveDiscovery` | 15.209 s | 14.042 s | 0.520 s |
| `AllFixtureWrappedDiscoveryLatencyBenchmark.denseDistributedMethodContainsCaseInsensitiveDiscovery` | 14.019 s | 12.355 s | 1.836 s |
| `AllFixtureWrappedDiscoveryLatencyBenchmark.earlyGraphClassPrefixCaseInsensitiveDiscovery` | 11.506 s | 13.024 s | 1.481 s |
| `AllFixtureWrappedDiscoveryLatencyBenchmark.middleGraphsClassPrefixCaseInsensitiveDiscovery` | 14.314 s | 16.148 s | 1.349 s |
| `AllFixtureWrappedDiscoveryLatencyBenchmark.lateGraphClassPrefixCaseInsensitiveDiscovery` | 12.695 s | 11.374 s | 1.438 s |
| `AllFixtureWrappedDiscoveryLatencyBenchmark.broadlyDistributedClassPrefixCaseInsensitiveDiscovery` | 13.927 s | 13.479 s | 1.715 s |
| `AllFixtureWrappedDiscoveryLatencyBenchmark.firstLastGraphBimodalClassPrefixCaseInsensitiveDiscovery` | 16.289 s | 18.046 s | 2.842 s |
| `AllFixtureWrappedDiscoveryLatencyBenchmark.skewedMixedClassMethodOperatorCaseInsensitiveDiscovery` | 15.977 s | 16.817 s | 1.811 s |
| **Four-real-graph arithmetic mean** | **14.242 s** | **14.411 s** | **1.624 s** |
| `WrappedDiscoveryLatencyBenchmark.coldWrappedCaseInsensitiveDiscovery[graphCount=1]` | 3.994 ms | 4.207 ms | 0.566 ms |
| `WrappedDiscoveryLatencyBenchmark.coldWrappedCaseInsensitiveDiscovery[graphCount=17]` | 68.841 ms | 83.809 ms | 7.917 ms |
| `WrappedDiscoveryLatencyBenchmark.wrappedCaseInsensitiveDiscovery[graphCount=1]` | 5.660 ms | 5.108 ms | 0.126 ms |
| `WrappedDiscoveryLatencyBenchmark.wrappedCaseInsensitiveDiscovery[graphCount=17]` | 97.534 ms | 71.127 ms | 0.216 ms |

The four-real-graph average improves by 8.77x versus pre-PR-95 and 8.87x versus `main`. Every one of the 12 required rows passes the fixed-baseline minimum 50% improvement and current-base 15% regression gate.

## Verification

- `./gradlew check --no-daemon` — passed, including Hive/Tika/Kotlin Compiler large-corpus build/save/mapped-load/query gates and Kover verification
- `./gradlew :core:test :cypher:test :cypher:detekt :webgraph:test :webgraph:detekt :webgraph:compileJmhKotlin --rerun-tasks --no-build-cache --no-daemon` — passed
- `node --test .github/scripts/benchmark-gate.test.mjs` — 24/24 passed
- `actionlint .github/workflows/benchmark.yml` — passed
- fixed/base/candidate all-fixture correctness digest comparison — passed, 8/8
- 12-row `compare-latency-baseline` — passed
- `git diff --check` — passed

Method-level conclusion: no `CypherBenchmark` regression exceeds the existing 15% gate.

End-to-end conclusion: no adjacent build/save/load/query regression was found. Android mapped load improved from 149.418 to 139.761 ms, mapped query changes ranged from -12.6% to +6.7%, and Android build/save/load/query changed from 25,294.562 to 24,900.711 ms (-1.6%). The required Tika, Hive, and Kotlin Compiler full-pipeline gates pass.