### PR TITLE
Bound memory for filtered DATAFLOW queries

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,8 @@ jobs:
       run: |
         cp candidate/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/BudgetedCypherBenchmark.kt \
           base/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/BudgetedCypherBenchmark.kt
+        cp candidate/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt \
+          base/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt
         base/gradlew -p base :cypher:jmhJar --no-daemon
         candidate/gradlew -p candidate :cypher:jmhJar --no-daemon
 

--- a/graphite-cypher/build.gradle.kts
+++ b/graphite-cypher/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.Test
+
 description = "Graphite Cypher - Cypher query engine for Graphite graphs"
 
 plugins {
@@ -72,4 +74,25 @@ tasks.named("compileTestKotlin") {
 
 tasks.named("compileJmhKotlin") {
     dependsOn(tasks.named("generateJmhGrammarSource"))
+}
+
+val filteredRelationshipMemoryTest by tasks.registering(Test::class) {
+    description = "Verifies filtered relationship queries stay within a bounded heap"
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    filter {
+        includeTestsMatching("io.johnsonlee.graphite.cypher.FilteredRelationshipMemoryTest")
+    }
+    maxHeapSize = "256m"
+    forkEvery = 1
+    doNotTrackState("The heap-bound relationship regression must execute on every invocation")
+}
+
+tasks.named<Test>("test") {
+    exclude("**/FilteredRelationshipMemoryTest.class")
+}
+
+tasks.named("check") {
+    dependsOn(filteredRelationshipMemoryTest)
 }

--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt
@@ -104,6 +104,14 @@ open class CypherBenchmark {
     }
 
     @Benchmark
+    fun filteredSingleHopRelationship(): CypherResult {
+        return graph.query(
+            "MATCH (c:IntConstant)-[:DATAFLOW]->(cs:CallSiteNode) " +
+                "WHERE c.value > 250 RETURN c.value, cs.callee_name LIMIT 50"
+        )
+    }
+
+    @Benchmark
     fun aggregationCountGroupBy(): CypherResult {
         return graph.query("MATCH (n:CallSiteNode) RETURN n.callee_class, count(*) AS cnt")
     }

--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt
@@ -112,6 +112,16 @@ open class CypherBenchmark {
     }
 
     @Benchmark
+    fun orderedFilteredSingleHopRelationship(): CypherResult {
+        return graph.query(
+            "MATCH (c:IntConstant)-[:DATAFLOW]->(cs:CallSiteNode) " +
+                "WHERE c.value > 250 " +
+                "RETURN c.value AS value, cs.callee_name AS callee " +
+                "ORDER BY value DESC, callee ASC LIMIT 50"
+        )
+    }
+
+    @Benchmark
     fun aggregationCountGroupBy(): CypherResult {
         return graph.query("MATCH (n:CallSiteNode) RETURN n.callee_class, count(*) AS cnt")
     }

--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CypherBenchmark.kt
@@ -132,6 +132,15 @@ open class CypherBenchmark {
     }
 
     @Benchmark
+    fun filteredVariableLengthPath(): CypherResult {
+        return graph.query(
+            "MATCH (a:IntConstant)-[:DATAFLOW*1..1]->(b:CallSiteNode) " +
+                "WHERE b.line < 0 " +
+                "RETURN a.value AS value, b.callee_name AS callee LIMIT 20"
+        )
+    }
+
+    @Benchmark
     fun returnDistinct(): CypherResult {
         return graph.query("MATCH (n:CallSiteNode) RETURN DISTINCT n.callee_class")
     }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessor.kt
@@ -298,7 +298,7 @@ object NodePropertyAccessor {
         "CALL" -> CallEdge::class.java
         "TYPE" -> TypeEdge::class.java
         "CONTROL_FLOW", "CONTROLFLOW" -> ControlFlowEdge::class.java
-        "RESOURCE", "RESOURCE_EDGE", "RESOURCE_OPEN", "RESOURCE_LOAD",
+        "RESOURCE", "RESOURCE_OPEN", "RESOURCE_LOAD",
         "RESOURCE_BUNDLE_CANDIDATE", "RESOURCE_LOOKUP", "RESOURCE_KEYS" -> ResourceEdge::class.java
         else -> null
     }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -140,6 +140,15 @@ object PathFinder {
         val start = SearchState(startNode, incomingEdge = null, parent = null, depth = 0)
         if (matchesTarget(start, options)) yield(PathMatch(start))
         if (options.maxDepth <= 0) return@sequence
+        if (options.maxDepth == 1) {
+            for (edge in edgesForDirection(graph, startNode.id, options)) {
+                val nextId = nextNodeId(edge, startNode.id, options.direction)
+                val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
+                val nextState = SearchState(nextNode, edge, start, depth = 1)
+                if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
+            }
+            return@sequence
+        }
 
         val stack = ArrayDeque<SearchFrame>()
         val startEdges = edgesForDirection(graph, startNode.id, options).iterator()
@@ -166,9 +175,16 @@ object PathFinder {
             val nextState = SearchState(nextNode, edge, frame.state, frame.state.depth + 1)
             if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
 
-            val expansion = expandableFrame(graph, nextId, nextState, options, expansionMemo)
-            frame.blockedAncestors.addAll(expansion.blockedAncestors)
-            expansion.frame?.let(stack::addLast)
+            if (nextState.depth < options.maxDepth) {
+                expandableFrame(
+                    graph,
+                    nextId,
+                    nextState,
+                    options,
+                    expansionMemo,
+                    frame.blockedAncestors
+                )?.let(stack::addLast)
+            }
         }
     }
 
@@ -178,23 +194,25 @@ object PathFinder {
         nodeId: NodeId,
         state: SearchState,
         options: SearchOptions,
-        expansionMemo: LinkedHashMap<Int, ExpansionRecord>
-    ): ExpansionDecision {
-        if (state.depth >= options.maxDepth) return ExpansionDecision()
+        expansionMemo: LinkedHashMap<Int, ExpansionRecord>,
+        blockedAncestors: MutableSet<Int>
+    ): SearchFrame? {
         if (hasAncestor(state.parent, nodeId)) {
-            return ExpansionDecision(blockedAncestors = setOf(nodeId.value))
+            blockedAncestors.add(nodeId.value)
+            return null
         }
 
         val edges = edgesForDirection(graph, nodeId, options).iterator()
-        if (!edges.hasNext()) return ExpansionDecision()
+        if (!edges.hasNext()) return null
         val previous = expansionMemo[nodeId.value]
         if (previous != null &&
             previous.depth == state.depth &&
             ancestorIds(state.parent).containsAll(previous.blockedAncestors)
         ) {
-            return ExpansionDecision(blockedAncestors = previous.blockedAncestors)
+            blockedAncestors.addAll(previous.blockedAncestors)
+            return null
         }
-        return ExpansionDecision(frame = SearchFrame(state, edges))
+        return SearchFrame(state, edges)
     }
 
     private fun ancestorIds(state: SearchState?): Set<Int> {
@@ -231,11 +249,6 @@ object PathFinder {
         val state: SearchState,
         val edges: Iterator<Edge>,
         val blockedAncestors: MutableSet<Int> = mutableSetOf()
-    )
-
-    private data class ExpansionDecision(
-        val frame: SearchFrame? = null,
-        val blockedAncestors: Set<Int> = emptySet()
     )
 
     private data class ExpansionRecord(

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -51,7 +51,7 @@ object PathFinder {
     }
 
     /**
-     * Find paths from source nodes to target nodes with a depth-bounded traversal.
+     * Find all paths from source nodes to target nodes via breadth-first search.
      *
      * @param graph The graph to search
      * @param sources Source node IDs to start from
@@ -70,11 +70,13 @@ object PathFinder {
         minDepth: Int = 1,
         maxDepth: Int = 10,
         direction: Direction = Direction.OUTGOING
-    ): List<Path> = findPathMatches(
-        graph,
-        sources,
-        SearchOptions(targets, edgeType, minDepth, maxDepth, direction)
-    ).map { it.materialize(workTracker = null) }.toList()
+    ): List<Path> {
+        val options = SearchOptions(targets, edgeType, minDepth, maxDepth, direction)
+        return sources.asSequence().flatMap { source ->
+            val startNode = loadNode(graph, source, workTracker = null)
+            if (startNode == null) emptySequence() else breadthFirst(graph, startNode, options)
+        }.map { it.materialize(workTracker = null) }.toList()
+    }
 
     internal fun findPathMatches(
         graph: Graph,
@@ -87,11 +89,39 @@ object PathFinder {
         }
     }
 
+    /** Preserve the public [findPaths] shortest-first contract. */
+    private fun breadthFirst(
+        graph: Graph,
+        startNode: Node,
+        options: SearchOptions
+    ): Sequence<PathMatch> = sequence {
+        val visited = mutableSetOf<Int>()
+        val queue = ArrayDeque<SearchState>()
+        queue.add(SearchState(startNode, incomingEdge = null, parent = null, depth = 0))
+
+        while (queue.isNotEmpty()) {
+            val state = queue.removeFirst()
+            val current = state.node.id
+
+            if (state.depth == 0 && matchesTarget(state, options)) yield(PathMatch(state))
+            if (state.depth >= options.maxDepth) continue
+            if (!visited.add(current.value)) continue
+
+            for (edge in edgesForDirection(graph, current, options)) {
+                val nextId = nextNodeId(edge, current, options.direction)
+                val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
+                val nextState = SearchState(nextNode, edge, state, state.depth + 1)
+                if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
+                queue.add(nextState)
+            }
+        }
+    }
+
     /**
      * Traverse one branch at a time so suspended lazy consumers retain at most [SearchOptions.maxDepth]
      * search states instead of a complete breadth-first frontier.
-     * The shallowest-depth map grows with expanded node IDs, but does not retain nodes or parent paths;
-     * only the stack's O(maxDepth) frames retain those objects.
+     * Nodes already present on the current branch are not expanded again, so cycles terminate without
+     * retaining a traversal-wide visited set. Only the stack's O(maxDepth) frames retain search state.
      *
      * Matches keep the graph's edge order within each branch. Cypher does not define a global result
      * order without ORDER BY, so depth-first traversal is safe for the lazy query pipeline while allowing
@@ -102,11 +132,9 @@ object PathFinder {
         startNode: Node,
         options: SearchOptions
     ): Sequence<PathMatch> = sequence {
-        val expandedAtDepth = mutableMapOf<Int, Int>()
         val start = SearchState(startNode, incomingEdge = null, parent = null, depth = 0)
         if (matchesTarget(start, options)) yield(PathMatch(start))
         if (options.maxDepth <= 0) return@sequence
-        expandedAtDepth[startNode.id.value] = 0
 
         val stack = ArrayDeque<SearchFrame>()
         stack.addLast(SearchFrame(start, edgesForDirection(graph, startNode.id, options).iterator()))
@@ -125,14 +153,21 @@ object PathFinder {
             val nextState = SearchState(nextNode, edge, frame.state, frame.state.depth + 1)
             if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
 
-            val previousDepth = expandedAtDepth[nextId.value]
             if (nextState.depth < options.maxDepth &&
-                (previousDepth == null || nextState.depth < previousDepth)
+                !hasAncestor(frame.state, nextId)
             ) {
-                expandedAtDepth[nextId.value] = nextState.depth
                 stack.addLast(SearchFrame(nextState, edgesForDirection(graph, nextId, options).iterator()))
             }
         }
+    }
+
+    private fun hasAncestor(state: SearchState?, nodeId: NodeId): Boolean {
+        var cursor = state
+        while (cursor != null) {
+            if (cursor.node.id == nodeId) return true
+            cursor = cursor.parent
+        }
+        return false
     }
 
     private data class SearchFrame(

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -99,7 +99,7 @@ object PathFinder {
             val state = queue.removeFirst()
             val current = state.node.id
 
-            if (state.depth >= options.minDepth && (options.targets == null || current in options.targets)) {
+            if (state.depth == 0 && matchesTarget(state, options)) {
                 yield(PathMatch(state))
             }
 
@@ -110,12 +110,17 @@ object PathFinder {
             for (edge in edges) {
                 val nextId = nextNodeId(edge, current, options.direction)
                 val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
-                queue.add(SearchState(nextNode, edge, state, state.depth + 1))
+                val nextState = SearchState(nextNode, edge, state, state.depth + 1)
+                if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
+                queue.add(nextState)
             }
         }
     }
 
-    private fun edgesForDirection(graph: Graph, nodeId: NodeId, options: SearchOptions): List<Edge> =
+    private fun matchesTarget(state: SearchState, options: SearchOptions): Boolean =
+        state.depth >= options.minDepth && (options.targets == null || state.node.id in options.targets)
+
+    private fun edgesForDirection(graph: Graph, nodeId: NodeId, options: SearchOptions): Sequence<Edge> =
         when (options.direction) {
             Direction.OUTGOING -> filteredEdges(graph.outgoing(nodeId), options.edgeType, options.workTracker)
             Direction.INCOMING -> filteredEdges(graph.incoming(nodeId), options.edgeType, options.workTracker)
@@ -138,13 +143,11 @@ object PathFinder {
         edges: Sequence<Edge>,
         edgeType: Class<out Edge>?,
         workTracker: CypherWorkTracker?
-    ): List<Edge> {
-        val result = mutableListOf<Edge>()
+    ): Sequence<Edge> = sequence {
         for (edge in edges) {
             workTracker?.consume()
-            if (edgeType == null || edgeType.isInstance(edge)) result.add(edge)
+            if (edgeType == null || edgeType.isInstance(edge)) yield(edge)
         }
-        return result
     }
 
     enum class Direction { OUTGOING, INCOMING, BOTH }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -19,7 +19,8 @@ object PathFinder {
         val maxDepth: Int,
         val direction: Direction,
         val workTracker: CypherWorkTracker? = null,
-        val edgePredicate: ((Edge) -> Boolean)? = null
+        val edgePredicate: ((Edge) -> Boolean)? = null,
+        val nodePredicate: ((Node) -> Boolean)? = null
     )
 
     internal class SearchState(
@@ -121,11 +122,11 @@ object PathFinder {
      * Traverse one branch at a time so suspended lazy consumers retain at most [SearchOptions.maxDepth]
      * search states instead of a complete breadth-first frontier.
      * Nodes already present on the current branch are not expanded again, so cycles terminate without
-     * retaining a traversal-wide visited set. A fixed-size memo suppresses reconvergent expansion while
-     * recording the ancestors that actually blocked each completed suffix. A revisit is suppressed only
-     * when its ancestor set still contains every prior blocker. This keeps acyclic reconvergence cheap
-     * without dropping a suffix that becomes legal under a different branch. Eviction can only cause safe
-     * re-expansion. Only the stack's O(maxDepth) frames retain nodes and parent paths.
+     * retaining a traversal-wide visited set. A fixed-size memo suppresses only suffixes that completed
+     * without producing a match or encountering an ancestor back-edge. Result-producing suffixes are
+     * always replayed for every prefix, preserving Cypher row multiplicity; cycle-dependent suffixes are
+     * never memoized, preserving paths that become legal under a different ancestor set. Eviction can only
+     * cause safe re-expansion. Only the stack's O(maxDepth) frames retain nodes and parent paths.
      *
      * Matches keep the graph's edge order within each branch. Cypher does not define a global result
      * order without ORDER BY, so depth-first traversal is safe for the lazy query pipeline while allowing
@@ -136,17 +137,12 @@ object PathFinder {
         startNode: Node,
         options: SearchOptions
     ): Sequence<PathMatch> = sequence {
-        val expansionMemo = LinkedHashMap<Int, ExpansionRecord>()
+        val deadSuffixMemo = LinkedHashMap<ExpansionKey, Unit>()
         val start = SearchState(startNode, incomingEdge = null, parent = null, depth = 0)
         if (matchesTarget(start, options)) yield(PathMatch(start))
         if (options.maxDepth <= 0) return@sequence
         if (options.maxDepth == 1) {
-            for (edge in edgesForDirection(graph, startNode.id, options)) {
-                val nextId = nextNodeId(edge, startNode.id, options.direction)
-                val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
-                val nextState = SearchState(nextNode, edge, start, depth = 1)
-                if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
-            }
+            yieldAll(singleHop(graph, start, options))
             return@sequence
         }
 
@@ -159,12 +155,17 @@ object PathFinder {
             val frame = stack.last()
             if (!frame.edges.hasNext()) {
                 val completed = stack.removeLast()
-                rememberBounded(
-                    expansionMemo,
-                    completed.state.node.id.value,
-                    ExpansionRecord(completed.state.depth, completed.blockedAncestors.toSet())
-                )
-                stack.lastOrNull()?.blockedAncestors?.addAll(completed.blockedAncestors)
+                if (!completed.foundMatch && !completed.cycleBlocked) {
+                    rememberBounded(
+                        deadSuffixMemo,
+                        ExpansionKey(completed.state.node.id.value, completed.state.depth),
+                        Unit
+                    )
+                }
+                stack.lastOrNull()?.let { parent ->
+                    parent.foundMatch = parent.foundMatch || completed.foundMatch
+                    parent.cycleBlocked = parent.cycleBlocked || completed.cycleBlocked
+                }
                 continue
             }
 
@@ -173,7 +174,10 @@ object PathFinder {
             val nextId = nextNodeId(edge, current, options.direction)
             val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
             val nextState = SearchState(nextNode, edge, frame.state, frame.state.depth + 1)
-            if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
+            if (matchesTarget(nextState, options)) {
+                frame.foundMatch = true
+                yield(PathMatch(nextState))
+            }
 
             if (nextState.depth < options.maxDepth) {
                 expandableFrame(
@@ -181,10 +185,23 @@ object PathFinder {
                     nextId,
                     nextState,
                     options,
-                    expansionMemo,
-                    frame.blockedAncestors
+                    deadSuffixMemo,
+                    frame
                 )?.let(stack::addLast)
             }
+        }
+    }
+
+    private fun singleHop(
+        graph: Graph,
+        start: SearchState,
+        options: SearchOptions
+    ): Sequence<PathMatch> = sequence {
+        for (edge in edgesForDirection(graph, start.node.id, options)) {
+            val nextId = nextNodeId(edge, start.node.id, options.direction)
+            val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
+            val nextState = SearchState(nextNode, edge, start, depth = 1)
+            if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
         }
     }
 
@@ -194,39 +211,22 @@ object PathFinder {
         nodeId: NodeId,
         state: SearchState,
         options: SearchOptions,
-        expansionMemo: LinkedHashMap<Int, ExpansionRecord>,
-        blockedAncestors: MutableSet<Int>
+        deadSuffixMemo: LinkedHashMap<ExpansionKey, Unit>,
+        parentFrame: SearchFrame
     ): SearchFrame? {
         if (hasAncestor(state.parent, nodeId)) {
-            blockedAncestors.add(nodeId.value)
+            parentFrame.cycleBlocked = true
             return null
         }
 
+        if (ExpansionKey(nodeId.value, state.depth) in deadSuffixMemo) return null
         val edges = edgesForDirection(graph, nodeId, options).iterator()
         if (!edges.hasNext()) return null
-        val previous = expansionMemo[nodeId.value]
-        if (previous != null &&
-            previous.depth == state.depth &&
-            ancestorIds(state.parent).containsAll(previous.blockedAncestors)
-        ) {
-            blockedAncestors.addAll(previous.blockedAncestors)
-            return null
-        }
         return SearchFrame(state, edges)
     }
 
-    private fun ancestorIds(state: SearchState?): Set<Int> {
-        val ids = mutableSetOf<Int>()
-        var cursor = state
-        while (cursor != null) {
-            ids.add(cursor.node.id.value)
-            cursor = cursor.parent
-        }
-        return ids
-    }
-
     private fun <K, V> rememberBounded(memo: LinkedHashMap<K, V>, key: K, value: V) {
-        if (!memo.containsKey(key) && memo.size >= EXPANSION_MEMO_CAPACITY) {
+        if (!memo.containsKey(key) && memo.size >= DEAD_SUFFIX_MEMO_CAPACITY) {
             val eldest = memo.entries.iterator()
             if (eldest.hasNext()) {
                 eldest.next()
@@ -248,16 +248,19 @@ object PathFinder {
     private data class SearchFrame(
         val state: SearchState,
         val edges: Iterator<Edge>,
-        val blockedAncestors: MutableSet<Int> = mutableSetOf()
+        var foundMatch: Boolean = false,
+        var cycleBlocked: Boolean = false
     )
 
-    private data class ExpansionRecord(
-        val depth: Int,
-        val blockedAncestors: Set<Int>
+    private data class ExpansionKey(
+        val nodeId: Int,
+        val depth: Int
     )
 
     private fun matchesTarget(state: SearchState, options: SearchOptions): Boolean =
-        state.depth >= options.minDepth && (options.targets == null || state.node.id in options.targets)
+        state.depth >= options.minDepth &&
+            (options.targets == null || state.node.id in options.targets) &&
+            (options.nodePredicate?.invoke(state.node) != false)
 
     private fun edgesForDirection(graph: Graph, nodeId: NodeId, options: SearchOptions): Sequence<Edge> =
         when (options.direction) {
@@ -292,5 +295,5 @@ object PathFinder {
 
     enum class Direction { OUTGOING, INCOMING, BOTH }
 
-    private const val EXPANSION_MEMO_CAPACITY = 16_384
+    private const val DEAD_SUFFIX_MEMO_CAPACITY = 16_384
 }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -122,8 +122,10 @@ object PathFinder {
      * search states instead of a complete breadth-first frontier.
      * Nodes already present on the current branch are not expanded again, so cycles terminate without
      * retaining a traversal-wide visited set. A fixed-size memo suppresses reconvergent expansion while
-     * preserving the memory bound; eviction can only cause safe re-expansion. Only the stack's O(maxDepth)
-     * frames retain nodes and parent paths.
+     * recording the ancestors that actually blocked each completed suffix. A revisit is suppressed only
+     * when its ancestor set still contains every prior blocker. This keeps acyclic reconvergence cheap
+     * without dropping a suffix that becomes legal under a different branch. Eviction can only cause safe
+     * re-expansion. Only the stack's O(maxDepth) frames retain nodes and parent paths.
      *
      * Matches keep the graph's edge order within each branch. Cypher does not define a global result
      * order without ORDER BY, so depth-first traversal is safe for the lazy query pipeline while allowing
@@ -134,7 +136,7 @@ object PathFinder {
         startNode: Node,
         options: SearchOptions
     ): Sequence<PathMatch> = sequence {
-        val expandedAtDepth = LinkedHashMap<Int, Int>()
+        val expansionMemo = LinkedHashMap<Int, ExpansionRecord>()
         val start = SearchState(startNode, incomingEdge = null, parent = null, depth = 0)
         if (matchesTarget(start, options)) yield(PathMatch(start))
         if (options.maxDepth <= 0) return@sequence
@@ -142,13 +144,18 @@ object PathFinder {
         val stack = ArrayDeque<SearchFrame>()
         val startEdges = edgesForDirection(graph, startNode.id, options).iterator()
         if (!startEdges.hasNext()) return@sequence
-        rememberExpansion(expandedAtDepth, startNode.id, depth = 0)
         stack.addLast(SearchFrame(start, startEdges))
 
         while (stack.isNotEmpty()) {
             val frame = stack.last()
             if (!frame.edges.hasNext()) {
-                stack.removeLast()
+                val completed = stack.removeLast()
+                rememberBounded(
+                    expansionMemo,
+                    completed.state.node.id.value,
+                    ExpansionRecord(completed.state.depth, completed.blockedAncestors.toSet())
+                )
+                stack.lastOrNull()?.blockedAncestors?.addAll(completed.blockedAncestors)
                 continue
             }
 
@@ -159,7 +166,9 @@ object PathFinder {
             val nextState = SearchState(nextNode, edge, frame.state, frame.state.depth + 1)
             if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
 
-            expandableFrame(graph, nextId, nextState, options, expandedAtDepth)?.let(stack::addLast)
+            val expansion = expandableFrame(graph, nextId, nextState, options, expansionMemo)
+            frame.blockedAncestors.addAll(expansion.blockedAncestors)
+            expansion.frame?.let(stack::addLast)
         }
     }
 
@@ -169,27 +178,44 @@ object PathFinder {
         nodeId: NodeId,
         state: SearchState,
         options: SearchOptions,
-        expandedAtDepth: LinkedHashMap<Int, Int>
-    ): SearchFrame? {
-        if (state.depth >= options.maxDepth || hasAncestor(state.parent, nodeId)) return null
-        val previousDepth = expandedAtDepth[nodeId.value]
-        if (previousDepth != null && previousDepth <= state.depth) return null
+        expansionMemo: LinkedHashMap<Int, ExpansionRecord>
+    ): ExpansionDecision {
+        if (state.depth >= options.maxDepth) return ExpansionDecision()
+        if (hasAncestor(state.parent, nodeId)) {
+            return ExpansionDecision(blockedAncestors = setOf(nodeId.value))
+        }
 
         val edges = edgesForDirection(graph, nodeId, options).iterator()
-        if (!edges.hasNext()) return null
-        rememberExpansion(expandedAtDepth, nodeId, state.depth)
-        return SearchFrame(state, edges)
+        if (!edges.hasNext()) return ExpansionDecision()
+        val previous = expansionMemo[nodeId.value]
+        if (previous != null &&
+            previous.depth == state.depth &&
+            ancestorIds(state.parent).containsAll(previous.blockedAncestors)
+        ) {
+            return ExpansionDecision(blockedAncestors = previous.blockedAncestors)
+        }
+        return ExpansionDecision(frame = SearchFrame(state, edges))
     }
 
-    private fun rememberExpansion(expandedAtDepth: LinkedHashMap<Int, Int>, nodeId: NodeId, depth: Int) {
-        if (!expandedAtDepth.containsKey(nodeId.value) && expandedAtDepth.size >= EXPANSION_MEMO_CAPACITY) {
-            val eldest = expandedAtDepth.entries.iterator()
+    private fun ancestorIds(state: SearchState?): Set<Int> {
+        val ids = mutableSetOf<Int>()
+        var cursor = state
+        while (cursor != null) {
+            ids.add(cursor.node.id.value)
+            cursor = cursor.parent
+        }
+        return ids
+    }
+
+    private fun <K, V> rememberBounded(memo: LinkedHashMap<K, V>, key: K, value: V) {
+        if (!memo.containsKey(key) && memo.size >= EXPANSION_MEMO_CAPACITY) {
+            val eldest = memo.entries.iterator()
             if (eldest.hasNext()) {
                 eldest.next()
                 eldest.remove()
             }
         }
-        expandedAtDepth[nodeId.value] = depth
+        memo[key] = value
     }
 
     private fun hasAncestor(state: SearchState?, nodeId: NodeId): Boolean {
@@ -203,7 +229,18 @@ object PathFinder {
 
     private data class SearchFrame(
         val state: SearchState,
-        val edges: Iterator<Edge>
+        val edges: Iterator<Edge>,
+        val blockedAncestors: MutableSet<Int> = mutableSetOf()
+    )
+
+    private data class ExpansionDecision(
+        val frame: SearchFrame? = null,
+        val blockedAncestors: Set<Int> = emptySet()
+    )
+
+    private data class ExpansionRecord(
+        val depth: Int,
+        val blockedAncestors: Set<Int>
     )
 
     private fun matchesTarget(state: SearchState, options: SearchOptions): Boolean =

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -18,7 +18,8 @@ object PathFinder {
         val minDepth: Int,
         val maxDepth: Int,
         val direction: Direction,
-        val workTracker: CypherWorkTracker? = null
+        val workTracker: CypherWorkTracker? = null,
+        val edgePredicate: ((Edge) -> Boolean)? = null
     )
 
     internal class SearchState(
@@ -50,7 +51,7 @@ object PathFinder {
     }
 
     /**
-     * Find all paths from source nodes to target nodes via BFS.
+     * Find paths from source nodes to target nodes with a depth-bounded traversal.
      *
      * @param graph The graph to search
      * @param sources Source node IDs to start from
@@ -82,50 +83,72 @@ object PathFinder {
     ): Sequence<PathMatch> = sequence {
         for (source in sources) {
             val startNode = loadNode(graph, source, options.workTracker) ?: continue
-            yieldAll(bfs(graph, startNode, options))
+            yieldAll(depthFirst(graph, startNode, options))
         }
     }
 
-    private fun bfs(
+    /**
+     * Traverse one branch at a time so suspended lazy consumers retain at most [SearchOptions.maxDepth]
+     * search states instead of a complete breadth-first frontier.
+     * The shallowest-depth map grows with expanded node IDs, but does not retain nodes or parent paths;
+     * only the stack's O(maxDepth) frames retain those objects.
+     *
+     * Matches keep the graph's edge order within each branch. Cypher does not define a global result
+     * order without ORDER BY, so depth-first traversal is safe for the lazy query pipeline while allowing
+     * LIMIT to stop before unrelated siblings are loaded.
+     */
+    private fun depthFirst(
         graph: Graph,
         startNode: Node,
         options: SearchOptions
     ): Sequence<PathMatch> = sequence {
-        val visited = mutableSetOf<Int>()
-        val queue = ArrayDeque<SearchState>()
-        queue.add(SearchState(startNode, incomingEdge = null, parent = null, depth = 0))
+        val expandedAtDepth = mutableMapOf<Int, Int>()
+        val start = SearchState(startNode, incomingEdge = null, parent = null, depth = 0)
+        if (matchesTarget(start, options)) yield(PathMatch(start))
+        if (options.maxDepth <= 0) return@sequence
+        expandedAtDepth[startNode.id.value] = 0
 
-        while (queue.isNotEmpty()) {
-            val state = queue.removeFirst()
-            val current = state.node.id
+        val stack = ArrayDeque<SearchFrame>()
+        stack.addLast(SearchFrame(start, edgesForDirection(graph, startNode.id, options).iterator()))
 
-            if (state.depth == 0 && matchesTarget(state, options)) {
-                yield(PathMatch(state))
+        while (stack.isNotEmpty()) {
+            val frame = stack.last()
+            if (!frame.edges.hasNext()) {
+                stack.removeLast()
+                continue
             }
 
-            if (state.depth >= options.maxDepth) continue
-            if (!visited.add(current.value)) continue
+            val edge = frame.edges.next()
+            val current = frame.state.node.id
+            val nextId = nextNodeId(edge, current, options.direction)
+            val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
+            val nextState = SearchState(nextNode, edge, frame.state, frame.state.depth + 1)
+            if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
 
-            val edges = edgesForDirection(graph, current, options)
-            for (edge in edges) {
-                val nextId = nextNodeId(edge, current, options.direction)
-                val nextNode = loadNode(graph, nextId, options.workTracker) ?: continue
-                val nextState = SearchState(nextNode, edge, state, state.depth + 1)
-                if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
-                queue.add(nextState)
+            val previousDepth = expandedAtDepth[nextId.value]
+            if (nextState.depth < options.maxDepth &&
+                (previousDepth == null || nextState.depth < previousDepth)
+            ) {
+                expandedAtDepth[nextId.value] = nextState.depth
+                stack.addLast(SearchFrame(nextState, edgesForDirection(graph, nextId, options).iterator()))
             }
         }
     }
+
+    private data class SearchFrame(
+        val state: SearchState,
+        val edges: Iterator<Edge>
+    )
 
     private fun matchesTarget(state: SearchState, options: SearchOptions): Boolean =
         state.depth >= options.minDepth && (options.targets == null || state.node.id in options.targets)
 
     private fun edgesForDirection(graph: Graph, nodeId: NodeId, options: SearchOptions): Sequence<Edge> =
         when (options.direction) {
-            Direction.OUTGOING -> filteredEdges(graph.outgoing(nodeId), options.edgeType, options.workTracker)
-            Direction.INCOMING -> filteredEdges(graph.incoming(nodeId), options.edgeType, options.workTracker)
-            Direction.BOTH -> filteredEdges(graph.outgoing(nodeId), options.edgeType, options.workTracker) +
-                filteredEdges(graph.incoming(nodeId), options.edgeType, options.workTracker)
+            Direction.OUTGOING -> filteredEdges(graph.outgoing(nodeId), options)
+            Direction.INCOMING -> filteredEdges(graph.incoming(nodeId), options)
+            Direction.BOTH -> filteredEdges(graph.outgoing(nodeId), options) +
+                filteredEdges(graph.incoming(nodeId), options)
         }
 
     private fun nextNodeId(edge: Edge, current: NodeId, direction: Direction): NodeId = when (direction) {
@@ -141,12 +164,13 @@ object PathFinder {
 
     private fun filteredEdges(
         edges: Sequence<Edge>,
-        edgeType: Class<out Edge>?,
-        workTracker: CypherWorkTracker?
+        options: SearchOptions
     ): Sequence<Edge> = sequence {
         for (edge in edges) {
-            workTracker?.consume()
-            if (edgeType == null || edgeType.isInstance(edge)) yield(edge)
+            options.workTracker?.consume()
+            val typeMatches = options.edgeType?.isInstance(edge) != false
+            val predicateMatches = options.edgePredicate?.invoke(edge) != false
+            if (typeMatches && predicateMatches) yield(edge)
         }
     }
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/PathFinder.kt
@@ -121,7 +121,9 @@ object PathFinder {
      * Traverse one branch at a time so suspended lazy consumers retain at most [SearchOptions.maxDepth]
      * search states instead of a complete breadth-first frontier.
      * Nodes already present on the current branch are not expanded again, so cycles terminate without
-     * retaining a traversal-wide visited set. Only the stack's O(maxDepth) frames retain search state.
+     * retaining a traversal-wide visited set. A fixed-size memo suppresses reconvergent expansion while
+     * preserving the memory bound; eviction can only cause safe re-expansion. Only the stack's O(maxDepth)
+     * frames retain nodes and parent paths.
      *
      * Matches keep the graph's edge order within each branch. Cypher does not define a global result
      * order without ORDER BY, so depth-first traversal is safe for the lazy query pipeline while allowing
@@ -132,12 +134,16 @@ object PathFinder {
         startNode: Node,
         options: SearchOptions
     ): Sequence<PathMatch> = sequence {
+        val expandedAtDepth = LinkedHashMap<Int, Int>()
         val start = SearchState(startNode, incomingEdge = null, parent = null, depth = 0)
         if (matchesTarget(start, options)) yield(PathMatch(start))
         if (options.maxDepth <= 0) return@sequence
 
         val stack = ArrayDeque<SearchFrame>()
-        stack.addLast(SearchFrame(start, edgesForDirection(graph, startNode.id, options).iterator()))
+        val startEdges = edgesForDirection(graph, startNode.id, options).iterator()
+        if (!startEdges.hasNext()) return@sequence
+        rememberExpansion(expandedAtDepth, startNode.id, depth = 0)
+        stack.addLast(SearchFrame(start, startEdges))
 
         while (stack.isNotEmpty()) {
             val frame = stack.last()
@@ -153,12 +159,37 @@ object PathFinder {
             val nextState = SearchState(nextNode, edge, frame.state, frame.state.depth + 1)
             if (matchesTarget(nextState, options)) yield(PathMatch(nextState))
 
-            if (nextState.depth < options.maxDepth &&
-                !hasAncestor(frame.state, nextId)
-            ) {
-                stack.addLast(SearchFrame(nextState, edgesForDirection(graph, nextId, options).iterator()))
+            expandableFrame(graph, nextId, nextState, options, expandedAtDepth)?.let(stack::addLast)
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun expandableFrame(
+        graph: Graph,
+        nodeId: NodeId,
+        state: SearchState,
+        options: SearchOptions,
+        expandedAtDepth: LinkedHashMap<Int, Int>
+    ): SearchFrame? {
+        if (state.depth >= options.maxDepth || hasAncestor(state.parent, nodeId)) return null
+        val previousDepth = expandedAtDepth[nodeId.value]
+        if (previousDepth != null && previousDepth <= state.depth) return null
+
+        val edges = edgesForDirection(graph, nodeId, options).iterator()
+        if (!edges.hasNext()) return null
+        rememberExpansion(expandedAtDepth, nodeId, state.depth)
+        return SearchFrame(state, edges)
+    }
+
+    private fun rememberExpansion(expandedAtDepth: LinkedHashMap<Int, Int>, nodeId: NodeId, depth: Int) {
+        if (!expandedAtDepth.containsKey(nodeId.value) && expandedAtDepth.size >= EXPANSION_MEMO_CAPACITY) {
+            val eldest = expandedAtDepth.entries.iterator()
+            if (eldest.hasNext()) {
+                eldest.next()
+                eldest.remove()
             }
         }
+        expandedAtDepth[nodeId.value] = depth
     }
 
     private fun hasAncestor(state: SearchState?, nodeId: NodeId): Boolean {
@@ -210,4 +241,6 @@ object PathFinder {
     }
 
     enum class Direction { OUTGOING, INCOMING, BOTH }
+
+    private const val EXPANSION_MEMO_CAPACITY = 16_384
 }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -12,6 +12,7 @@ import io.johnsonlee.graphite.core.LocalVariable
 import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.core.ResourceEdge
+import io.johnsonlee.graphite.core.ResourceRelation
 import io.johnsonlee.graphite.core.TypeEdge
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.graph.StringPropertyDisjunctionLookupStrategy
@@ -534,7 +535,8 @@ class QueryPipeline private constructor(
 
     private data class RankedProjectedRow(
         val row: MutableMap<String, Any?>,
-        val encounterOrder: Long
+        val encounterOrder: Long,
+        val sortValues: List<Any?> = emptyList()
     )
 
     private data class OrderedPropertyLimitQuery(
@@ -1361,20 +1363,21 @@ class QueryPipeline private constructor(
     }
 
     /**
-     * Streams a filtered MATCH pattern through projection and pagination so
-     * LIMIT bounds retained rows instead of being applied after eager
-     * materialization. DISTINCT retains at most SKIP + LIMIT visible values.
+     * Streams a filtered MATCH pattern through projection, ordering, and pagination so
+     * LIMIT bounds retained rows instead of being applied after eager materialization.
+     * DISTINCT and ORDER BY retain at most SKIP + LIMIT visible values.
      */
     @Suppress("ComplexCondition", "CyclomaticComplexMethod", "MagicNumber", "ReturnCount")
     private fun tryStreamingFilteredMatchLimit(clauses: List<CypherClause>): CypherResult? {
-        if (clauses.size !in 4..5) return null
+        if (clauses.size !in 4..6) return null
         val match = clauses.getOrNull(0) as? CypherClause.Match ?: return null
         val where = clauses.getOrNull(1) as? CypherClause.Where ?: return null
         val ret = clauses.getOrNull(2) as? CypherClause.Return ?: return null
-        val skip = clauses.getOrNull(clauses.lastIndex - 1) as? CypherClause.Skip
-        val limit = clauses.lastOrNull() as? CypherClause.Limit ?: return null
-        if (clauses.size == 5 && skip == null) return null
-        if (clauses.size == 4 && skip != null) return null
+        var suffixIndex = 3
+        val orderBy = (clauses.getOrNull(suffixIndex) as? CypherClause.OrderBy)?.also { suffixIndex++ }
+        val skip = (clauses.getOrNull(suffixIndex) as? CypherClause.Skip)?.also { suffixIndex++ }
+        val limit = clauses.getOrNull(suffixIndex) as? CypherClause.Limit ?: return null
+        if (suffixIndex != clauses.lastIndex) return null
         if (match.optional || match.patterns.size != 1 || match.patterns.single().pathVariable != null ||
             ret.items.any { containsAggregation(it.expression) } ||
             ret.items.any { (it.expression as? CypherExpr.Variable)?.name == "*" }
@@ -1398,6 +1401,17 @@ class QueryPipeline private constructor(
             ?: sources
 
         val matches = matchPatternLazily(pattern, emptyMap(), candidateSources)
+        if (orderBy != null) {
+            return projectOrderedFilteredRows(
+                matches,
+                where,
+                ret,
+                orderBy,
+                columns,
+                skipCount,
+                retainedCount.toInt()
+            )
+        }
         if (ret.distinct) {
             return projectDistinctFilteredRows(matches, where, ret, columns, skipCount, retainedCount.toInt())
         }
@@ -1429,6 +1443,87 @@ class QueryPipeline private constructor(
             if (!qualified && distinctRows.size >= retainedCount) break
         }
         return CypherResult(columns, distinctRows.values.drop(skipCount))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun projectOrderedFilteredRows(
+        matches: Sequence<Map<String, Any?>>,
+        where: CypherClause.Where,
+        ret: CypherClause.Return,
+        orderBy: CypherClause.OrderBy,
+        columns: List<String>,
+        skipCount: Int,
+        retainedCount: Int
+    ): CypherResult {
+        val comparator = rankedRowComparator(orderBy)
+        val topRows = PriorityQueue<RankedProjectedRow>(comparator.reversed())
+        val selectedDistinctRows = if (ret.distinct) {
+            HashMap<Map<String, Any?>, RankedProjectedRow>()
+        } else {
+            null
+        }
+        var encounterOrder = 0L
+
+        for (bindings in matches) {
+            if (evaluator.evaluate(where.condition, bindings) != true) continue
+            val projected = projectRow(ret.items, columns, bindings)
+            val visible = selectedDistinctRows?.let { projected.filterKeys { key -> key != INTERNAL_PROVENANCE_KEY } }
+            val existing = visible?.let { selectedDistinctRows?.get(it) }
+            if (existing != null) {
+                val graphIds = (existing.row[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty() +
+                    (projected[INTERNAL_PROVENANCE_KEY] as? Set<String>).orEmpty()
+                if (graphIds.isNotEmpty()) existing.row[INTERNAL_PROVENANCE_KEY] = graphIds
+                encounterOrder++
+                continue
+            }
+
+            val ranked = RankedProjectedRow(
+                row = projected,
+                encounterOrder = encounterOrder++,
+                sortValues = evaluateOrderValues(orderBy, bindings, projected)
+            )
+            if (topRows.size < retainedCount) {
+                topRows.add(ranked)
+                if (visible != null) selectedDistinctRows?.put(visible, ranked)
+            } else if (comparator.compare(ranked, topRows.peek()) < 0) {
+                val removed = topRows.poll()
+                selectedDistinctRows?.remove(removed.row.filterKeys { it != INTERNAL_PROVENANCE_KEY })
+                topRows.add(ranked)
+                if (visible != null) selectedDistinctRows?.put(visible, ranked)
+            }
+        }
+        checkCancelled()
+
+        val rows = topRows.toList()
+            .sortedWith(comparator)
+            .drop(skipCount)
+            .map(RankedProjectedRow::row)
+        return CypherResult(columns, rows)
+    }
+
+    private fun rankedRowComparator(orderBy: CypherClause.OrderBy): Comparator<RankedProjectedRow> {
+        var comparisons = 0
+        return Comparator { left, right ->
+            if (workTrackingEnabled) pollCancellation(comparisons++)
+            for ((index, item) in orderBy.items.withIndex()) {
+                val leftValue = left.sortValues[index]
+                val rightValue = right.sortValues[index]
+                val comparison = compareNullable(leftValue, rightValue)
+                if (comparison != 0) {
+                    return@Comparator if (item.ascending) comparison else -comparison
+                }
+            }
+            left.encounterOrder.compareTo(right.encounterOrder)
+        }
+    }
+
+    private fun evaluateOrderValues(
+        orderBy: CypherClause.OrderBy,
+        bindings: Map<String, Any?>,
+        projected: Map<String, Any?>
+    ): List<Any?> {
+        val orderContext = bindings.toMutableMap().apply { putAll(projected) }
+        return orderBy.items.map { item -> evaluateOrderValue(item.expression, orderContext) }
     }
 
     /**
@@ -1519,7 +1614,7 @@ class QueryPipeline private constructor(
         items: List<ReturnItem>,
         columns: List<String>,
         bindings: Map<String, Any?>
-    ): Map<String, Any?> {
+    ): MutableMap<String, Any?> {
         val projected = mutableMapOf<String, Any?>()
         for (i in items.indices) {
             projected[columns[i]] = evaluator.evaluate(items[i].expression, bindings)
@@ -1968,9 +2063,8 @@ class QueryPipeline private constructor(
         bindings: Map<String, Any?>
     ): Boolean {
         if (rel.types.isNotEmpty()) {
-            val edgeTypeName = CypherFunctions.type(edge)
             val typeMatches = rel.types.any { requested ->
-                matchesRelationshipType(edge, edgeTypeName, requested)
+                matchesRelationshipType(edge, requested)
             }
             if (!typeMatches) {
                 return false
@@ -1995,10 +2089,32 @@ class QueryPipeline private constructor(
         }
     }
 
-    private fun matchesRelationshipType(edge: Edge, actual: String?, requested: String): Boolean =
-        requested.equals(actual, ignoreCase = true) ||
-            requested.replace("_", "").equals(actual?.replace("_", ""), ignoreCase = true) ||
-            (edge is ResourceEdge && requested.equals("RESOURCE", ignoreCase = true))
+    /**
+     * Matches only the relationship spellings that are part of the Cypher surface.
+     *
+     * Keep the aliases explicit: removing every underscore made malformed names
+     * such as `D_A_T_A_F_L_O_W` indistinguishable from `DATAFLOW` and allocated
+     * normalized strings for every candidate edge.
+     */
+    private fun matchesRelationshipType(edge: Edge, requested: String): Boolean = when (edge) {
+        is DataFlowEdge ->
+            requested.equals("DATAFLOW", ignoreCase = true) ||
+                requested.equals("DATA_FLOW", ignoreCase = true)
+        is CallEdge -> requested.equals("CALL", ignoreCase = true)
+        is TypeEdge -> requested.equals("TYPE", ignoreCase = true)
+        is ControlFlowEdge ->
+            requested.equals("CONTROL_FLOW", ignoreCase = true) ||
+                requested.equals("CONTROLFLOW", ignoreCase = true)
+        is ResourceEdge ->
+            requested.equals("RESOURCE", ignoreCase = true) || when (edge.kind) {
+                ResourceRelation.OPENS -> requested.equals("RESOURCE_OPEN", ignoreCase = true)
+                ResourceRelation.LOADS -> requested.equals("RESOURCE_LOAD", ignoreCase = true)
+                ResourceRelation.BUNDLE_CANDIDATE ->
+                    requested.equals("RESOURCE_BUNDLE_CANDIDATE", ignoreCase = true)
+                ResourceRelation.LOOKUP -> requested.equals("RESOURCE_LOOKUP", ignoreCase = true)
+                ResourceRelation.ENUMERATES -> requested.equals("RESOURCE_KEYS", ignoreCase = true)
+            }
+    }
 
     // ========================================================================
     // Graph traversal helpers

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -1917,11 +1917,13 @@ class QueryPipeline private constructor(
             ?.let(::nodeCursor)
             ?: findLastBoundNode(bindings)
             ?: return emptySequence()
-        val edgeClass = rel.types.singleOrNull()?.let { NodePropertyAccessor.resolveEdgeType(it) }
-        return if (rel.variableLength) {
-            matchVariableLengthPathLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
-        } else {
-            matchSingleHopLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
+        val resolvedEdgeTypes = rel.types.mapNotNull(NodePropertyAccessor::resolveEdgeType).distinct()
+        val edgeClass = resolvedEdgeTypes.singleOrNull()
+        return when {
+            rel.types.isNotEmpty() && resolvedEdgeTypes.isEmpty() -> emptySequence()
+            rel.variableLength ->
+                matchVariableLengthPathLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
+            else -> matchSingleHopLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
         }
     }
 
@@ -1976,7 +1978,8 @@ class QueryPipeline private constructor(
                 minDepth = rel.minHops ?: 1,
                 maxDepth = rel.maxHops ?: 10,
                 direction = direction,
-                workTracker = workTracker
+                workTracker = workTracker,
+                edgePredicate = { edge -> matchesRelConstraints(edge, rel, bindings) }
             )
         )
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -1400,7 +1400,12 @@ class QueryPipeline private constructor(
             ?.let { graphId -> sources.filter { it.id == graphId } }
             ?: sources
 
-        val matches = matchPatternLazily(pattern, emptyMap(), candidateSources)
+        val matches = matchPatternLazily(
+            pattern,
+            emptyMap(),
+            candidateSources,
+            finalResultPredicate = { bindings -> evaluator.evaluate(where.condition, bindings) == true }
+        )
         if (orderBy != null) {
             return projectOrderedFilteredRows(
                 matches,
@@ -1728,7 +1733,8 @@ class QueryPipeline private constructor(
     private fun matchPatternLazily(
         pattern: CypherPattern,
         existingBindings: Map<String, Any?>,
-        candidateSources: List<CypherGraph> = sources
+        candidateSources: List<CypherGraph> = sources,
+        finalResultPredicate: ((Map<String, Any?>) -> Boolean)? = null
     ): Sequence<Map<String, Any?>> {
         val elements = pattern.elements
         if (elements.isEmpty()) return sequenceOf(existingBindings)
@@ -1744,8 +1750,9 @@ class QueryPipeline private constructor(
             val sourceNode = elements[i - 1] as PatternElement.NodePattern
             val rel = elements[i] as PatternElement.RelationshipPattern
             val targetNode = elements[i + 1] as PatternElement.NodePattern
+            val resultPredicate = finalResultPredicate.takeIf { i + 1 == elements.lastIndex }
             currentMatches = currentMatches.flatMap { bindings ->
-                matchRelationshipLazily(sourceNode, rel, targetNode, bindings)
+                matchRelationshipLazily(sourceNode, rel, targetNode, bindings, resultPredicate)
             }
             i += 2
         }
@@ -1910,7 +1917,8 @@ class QueryPipeline private constructor(
         sourceNodePattern: PatternElement.NodePattern,
         rel: PatternElement.RelationshipPattern,
         targetNodePattern: PatternElement.NodePattern,
-        bindings: Map<String, Any?>
+        bindings: Map<String, Any?>,
+        resultPredicate: ((Map<String, Any?>) -> Boolean)? = null
     ): Sequence<Map<String, Any?>> {
         val sourceNode = sourceNodePattern.variable
             ?.let(bindings::get)
@@ -1922,7 +1930,14 @@ class QueryPipeline private constructor(
         return when {
             rel.types.isNotEmpty() && resolvedEdgeTypes.isEmpty() -> emptySequence()
             rel.variableLength ->
-                matchVariableLengthPathLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
+                matchVariableLengthPathLazily(
+                    rel,
+                    targetNodePattern,
+                    sourceNode,
+                    bindings,
+                    edgeClass,
+                    resultPredicate
+                )
             else -> matchSingleHopLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
         }
     }
@@ -1960,7 +1975,8 @@ class QueryPipeline private constructor(
         targetNodePattern: PatternElement.NodePattern,
         sourceNode: NodeCursor,
         bindings: Map<String, Any?>,
-        edgeClass: Class<out Edge>?
+        edgeClass: Class<out Edge>?,
+        resultPredicate: ((Map<String, Any?>) -> Boolean)?
     ): Sequence<Map<String, Any?>> = sequence {
         val direction = when (rel.direction) {
             Direction.OUTGOING -> PathFinder.Direction.OUTGOING
@@ -1969,6 +1985,15 @@ class QueryPipeline private constructor(
         }
 
         val workTracker = if (workTrackingEnabled) activeWorkTracker.get() else null
+        val nodePredicate = if (resultPredicate != null && rel.variable == null) {
+            { node: Node ->
+                val endValue = nodeValue(sourceNode.source, node)
+                val targetMatch = matchTargetNode(targetNodePattern, endValue, bindings)
+                targetMatch != null && resultPredicate(targetMatch)
+            }
+        } else {
+            null
+        }
         val paths = PathFinder.findPathMatches(
             graph = sourceNode.source.graph,
             sources = setOf(sourceNode.node.id),
@@ -1979,7 +2004,8 @@ class QueryPipeline private constructor(
                 maxDepth = rel.maxHops ?: 10,
                 direction = direction,
                 workTracker = workTracker,
-                edgePredicate = { edge -> matchesRelConstraints(edge, rel, bindings) }
+                edgePredicate = { edge -> matchesRelConstraints(edge, rel, bindings) },
+                nodePredicate = nodePredicate
             )
         )
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -1985,15 +1985,13 @@ class QueryPipeline private constructor(
         }
 
         val workTracker = if (workTrackingEnabled) activeWorkTracker.get() else null
-        val nodePredicate = if (resultPredicate != null && rel.variable == null) {
-            { node: Node ->
-                val endValue = nodeValue(sourceNode.source, node)
-                val targetMatch = matchTargetNode(targetNodePattern, endValue, bindings)
-                targetMatch != null && resultPredicate(targetMatch)
-            }
-        } else {
-            null
-        }
+        val nodePredicate = variablePathNodePredicate(
+            rel,
+            targetNodePattern,
+            sourceNode,
+            bindings,
+            resultPredicate
+        )
         val paths = PathFinder.findPathMatches(
             graph = sourceNode.source.graph,
             sources = setOf(sourceNode.node.id),
@@ -2030,6 +2028,29 @@ class QueryPipeline private constructor(
                 addProvenance(newBindings, pathValue)
             }
             yield(newBindings)
+        }
+    }
+
+    private fun variablePathNodePredicate(
+        rel: PatternElement.RelationshipPattern,
+        targetNodePattern: PatternElement.NodePattern,
+        sourceNode: NodeCursor,
+        bindings: Map<String, Any?>,
+        resultPredicate: ((Map<String, Any?>) -> Boolean)?
+    ): ((Node) -> Boolean)? {
+        val targetNeedsFiltering = targetNodePattern.labels.isNotEmpty() ||
+            targetNodePattern.properties.isNotEmpty() ||
+            targetNodePattern.variable?.let(bindings::containsKey) == true
+        val canPushResultPredicate = resultPredicate != null && rel.variable == null
+        return if (targetNeedsFiltering || canPushResultPredicate) {
+            { node: Node ->
+                val endValue = nodeValue(sourceNode.source, node)
+                val targetMatch = matchTargetNode(targetNodePattern, endValue, bindings)
+                targetMatch != null &&
+                    (!canPushResultPredicate || resultPredicate?.invoke(targetMatch) == true)
+            }
+        } else {
+            null
         }
     }
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -1970,8 +1970,7 @@ class QueryPipeline private constructor(
         if (rel.types.isNotEmpty()) {
             val edgeTypeName = CypherFunctions.type(edge)
             val typeMatches = rel.types.any { requested ->
-                requested.equals(edgeTypeName, ignoreCase = true) ||
-                    (edge is ResourceEdge && requested.equals("RESOURCE", ignoreCase = true))
+                matchesRelationshipType(edge, edgeTypeName, requested)
             }
             if (!typeMatches) {
                 return false
@@ -1995,6 +1994,11 @@ class QueryPipeline private constructor(
             edgeValue == exprValue
         }
     }
+
+    private fun matchesRelationshipType(edge: Edge, actual: String?, requested: String): Boolean =
+        requested.equals(actual, ignoreCase = true) ||
+            requested.replace("_", "").equals(actual?.replace("_", ""), ignoreCase = true) ||
+            (edge is ResourceEdge && requested.equals("RESOURCE", ignoreCase = true))
 
     // ========================================================================
     // Graph traversal helpers

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -197,6 +197,7 @@ class QueryPipeline private constructor(
             ?: tryFastOrderedPropertyLimit(clauses)
             ?: tryFastDistinctPropertyLimit(clauses)
             ?: tryFastFilteredNodeLimit(clauses)
+            ?: tryStreamingFilteredMatchLimit(clauses)
             ?: tryFastSingleHopRelationshipLimit(clauses)
         if (fastResult != null) return fastResult
 
@@ -1360,16 +1361,82 @@ class QueryPipeline private constructor(
     }
 
     /**
+     * Streams a filtered MATCH pattern through projection and pagination so
+     * LIMIT bounds retained rows instead of being applied after eager
+     * materialization. DISTINCT retains at most SKIP + LIMIT visible values.
+     */
+    @Suppress("ComplexCondition", "CyclomaticComplexMethod", "MagicNumber", "ReturnCount")
+    private fun tryStreamingFilteredMatchLimit(clauses: List<CypherClause>): CypherResult? {
+        if (clauses.size !in 4..5) return null
+        val match = clauses.getOrNull(0) as? CypherClause.Match ?: return null
+        val where = clauses.getOrNull(1) as? CypherClause.Where ?: return null
+        val ret = clauses.getOrNull(2) as? CypherClause.Return ?: return null
+        val skip = clauses.getOrNull(clauses.lastIndex - 1) as? CypherClause.Skip
+        val limit = clauses.lastOrNull() as? CypherClause.Limit ?: return null
+        if (clauses.size == 5 && skip == null) return null
+        if (clauses.size == 4 && skip != null) return null
+        if (match.optional || match.patterns.size != 1 || match.patterns.single().pathVariable != null ||
+            ret.items.any { containsAggregation(it.expression) } ||
+            ret.items.any { (it.expression as? CypherExpr.Variable)?.name == "*" }
+        ) {
+            return null
+        }
+
+        val limitCount = literalLimitCount(limit.count) ?: return null
+        val skipCount = skip?.count?.let(::literalLimitCount) ?: 0
+        if (skipCount < 0) return null
+        val columns = ret.items.map { it.alias ?: it.expression.toCypherString() }
+        if (limitCount <= 0) return CypherResult(columns, emptyList())
+        val retainedCount = skipCount.toLong() + limitCount
+        if (retainedCount > Int.MAX_VALUE) return null
+
+        val pattern = match.patterns.single()
+        val firstNode = pattern.elements.firstOrNull() as? PatternElement.NodePattern
+        val candidateSources = firstNode?.variable
+            ?.let { variable -> graphIdEquality(where.condition, variable) }
+            ?.let { graphId -> sources.filter { it.id == graphId } }
+            ?: sources
+
+        val matches = matchPatternLazily(pattern, emptyMap(), candidateSources)
+        if (ret.distinct) {
+            return projectDistinctFilteredRows(matches, where, ret, columns, skipCount, retainedCount.toInt())
+        }
+
+        val rows = mutableListOf<Map<String, Any?>>()
+        var matchedRows = 0
+        for (bindings in matches) {
+            if (evaluator.evaluate(where.condition, bindings) != true) continue
+            if (matchedRows++ < skipCount) continue
+            rows.add(projectRow(ret.items, columns, bindings))
+            if (rows.size >= limitCount) break
+        }
+        return CypherResult(columns, rows)
+    }
+
+    private fun projectDistinctFilteredRows(
+        matches: Sequence<Map<String, Any?>>,
+        where: CypherClause.Where,
+        ret: CypherClause.Return,
+        columns: List<String>,
+        skipCount: Int,
+        retainedCount: Int
+    ): CypherResult {
+        val distinctRows = LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>()
+        for (bindings in matches) {
+            if (evaluator.evaluate(where.condition, bindings) != true) continue
+            val projected = projectRow(ret.items, columns, bindings)
+            addDistinctRow(distinctRows, projected, retainedCount)
+            if (!qualified && distinctRows.size >= retainedCount) break
+        }
+        return CypherResult(columns, distinctRows.values.drop(skipCount))
+    }
+
+    /**
      * Fast path for:
      *
      *   MATCH (a:Source)-[:TYPE]->(b:Target) RETURN ... LIMIT k
-     *
-     * The generic pipeline materializes node and relationship intermediates.
-     * For a single non-variable-length hop without filtering/reordering clauses,
-     * we can stream complete relationship matches and stop once LIMIT rows have
-     * been projected.
      */
-    @Suppress("CyclomaticComplexMethod", "ComplexCondition", "ReturnCount")
+    @Suppress("ComplexCondition", "CyclomaticComplexMethod", "ReturnCount")
     private fun tryFastSingleHopRelationshipLimit(clauses: List<CypherClause>): CypherResult? {
         if (clauses.size != SINGLE_HOP_LIMIT_QUERY_CLAUSES) return null
         val match = clauses[0] as? CypherClause.Match ?: return null
@@ -1413,13 +1480,39 @@ class QueryPipeline private constructor(
                 val targetBindings = matchTargetNode(targetPattern, targetValue, sourceBindings) ?: continue
 
                 val bindings = targetBindings.toMutableMap()
-                if (rel.variable != null) bindings[rel.variable] = edge.value
+                if (rel.variable != null) {
+                    bindings[rel.variable] = edge.value
+                    addProvenance(bindings, edge.value)
+                }
                 rows.add(projectRow(ret.items, columns, bindings))
                 if (rows.size >= limitCount) return CypherResult(columns, rows)
             }
         }
 
         return CypherResult(columns, rows)
+    }
+
+    private fun graphIdEquality(expression: CypherExpr, variable: String): String? = when (expression) {
+        is CypherExpr.And -> graphIdEquality(expression.left, variable)
+            ?: graphIdEquality(expression.right, variable)
+        is CypherExpr.Comparison -> if (expression.op == "=") {
+            when {
+                isGraphIdReference(expression.left, variable) ->
+                    (expression.right as? CypherExpr.Literal)?.value as? String
+                isGraphIdReference(expression.right, variable) ->
+                    (expression.left as? CypherExpr.Literal)?.value as? String
+                else -> null
+            }
+        } else null
+        else -> null
+    }
+
+    private fun isGraphIdReference(expression: CypherExpr, variable: String): Boolean = when (expression) {
+        is CypherExpr.Property -> expression.expression == CypherExpr.Variable(variable) &&
+            expression.propertyName == GRAPH_ID_PROPERTY
+        is CypherExpr.FunctionCall -> expression.name.equals("graphId", ignoreCase = true) &&
+            !expression.distinct && expression.args.singleOrNull() == CypherExpr.Variable(variable)
+        else -> false
     }
 
     private fun projectRow(
@@ -1508,12 +1601,19 @@ class QueryPipeline private constructor(
     ): List<Map<String, Any?>> {
         val elements = pattern.elements
         if (elements.isEmpty()) return listOf(existingBindings)
-
-        val matches = if (limit != null && elements.size > 1) {
-            matchPatternLazily(elements, existingBindings, limit)
-        } else {
-            matchPatternEagerly(elements, existingBindings, limit)
+        if (limit != null) {
+            val matches = matchPatternLazily(pattern.copy(pathVariable = null), existingBindings).take(limit)
+            val pathVariable = pattern.pathVariable ?: return matches.toList()
+            return matches.map { bindings ->
+                val path = buildPathRepresentation(pattern, bindings)
+                bindings.toMutableMap().apply {
+                    this[pathVariable] = path
+                    addProvenance(this, path)
+                }
+            }.toList()
         }
+
+        val matches = matchPatternEagerly(elements, existingBindings, limit = null)
 
         // If the pattern has a path variable, bind it to the matched path
         if (pattern.pathVariable != null) {
@@ -1529,6 +1629,34 @@ class QueryPipeline private constructor(
         return matches
     }
 
+    @Suppress("ReturnCount")
+    private fun matchPatternLazily(
+        pattern: CypherPattern,
+        existingBindings: Map<String, Any?>,
+        candidateSources: List<CypherGraph> = sources
+    ): Sequence<Map<String, Any?>> {
+        val elements = pattern.elements
+        if (elements.isEmpty()) return sequenceOf(existingBindings)
+        require(pattern.pathVariable == null) { "Named paths require materialized path reconstruction" }
+
+        var currentMatches: Sequence<Map<String, Any?>> = matchNodeElementLazily(
+            elements[0] as PatternElement.NodePattern,
+            existingBindings,
+            candidateSources
+        )
+        var i = 1
+        while (i < elements.size) {
+            val sourceNode = elements[i - 1] as PatternElement.NodePattern
+            val rel = elements[i] as PatternElement.RelationshipPattern
+            val targetNode = elements[i + 1] as PatternElement.NodePattern
+            currentMatches = currentMatches.flatMap { bindings ->
+                matchRelationshipLazily(sourceNode, rel, targetNode, bindings)
+            }
+            i += 2
+        }
+        return currentMatches
+    }
+
     private fun matchPatternEagerly(
         elements: List<PatternElement>,
         existingBindings: Map<String, Any?>,
@@ -1538,44 +1666,19 @@ class QueryPipeline private constructor(
 
         var i = 1
         while (i < elements.size) {
+            val sourceNode = elements[i - 1] as PatternElement.NodePattern
             val rel = elements[i] as PatternElement.RelationshipPattern
             val targetNode = elements[i + 1] as PatternElement.NodePattern
             i += 2
 
             val nextMatches = mutableListOf<Map<String, Any?>>()
             for (bindings in currentMatches) {
-                nextMatches.addAll(matchRelationship(rel, targetNode, bindings, limit = null))
+                nextMatches.addAll(matchRelationship(sourceNode, rel, targetNode, bindings, limit = null))
             }
             currentMatches = nextMatches
         }
 
         return currentMatches
-    }
-
-    private fun matchPatternLazily(
-        elements: List<PatternElement>,
-        existingBindings: Map<String, Any?>,
-        limit: Int
-    ): List<Map<String, Any?>> {
-        var currentMatches = matchNodeElementLazily(
-            elements[0] as PatternElement.NodePattern,
-            existingBindings
-        )
-
-        var i = 1
-        while (i < elements.size) {
-            val rel = elements[i] as PatternElement.RelationshipPattern
-            val targetNode = elements[i + 1] as PatternElement.NodePattern
-            i += 2
-
-            val relationshipLimit = limit.takeIf { i >= elements.size }
-            val nextMatches = currentMatches.flatMap { bindings ->
-                matchRelationship(rel, targetNode, bindings, relationshipLimit).asSequence()
-            }
-            currentMatches = relationshipLimit?.let(nextMatches::take) ?: nextMatches
-        }
-
-        return currentMatches.toList()
     }
 
     /**
@@ -1651,13 +1754,15 @@ class QueryPipeline private constructor(
 
     private fun matchNodeElementLazily(
         nodePattern: PatternElement.NodePattern,
-        existingBindings: Map<String, Any?>
-    ): Sequence<Map<String, Any?>> = nodeElementCandidates(nodePattern, existingBindings)
+        existingBindings: Map<String, Any?>,
+        candidateSources: List<CypherGraph> = sources
+    ): Sequence<Map<String, Any?>> = nodeElementCandidates(nodePattern, existingBindings, candidateSources)
         .mapNotNull { candidate -> bindNodeCandidate(candidate, nodePattern, existingBindings) }
 
     private fun nodeElementCandidates(
         nodePattern: PatternElement.NodePattern,
-        existingBindings: Map<String, Any?>
+        existingBindings: Map<String, Any?>,
+        candidateSources: List<CypherGraph> = sources
     ): Sequence<Any> {
         val nodeClass = nodePattern.labels.firstOrNull()
             ?.let { NodePropertyAccessor.resolveNodeLabel(it) }
@@ -1674,7 +1779,7 @@ class QueryPipeline private constructor(
                 emptySequence()
             }
         } else {
-            nodeCandidates(nodeClass)
+            nodeCandidates(nodeClass, candidateSources)
         }
     }
 
@@ -1696,36 +1801,42 @@ class QueryPipeline private constructor(
      * Match a relationship + target node from the current source node binding.
      */
     private fun matchRelationship(
+        sourceNodePattern: PatternElement.NodePattern,
         rel: PatternElement.RelationshipPattern,
         targetNodePattern: PatternElement.NodePattern,
         bindings: Map<String, Any?>,
         limit: Int?
     ): List<Map<String, Any?>> {
-        val results = mutableListOf<Map<String, Any?>>()
-
-        // The source node is the last-bound node in the current bindings.
-        val sourceNode = findLastBoundNode(bindings) ?: return results
-
-        val edgeClass = rel.types.firstOrNull()?.let { NodePropertyAccessor.resolveEdgeType(it) }
-
-        if (rel.variableLength) {
-            matchVariableLengthPath(rel, targetNodePattern, sourceNode, bindings, edgeClass, limit, results)
-        } else {
-            matchSingleHop(rel, targetNodePattern, sourceNode, bindings, edgeClass, limit, results)
-        }
-
-        return results
+        val matches = matchRelationshipLazily(sourceNodePattern, rel, targetNodePattern, bindings)
+        return (limit?.let(matches::take) ?: matches).toList()
     }
 
-    private fun matchSingleHop(
+    private fun matchRelationshipLazily(
+        sourceNodePattern: PatternElement.NodePattern,
+        rel: PatternElement.RelationshipPattern,
+        targetNodePattern: PatternElement.NodePattern,
+        bindings: Map<String, Any?>
+    ): Sequence<Map<String, Any?>> {
+        val sourceNode = sourceNodePattern.variable
+            ?.let(bindings::get)
+            ?.let(::nodeCursor)
+            ?: findLastBoundNode(bindings)
+            ?: return emptySequence()
+        val edgeClass = rel.types.singleOrNull()?.let { NodePropertyAccessor.resolveEdgeType(it) }
+        return if (rel.variableLength) {
+            matchVariableLengthPathLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
+        } else {
+            matchSingleHopLazily(rel, targetNodePattern, sourceNode, bindings, edgeClass)
+        }
+    }
+
+    private fun matchSingleHopLazily(
         rel: PatternElement.RelationshipPattern,
         targetNodePattern: PatternElement.NodePattern,
         sourceNode: NodeCursor,
         bindings: Map<String, Any?>,
-        edgeClass: Class<out Edge>?,
-        limit: Int?,
-        results: MutableList<Map<String, Any?>>
-    ) {
+        edgeClass: Class<out Edge>?
+    ): Sequence<Map<String, Any?>> = sequence {
         val edges = edgesForDirection(sourceNode, rel.direction, edgeClass)
 
         for (edge in edges) {
@@ -1743,20 +1854,17 @@ class QueryPipeline private constructor(
                 newBindings[rel.variable] = edge.value
                 addProvenance(newBindings, edge.value)
             }
-            results.add(newBindings)
-            if (limit != null && results.size >= limit) break
+            yield(newBindings)
         }
     }
 
-    private fun matchVariableLengthPath(
+    private fun matchVariableLengthPathLazily(
         rel: PatternElement.RelationshipPattern,
         targetNodePattern: PatternElement.NodePattern,
         sourceNode: NodeCursor,
         bindings: Map<String, Any?>,
-        edgeClass: Class<out Edge>?,
-        limit: Int?,
-        results: MutableList<Map<String, Any?>>
-    ) {
+        edgeClass: Class<out Edge>?
+    ): Sequence<Map<String, Any?>> = sequence {
         val direction = when (rel.direction) {
             Direction.OUTGOING -> PathFinder.Direction.OUTGOING
             Direction.INCOMING -> PathFinder.Direction.INCOMING
@@ -1797,8 +1905,7 @@ class QueryPipeline private constructor(
                 newBindings[rel.variable] = pathValue
                 addProvenance(newBindings, pathValue)
             }
-            results.add(newBindings)
-            if (limit != null && results.size >= limit) break
+            yield(newBindings)
         }
     }
 
@@ -1939,9 +2046,12 @@ class QueryPipeline private constructor(
         return last
     }
 
-    private fun <T : Node> nodeCandidates(type: Class<T>): Sequence<Any> =
+    private fun <T : Node> nodeCandidates(
+        type: Class<T>,
+        candidateSources: List<CypherGraph> = sources
+    ): Sequence<Any> =
         if (qualified) {
-            sources.asSequence().flatMap { source ->
+            candidateSources.asSequence().flatMap { source ->
                 trackWork(source.graph.nodes(type)).map { node -> QualifiedNode(source.id, source.graph, node) }
             }
         } else {

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -201,6 +201,50 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `filtered relationship graph id pruning recognizes equivalent predicates`() {
+        val orders = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId(1), 10))
+            .addNode(IntConstant(NodeId(2), 20))
+            .addEdge(DataFlowEdge(NodeId(1), NodeId(2), DataFlowKind.ASSIGN))
+            .build()
+        val executor = executor("billing" to graph(IntConstant(NodeId(1), 30)), "orders" to orders)
+        val predicates = listOf(
+            "'orders' = c.graphId",
+            "graphId(c) = 'orders'",
+            "c.graphId <> 'billing'",
+            "true"
+        )
+
+        for (predicate in predicates) {
+            val result = executor.execute(
+                "MATCH (c)-[:DATAFLOW]->(n) WHERE $predicate " +
+                    "RETURN c.graphId AS graph, n.value AS value LIMIT 1"
+            )
+
+            assertEquals("orders", result.rows.single()["graph"])
+            assertEquals(20, result.rows.single()["value"])
+        }
+    }
+
+    @Test
+    fun `filtered distinct relationship limit merges graph provenance`() {
+        fun dataFlowGraph(): Graph = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId(1), 10))
+            .addNode(IntConstant(NodeId(2), 20))
+            .addEdge(DataFlowEdge(NodeId(1), NodeId(2), DataFlowKind.ASSIGN))
+            .build()
+        val executor = executor("billing" to dataFlowGraph(), "orders" to dataFlowGraph())
+
+        val result = executor.execute(
+            "MATCH (c)-[:DATAFLOW]->(n) WHERE n.value = 20 " +
+                "RETURN DISTINCT n.value AS value LIMIT 1"
+        )
+
+        assertEquals(20, result.rows.single()["value"])
+        assertEquals(listOf("billing", "orders"), graphIds(result.rows.single()).sorted())
+    }
+
+    @Test
     fun `aggregates once across all selected graphs and retains contributors`() {
         val executor = executor(
             "orders" to graph(IntConstant(NodeId(1), 10), IntConstant(NodeId(2), 20)),

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -174,6 +174,33 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `filtered relationship limit scopes an exact graph id before traversal`() {
+        val orders = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId(1), 10))
+            .addNode(IntConstant(NodeId(2), 20))
+            .addEdge(DataFlowEdge(NodeId(1), NodeId(2), DataFlowKind.ASSIGN))
+            .build()
+        val billing = graph(IntConstant(NodeId(1), 30))
+        val unreadableBilling = object : Graph by billing {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                error("Graph-id equality must prune unrelated graphs")
+        }
+        val executor = executor("billing" to unreadableBilling, "orders" to orders)
+
+        val result = executor.execute(
+            "MATCH (c)-[r:DATAFLOW]->(n) " +
+                "WHERE c.graphId = 'orders' AND c.value = 10 " +
+                "RETURN c.graphId AS graph, c.value AS source, n.value AS target, r.kind AS kind LIMIT 1"
+        )
+
+        assertEquals("orders", result.rows.single()["graph"])
+        assertEquals(10, result.rows.single()["source"])
+        assertEquals(20, result.rows.single()["target"])
+        assertEquals("ASSIGN", result.rows.single()["kind"])
+        assertEquals(listOf("orders"), graphIds(result.rows.single()))
+    }
+
+    @Test
     fun `aggregates once across all selected graphs and retains contributors`() {
         val executor = executor(
             "orders" to graph(IntConstant(NodeId(1), 10), IntConstant(NodeId(2), 20)),

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -740,6 +740,16 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `filtered variable path evaluates where after binding relationship variable`() {
+        val result = CypherExecutor(dataFlowChain(length = 1)).execute(
+            "MATCH (a:IntConstant)-[r:DATAFLOW*1..1]->(b:LocalVariable) " +
+                "WHERE r IS NOT NULL RETURN b.name AS name LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("name" to "local-0")), result.rows)
+    }
+
+    @Test
     fun `filtered distinct relationship pagination retains only the requested window`() {
         val owner = TypeDescriptor("com.example.StreamingDistinct")
         val valueType = TypeDescriptor("int")

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -4,6 +4,8 @@ import io.johnsonlee.graphite.core.AnnotationNode
 import io.johnsonlee.graphite.core.BooleanConstant
 import io.johnsonlee.graphite.core.CallEdge
 import io.johnsonlee.graphite.core.CallSiteNode
+import io.johnsonlee.graphite.core.ControlFlowEdge
+import io.johnsonlee.graphite.core.ControlFlowKind
 import io.johnsonlee.graphite.core.DataFlowEdge
 import io.johnsonlee.graphite.core.DataFlowKind
 import io.johnsonlee.graphite.core.DoubleConstant
@@ -27,6 +29,8 @@ import io.johnsonlee.graphite.core.ResourceValueNode
 import io.johnsonlee.graphite.core.ReturnNode
 import io.johnsonlee.graphite.core.StringConstant
 import io.johnsonlee.graphite.core.TypeDescriptor
+import io.johnsonlee.graphite.core.TypeEdge
+import io.johnsonlee.graphite.core.TypeRelation
 import io.johnsonlee.graphite.core.ValueNode
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
@@ -560,6 +564,82 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `relationship types accept only documented spellings`() {
+        val source = IntConstant(NodeId.next(), 1)
+        val target = IntConstant(NodeId.next(), 2)
+        val relationshipGraph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN))
+            .addEdge(CallEdge(source.id, target.id, isVirtual = false))
+            .addEdge(TypeEdge(source.id, target.id, TypeRelation.EXTENDS))
+            .addEdge(ControlFlowEdge(source.id, target.id, ControlFlowKind.SEQUENTIAL))
+            .addEdge(ResourceEdge(source.id, target.id, ResourceRelation.LOOKUP))
+            .build()
+        val relationshipExecutor = CypherExecutor(relationshipGraph)
+        val accepted = mapOf(
+            "DATAFLOW" to "DATAFLOW",
+            "DATA_FLOW" to "DATAFLOW",
+            "data_flow" to "DATAFLOW",
+            "CALL" to "CALL",
+            "TYPE" to "TYPE",
+            "CONTROL_FLOW" to "CONTROL_FLOW",
+            "CONTROLFLOW" to "CONTROL_FLOW",
+            "RESOURCE" to "RESOURCE_LOOKUP",
+            "RESOURCE_LOOKUP" to "RESOURCE_LOOKUP"
+        )
+
+        accepted.forEach { (requested, actual) ->
+            val result = relationshipExecutor.execute(
+                "MATCH (a:IntConstant)-[r:$requested]->(b:IntConstant) RETURN type(r) AS type"
+            )
+            assertEquals(listOf(mapOf("type" to actual)), result.rows, requested)
+        }
+
+        val constrainedCall = relationshipExecutor.execute(
+            "MATCH (a:IntConstant)-[r:CALL {virtual: false, dynamic: false}]->(b:IntConstant) " +
+                "RETURN type(r) AS type"
+        )
+        assertEquals(listOf(mapOf("type" to "CALL")), constrainedCall.rows)
+
+        listOf("D_A_T_A_F_L_O_W", "C_A_L_L", "T_Y_P_E", "C_O_N_T_R_O_L_F_L_O_W", "RESOURCE_EDGE")
+            .forEach { malformed ->
+                val result = relationshipExecutor.execute(
+                    "MATCH (a:IntConstant)-[r:$malformed]->(b:IntConstant) RETURN type(r) AS type"
+                )
+                assertTrue(result.rows.isEmpty(), malformed)
+            }
+
+        val resourceTypes = listOf(
+            "RESOURCE_OPEN" to ResourceRelation.OPENS,
+            "RESOURCE_LOAD" to ResourceRelation.LOADS,
+            "RESOURCE_BUNDLE_CANDIDATE" to ResourceRelation.BUNDLE_CANDIDATE,
+            "RESOURCE_LOOKUP" to ResourceRelation.LOOKUP,
+            "RESOURCE_KEYS" to ResourceRelation.ENUMERATES
+        )
+        val resourceSource = IntConstant(NodeId.next(), -1)
+        val resourceTargets = resourceTypes.mapIndexed { index, _ -> IntConstant(NodeId.next(), index) }
+        val resourceGraph = DefaultGraph.Builder()
+            .addNode(resourceSource)
+            .apply {
+                resourceTargets.forEachIndexed { index, target ->
+                    addNode(target)
+                    addEdge(ResourceEdge(resourceSource.id, target.id, resourceTypes[index].second))
+                }
+            }
+            .build()
+        val resourceExecutor = CypherExecutor(resourceGraph)
+
+        resourceTypes.forEachIndexed { index, (requested, _) ->
+            val result = resourceExecutor.execute(
+                "MATCH (a:IntConstant)-[r:$requested]->(b:IntConstant) " +
+                    "WHERE b.value = $index RETURN type(r) AS type"
+            )
+            assertEquals(listOf(mapOf("type" to requested)), result.rows, requested)
+        }
+    }
+
+    @Test
     fun `filtered single hop limit streams complete matches before stopping`() {
         var outgoingCalls = 0
         val orderedGraph = object : Graph by graph {
@@ -688,6 +768,105 @@ class CypherExecutorTest {
         )
 
         assertEquals(listOf(mapOf("index" to 1)), result.rows)
+    }
+
+    @Test
+    fun `filtered relationship order by retains only skip plus limit rows`() {
+        val owner = TypeDescriptor("com.example.StreamingOrder")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val source = IntConstant(NodeId.next(), 42)
+        val targets = listOf(
+            ParameterNode(NodeId.next(), 0, valueType, method),
+            ParameterNode(NodeId.next(), 2, valueType, method),
+            ParameterNode(NodeId.next(), 1, valueType, method)
+        )
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .apply { targets.forEach(::addNode) }
+            .build()
+        var consumedEdges = 0
+        val guarded = object : Graph by base {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : Edge> outgoing(id: NodeId, type: Class<T>): Sequence<T> =
+                if (id == source.id && type == DataFlowEdge::class.java) {
+                    sequence {
+                        repeat(100_000) { index ->
+                            consumedEdges++
+                            val target = targets[index % targets.size]
+                            yield(DataFlowEdge(source.id, target.id, DataFlowKind.PARAMETER_PASS) as T)
+                        }
+                    }
+                } else {
+                    emptySequence()
+                }
+        }
+
+        val result = CypherExecutor(guarded).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 RETURN DISTINCT b.index AS index " +
+                "ORDER BY index DESC SKIP 1 LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("index" to 1)), result.rows)
+        assertEquals(100_000, consumedEdges, "ORDER BY must inspect every filtered relationship match")
+    }
+
+    @Test
+    fun `filtered relationship top k preserves expression null and multi-field ordering`() {
+        val owner = TypeDescriptor("com.example.StreamingOrderSemantics")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val source = IntConstant(NodeId.next(), 42)
+        val firstNullRank = ParameterNode(NodeId.next(), 1, valueType, method)
+        val secondNullRank = ParameterNode(NodeId.next(), 1, valueType, method)
+        val zeroRank = ParameterNode(NodeId.next(), 0, valueType, method)
+        val twoRank = ParameterNode(NodeId.next(), 2, valueType, method)
+        val orderedGraph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(firstNullRank)
+            .addNode(secondNullRank)
+            .addNode(zeroRank)
+            .addNode(twoRank)
+            .addEdge(DataFlowEdge(source.id, firstNullRank.id, DataFlowKind.PARAMETER_PASS))
+            .addEdge(DataFlowEdge(source.id, secondNullRank.id, DataFlowKind.PARAMETER_PASS))
+            .addEdge(DataFlowEdge(source.id, zeroRank.id, DataFlowKind.PARAMETER_PASS))
+            .addEdge(DataFlowEdge(source.id, twoRank.id, DataFlowKind.PARAMETER_PASS))
+            .build()
+
+        val result = CypherExecutor(orderedGraph).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 RETURN b.index AS index, b.id AS id " +
+                "ORDER BY CASE WHEN index = 1 THEN null ELSE index END ASC, id DESC SKIP 1 LIMIT 2"
+        )
+
+        assertEquals(
+            listOf(
+                mapOf("index" to 1, "id" to firstNullRank.id.value),
+                mapOf("index" to 0, "id" to zeroRank.id.value)
+            ),
+            result.rows
+        )
+
+        val hiddenPropertyOrder = CypherExecutor(orderedGraph).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 RETURN b.id AS id " +
+                "ORDER BY b.index ASC LIMIT 2"
+        )
+        assertEquals(
+            listOf(
+                mapOf("id" to zeroRank.id.value),
+                mapOf("id" to firstNullRank.id.value)
+            ),
+            hiddenPropertyOrder.rows
+        )
+
+        val hiddenExpressionOrder = CypherExecutor(orderedGraph).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 RETURN b.id AS id " +
+                "ORDER BY CASE WHEN b.index = 0 THEN -1 ELSE b.index END ASC LIMIT 2"
+        )
+        assertEquals(hiddenPropertyOrder.rows, hiddenExpressionOrder.rows)
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -560,6 +560,162 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `filtered single hop limit streams complete matches before stopping`() {
+        var outgoingCalls = 0
+        val orderedGraph = object : Graph by graph {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> =
+                if (type == IntConstant::class.java) {
+                    sequenceOf(
+                        graph.node(intConst42) as IntConstant,
+                        graph.node(intConst7) as IntConstant
+                    ) as Sequence<T>
+                } else {
+                    graph.nodes(type)
+                }
+
+            override fun outgoing(id: NodeId): Sequence<Edge> {
+                outgoingCalls++
+                check(outgoingCalls == 1) { "LIMIT must stop before scanning the next source node" }
+                return graph.outgoing(id)
+            }
+
+            override fun <T : Edge> outgoing(id: NodeId, type: Class<T>): Sequence<T> {
+                outgoingCalls++
+                check(outgoingCalls == 1) { "LIMIT must stop before scanning the next source node" }
+                return sequence {
+                    yieldAll(graph.outgoing(id, type))
+                    error("LIMIT must stop before consuming the source adjacency tail")
+                }
+            }
+        }
+
+        val result = CypherExecutor(orderedGraph).execute(
+            "MATCH (a:IntConstant)-[r:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 AND b.index = 0 AND r.kind = 'PARAMETER_PASS' " +
+                "RETURN a.value AS value, b.index AS parameter LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("value" to 42, "parameter" to 0)), result.rows)
+        assertEquals(1, outgoingCalls)
+    }
+
+    @Test
+    fun `filtered multi hop limit keeps intermediate relationships lazy`() {
+        val owner = TypeDescriptor("com.example.StreamingMultiHop")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val source = IntConstant(NodeId.next(), 1)
+        val middle = LocalVariable(NodeId.next(), "middle", valueType, method)
+        val target = LocalVariable(NodeId.next(), "target", valueType, method)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(middle)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, middle.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(middle.id, target.id, DataFlowKind.ASSIGN))
+            .build()
+        val guarded = object : Graph by base {
+            override fun <T : Edge> outgoing(id: NodeId, type: Class<T>): Sequence<T> =
+                if (id == source.id) {
+                    sequence {
+                        yieldAll(base.outgoing(id, type))
+                        error("Intermediate relationship fanout was materialized eagerly")
+                    }
+                } else {
+                    base.outgoing(id, type)
+                }
+        }
+
+        val result = CypherExecutor(guarded).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable)-[:DATAFLOW]->(c:LocalVariable) " +
+                "WHERE c.name = 'target' RETURN c.name AS name LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("name" to "target")), result.rows)
+    }
+
+    @Test
+    fun `filtered variable path limit stops before consuming adjacency tail`() {
+        val chain = dataFlowChain(length = 1)
+        val source = chain.nodes(IntConstant::class.java).single()
+        val guarded = object : Graph by chain {
+            override fun outgoing(id: NodeId): Sequence<Edge> =
+                if (id == source.id) {
+                    sequence {
+                        yieldAll(chain.outgoing(id))
+                        error("Variable path traversal consumed beyond LIMIT")
+                    }
+                } else {
+                    chain.outgoing(id)
+                }
+        }
+
+        val result = CypherExecutor(guarded).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW*1..100]->(b:LocalVariable) " +
+                "WHERE b.name = 'local-0' RETURN b.name AS name LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("name" to "local-0")), result.rows)
+    }
+
+    @Test
+    fun `filtered distinct relationship pagination retains only the requested window`() {
+        val owner = TypeDescriptor("com.example.StreamingDistinct")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val source = IntConstant(NodeId.next(), 42)
+        val first = ParameterNode(NodeId.next(), 0, valueType, method)
+        val second = ParameterNode(NodeId.next(), 1, valueType, method)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(first)
+            .addNode(second)
+            .build()
+        val guarded = object : Graph by base {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : Edge> outgoing(id: NodeId, type: Class<T>): Sequence<T> = sequence {
+                yield(DataFlowEdge(source.id, first.id, DataFlowKind.PARAMETER_PASS) as T)
+                yield(DataFlowEdge(source.id, first.id, DataFlowKind.PARAMETER_PASS) as T)
+                yield(DataFlowEdge(source.id, second.id, DataFlowKind.PARAMETER_PASS) as T)
+                error("DISTINCT SKIP LIMIT consumed beyond the requested visible values")
+            }
+        }
+
+        val result = CypherExecutor(guarded).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 RETURN DISTINCT b.index AS index SKIP 1 LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("index" to 1)), result.rows)
+    }
+
+    @Test
+    fun `a later pattern expands from its declared source variable`() {
+        val owner = TypeDescriptor("com.example.PatternSource")
+        val valueType = TypeDescriptor("int")
+        val method = MethodDescriptor(owner, "run", emptyList(), TypeDescriptor("void"))
+        val source = IntConstant(NodeId.next(), 1)
+        val middle = LocalVariable(NodeId.next(), "middle", valueType, method)
+        val target = ParameterNode(NodeId.next(), 0, valueType, method)
+        val patternGraph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(middle)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, middle.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(source.id, target.id, DataFlowKind.PARAMETER_PASS))
+            .build()
+
+        val result = CypherExecutor(patternGraph).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:LocalVariable), " +
+                "(a)-[:DATAFLOW]->(c:ParameterNode) " +
+                "WHERE b.name = 'middle' RETURN c.index AS index LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("index" to 0)), result.rows)
+    }
+
+    @Test
     fun `limit does not discard a later branch that completes the pattern`() {
         val owner = TypeDescriptor("com.example.BranchLimit")
         val valueType = TypeDescriptor("int")
@@ -1734,6 +1890,28 @@ class CypherExecutorTest {
         assertTrue(path is List<*>, "Path should be a list")
         val pathList = path as List<*>
         assertTrue(pathList.size >= 3, "Path should contain at least 3 elements")
+    }
+
+    @Test
+    fun `named path limit stops before consuming adjacency tail`() {
+        val guarded = object : Graph by graph {
+            override fun <T : Edge> outgoing(id: NodeId, type: Class<T>): Sequence<T> =
+                if (id == intConst42) {
+                    sequence {
+                        yieldAll(graph.outgoing(id, type))
+                        error("Named path matching consumed beyond LIMIT")
+                    }
+                } else {
+                    graph.outgoing(id, type)
+                }
+        }
+
+        val result = CypherExecutor(guarded).execute(
+            "MATCH p = (c:IntConstant)-[:DATAFLOW]->(ps:ParameterNode) RETURN p LIMIT 1"
+        )
+
+        val path = result.rows.single()["p"] as List<*>
+        assertTrue(path.size >= 3, "Path should contain the matched node, edge, and node")
     }
 
     // --- NOT CONTAINS / NOT STARTS WITH / NOT ENDS WITH ---

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -691,6 +691,21 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `filtered relationship pagination handles bounded edge cases`() {
+        val zeroLimit = executor.execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 RETURN b.index AS index LIMIT 0"
+        )
+        val oversizedPage = executor.execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode) " +
+                "WHERE a.value = 42 RETURN b.index AS index SKIP 2147483647 LIMIT 1"
+        )
+
+        assertTrue(zeroLimit.rows.isEmpty())
+        assertTrue(oversizedPage.rows.isEmpty())
+    }
+
+    @Test
     fun `a later pattern expands from its declared source variable`() {
         val owner = TypeDescriptor("com.example.PatternSource")
         val valueType = TypeDescriptor("int")
@@ -1912,6 +1927,26 @@ class CypherExecutorTest {
 
         val path = result.rows.single()["p"] as List<*>
         assertTrue(path.size >= 3, "Path should contain the matched node, edge, and node")
+    }
+
+    @Test
+    fun `named path with relationship variable retains the bound edge`() {
+        val result = executor.execute(
+            "MATCH p = (c:IntConstant)-[r:DATAFLOW]->(ps:ParameterNode) RETURN p LIMIT 1"
+        )
+
+        val path = result.rows.single()["p"] as List<*>
+        assertTrue(path.size >= 3, "Path should contain the explicitly bound relationship")
+    }
+
+    @Test
+    fun `repeated target variable rejects a different node`() {
+        val result = executor.execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW]->(b:ParameterNode)-[:DATAFLOW]->(a) " +
+                "WHERE true RETURN a.value LIMIT 1"
+        )
+
+        assertTrue(result.rows.isEmpty())
     }
 
     // --- NOT CONTAINS / NOT STARTS WITH / NOT ENDS WITH ---

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -1202,6 +1202,36 @@ class CypherExecutorTest {
         assertTrue(result.rows.size <= 2)
     }
 
+    @Test
+    fun `variable-length relationship types are matched exactly`() {
+        val source = IntConstant(NodeId(1), 3)
+        val dataFlowTarget = IntConstant(NodeId(2), 2)
+        val callTarget = IntConstant(NodeId(3), 3)
+        val typeTarget = IntConstant(NodeId(4), 4)
+        val mixedGraph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(dataFlowTarget)
+            .addNode(callTarget)
+            .addNode(typeTarget)
+            .addEdge(DataFlowEdge(source.id, dataFlowTarget.id, DataFlowKind.ASSIGN))
+            .addEdge(CallEdge(source.id, callTarget.id, isVirtual = false))
+            .addEdge(TypeEdge(source.id, typeTarget.id, TypeRelation.EXTENDS))
+            .build()
+        val mixedExecutor = CypherExecutor(mixedGraph)
+
+        val union = mixedExecutor.execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW|CALL*1..1]->(b:IntConstant) " +
+                "WHERE a.value = 3 RETURN b.id ORDER BY b.id LIMIT 10"
+        )
+        val invalid = mixedExecutor.execute(
+            "MATCH (a:IntConstant)-[:D_A_T_A_F_L_O_W*1..1]->(b:IntConstant) " +
+                "WHERE a.value = 3 RETURN b.id ORDER BY b.id LIMIT 10"
+        )
+
+        assertEquals(listOf(2, 3), union.rows.map { it["b.id"] })
+        assertTrue(invalid.rows.isEmpty())
+    }
+
     // --- Edge Cases ---
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
 class FilteredRelationshipMemoryTest {
 
     @Test
-    fun `zero-hit filtered relationship scan does not retain intermediate rows`() {
+    fun `zero-hit ordered filtered relationship scan does not retain intermediate rows`() {
         val source = IntConstant(NodeId(1), 1)
         val target = IntConstant(NodeId(2), 2)
         val base = DefaultGraph.Builder()
@@ -34,7 +34,7 @@ class FilteredRelationshipMemoryTest {
 
         val result = CypherExecutor(virtualGraph).execute(
             "MATCH (a:IntConstant)-[r:DATAFLOW]->(b:IntConstant) " +
-                "WHERE b.value = -1 RETURN r LIMIT 1"
+                "WHERE b.value = -1 RETURN r ORDER BY b.value LIMIT 1"
         )
 
         assertTrue(result.rows.isEmpty())

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -8,6 +8,7 @@ import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class FilteredRelationshipMemoryTest {
@@ -32,14 +33,32 @@ class FilteredRelationshipMemoryTest {
         }
 
         val result = CypherExecutor(virtualGraph).execute(
-            "MATCH (a:IntConstant)-[r:DATA_FLOW]->(b:IntConstant) " +
+            "MATCH (a:IntConstant)-[r:DATAFLOW]->(b:IntConstant) " +
                 "WHERE b.value = -1 RETURN r LIMIT 1"
         )
 
         assertTrue(result.rows.isEmpty())
     }
 
+    @Test
+    fun `data flow alias produces a matching relationship binding`() {
+        val source = IntConstant(NodeId(3), 3)
+        val target = IntConstant(NodeId(4), 4)
+        val graph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN))
+            .build()
+
+        val result = CypherExecutor(graph).execute(
+            "MATCH (a:IntConstant)-[r:DATA_FLOW]->(b:IntConstant) " +
+                "WHERE b.value = 4 RETURN r.kind AS kind LIMIT 1"
+        )
+
+        assertEquals(listOf(mapOf("kind" to "ASSIGN")), result.rows)
+    }
+
     private companion object {
-        const val EDGE_COUNT = 1_000_000
+        const val EDGE_COUNT = 4_000_000
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -58,7 +58,34 @@ class FilteredRelationshipMemoryTest {
         assertEquals(listOf(mapOf("kind" to "ASSIGN")), result.rows)
     }
 
+    @Test
+    fun `zero-hit filtered one-hop variable path does not retain frontier states`() {
+        val source = IntConstant(NodeId(5), 5)
+        val target = IntConstant(NodeId(6), 6)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(target)
+            .build()
+        val virtualGraph = object : Graph by base {
+            override fun outgoing(id: NodeId): Sequence<Edge> =
+                if (id == source.id) {
+                    generateSequence { DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN) }
+                        .take(VARIABLE_PATH_EDGE_COUNT)
+                } else {
+                    emptySequence()
+                }
+        }
+
+        val result = CypherExecutor(virtualGraph).execute(
+            "MATCH (a:IntConstant)-[:DATAFLOW*1..1]->(b:IntConstant) " +
+                "WHERE b.value = -1 RETURN b.id ORDER BY b.id LIMIT 1"
+        )
+
+        assertTrue(result.rows.isEmpty())
+    }
+
     private companion object {
         const val EDGE_COUNT = 4_000_000
+        const val VARIABLE_PATH_EDGE_COUNT = 10_000_000
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -5,6 +5,7 @@ import io.johnsonlee.graphite.core.DataFlowEdge
 import io.johnsonlee.graphite.core.DataFlowKind
 import io.johnsonlee.graphite.core.Edge
 import io.johnsonlee.graphite.core.IntConstant
+import io.johnsonlee.graphite.core.Node
 import io.johnsonlee.graphite.core.NodeId
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
@@ -132,12 +133,56 @@ class FilteredRelationshipMemoryTest {
         assertTrue(result.rows.isEmpty())
     }
 
+    @Test
+    fun `deep cyclic path does not retain quadratic blocker state`() {
+        val source = IntConstant(NodeId(DEEP_CYCLE_ID_OFFSET), 0)
+        val terminalId = NodeId(DEEP_CYCLE_ID_OFFSET + DEEP_CYCLE_NODE_COUNT - 1)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .build()
+        val virtualGraph = object : Graph by base {
+            override fun node(id: NodeId): Node? =
+                if (id.value in DEEP_CYCLE_ID_OFFSET until DEEP_CYCLE_ID_OFFSET + DEEP_CYCLE_NODE_COUNT) {
+                    IntConstant(id, id.value - DEEP_CYCLE_ID_OFFSET)
+                } else {
+                    null
+                }
+
+            override fun outgoing(id: NodeId): Sequence<Edge> = when {
+                id.value in DEEP_CYCLE_ID_OFFSET until terminalId.value -> sequenceOf(
+                    DataFlowEdge(id, NodeId(id.value + 1), DataFlowKind.ASSIGN)
+                )
+                id == terminalId -> (0 until DEEP_CYCLE_NODE_COUNT - 1).asSequence().map { index ->
+                    DataFlowEdge(id, NodeId(DEEP_CYCLE_ID_OFFSET + index), DataFlowKind.ASSIGN)
+                }
+                else -> emptySequence()
+            }
+        }
+
+        val matches = PathFinder.findPathMatches(
+            virtualGraph,
+            setOf(source.id),
+            PathFinder.SearchOptions(
+                targets = emptySet(),
+                edgeType = DataFlowEdge::class.java,
+                minDepth = 1,
+                maxDepth = DEEP_CYCLE_NODE_COUNT + 1,
+                direction = PathFinder.Direction.OUTGOING,
+                workTracker = CypherWorkTracker(CypherExecutionBudget(DEFAULT_SERVER_WORK_BUDGET))
+            )
+        ).count()
+
+        assertEquals(0, matches)
+    }
+
     private companion object {
         const val EDGE_COUNT = 4_000_000
         const val VARIABLE_PATH_EDGE_COUNT = 10_000_000
         const val TARGET_ID_OFFSET = 1_000_000
         const val RECONVERGENT_LAYER_COUNT = 8
         const val RECONVERGENT_LAYER_WIDTH = 8
+        const val DEEP_CYCLE_NODE_COUNT = 3_000
+        const val DEEP_CYCLE_ID_OFFSET = 300_000
         const val DEFAULT_SERVER_WORK_BUDGET = 250_000L
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -1,0 +1,45 @@
+package io.johnsonlee.graphite.cypher
+
+import io.johnsonlee.graphite.core.DataFlowEdge
+import io.johnsonlee.graphite.core.DataFlowKind
+import io.johnsonlee.graphite.core.Edge
+import io.johnsonlee.graphite.core.IntConstant
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.Graph
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class FilteredRelationshipMemoryTest {
+
+    @Test
+    fun `zero-hit filtered relationship scan does not retain intermediate rows`() {
+        val source = IntConstant(NodeId(1), 1)
+        val target = IntConstant(NodeId(2), 2)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(target)
+            .build()
+        val virtualGraph = object : Graph by base {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : Edge> outgoing(id: NodeId, type: Class<T>): Sequence<T> =
+                if (id == source.id && type == DataFlowEdge::class.java) {
+                    generateSequence { DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN) }
+                        .take(EDGE_COUNT) as Sequence<T>
+                } else {
+                    emptySequence()
+                }
+        }
+
+        val result = CypherExecutor(virtualGraph).execute(
+            "MATCH (a:IntConstant)-[r:DATA_FLOW]->(b:IntConstant) " +
+                "WHERE b.value = -1 RETURN r LIMIT 1"
+        )
+
+        assertTrue(result.rows.isEmpty())
+    }
+
+    private companion object {
+        const val EDGE_COUNT = 1_000_000
+    }
+}

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -1,5 +1,6 @@
 package io.johnsonlee.graphite.cypher
 
+import io.johnsonlee.graphite.core.BooleanConstant
 import io.johnsonlee.graphite.core.DataFlowEdge
 import io.johnsonlee.graphite.core.DataFlowKind
 import io.johnsonlee.graphite.core.Edge
@@ -98,9 +99,45 @@ class FilteredRelationshipMemoryTest {
         assertTrue(result.rows.isEmpty())
     }
 
+    @Test
+    fun `zero-hit reconvergent variable path stays within the default work budget`() {
+        val source = BooleanConstant(NodeId(20), true)
+        val layers = (0 until RECONVERGENT_LAYER_COUNT).map { layer ->
+            (0 until RECONVERGENT_LAYER_WIDTH).map { index ->
+                val id = NodeId(21 + layer * RECONVERGENT_LAYER_WIDTH + index)
+                if (layer == RECONVERGENT_LAYER_COUNT - 1) IntConstant(id, index) else BooleanConstant(id, true)
+            }
+        }
+        val builder = DefaultGraph.Builder().addNode(source)
+        layers.flatten().forEach(builder::addNode)
+        layers.first().forEach { target ->
+            builder.addEdge(DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN))
+        }
+        layers.zipWithNext().forEach { (fromLayer, toLayer) ->
+            fromLayer.forEach { from ->
+                toLayer.forEach { to ->
+                    builder.addEdge(DataFlowEdge(from.id, to.id, DataFlowKind.ASSIGN))
+                }
+            }
+        }
+
+        val result = CypherExecutor(
+            builder.build(),
+            CypherExecutionBudget(maxWorkUnits = DEFAULT_SERVER_WORK_BUDGET)
+        ).execute(
+            "MATCH (a:BooleanConstant)-[:DATAFLOW*1..8]->(b:IntConstant) " +
+                "WHERE b.value = -1 RETURN b.id ORDER BY b.id LIMIT 1"
+        )
+
+        assertTrue(result.rows.isEmpty())
+    }
+
     private companion object {
         const val EDGE_COUNT = 4_000_000
         const val VARIABLE_PATH_EDGE_COUNT = 10_000_000
         const val TARGET_ID_OFFSET = 1_000_000
+        const val RECONVERGENT_LAYER_COUNT = 8
+        const val RECONVERGENT_LAYER_WIDTH = 8
+        const val DEFAULT_SERVER_WORK_BUDGET = 250_000L
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -102,34 +102,48 @@ class FilteredRelationshipMemoryTest {
 
     @Test
     fun `zero-hit reconvergent variable path stays within the default work budget`() {
-        val source = BooleanConstant(NodeId(20), true)
-        val layers = (0 until RECONVERGENT_LAYER_COUNT).map { layer ->
-            (0 until RECONVERGENT_LAYER_WIDTH).map { index ->
-                val id = NodeId(21 + layer * RECONVERGENT_LAYER_WIDTH + index)
-                if (layer == RECONVERGENT_LAYER_COUNT - 1) IntConstant(id, index) else BooleanConstant(id, true)
-            }
-        }
-        val builder = DefaultGraph.Builder().addNode(source)
-        layers.flatten().forEach(builder::addNode)
-        layers.first().forEach { target ->
-            builder.addEdge(DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN))
-        }
-        layers.zipWithNext().forEach { (fromLayer, toLayer) ->
-            fromLayer.forEach { from ->
-                toLayer.forEach { to ->
-                    builder.addEdge(DataFlowEdge(from.id, to.id, DataFlowKind.ASSIGN))
-                }
-            }
-        }
+        val graph = reconvergentGraph()
 
         val result = CypherExecutor(
-            builder.build(),
+            graph,
             CypherExecutionBudget(maxWorkUnits = DEFAULT_SERVER_WORK_BUDGET)
         ).execute(
             "MATCH (a:BooleanConstant)-[:DATAFLOW*1..8]->(b:IntConstant) " +
                 "WHERE b.value = -1 RETURN b.id ORDER BY b.id LIMIT 1"
         )
 
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `absent target label on reconvergent variable path stays within the default work budget`() {
+        val graph = reconvergentGraph(allDescendantsAreInt = true)
+
+        val result = CypherExecutor(
+            graph,
+            CypherExecutionBudget(maxWorkUnits = DEFAULT_SERVER_WORK_BUDGET)
+        ).execute(
+            "MATCH (a:BooleanConstant)-[:DATAFLOW*1..8]->(b:CallSiteNode) " +
+                "RETURN b.id LIMIT 1"
+        )
+
+        assertEquals(listOf("b.id"), result.columns)
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `absent target property on reconvergent variable path stays within the default work budget`() {
+        val graph = reconvergentGraph(allDescendantsAreInt = true)
+
+        val result = CypherExecutor(
+            graph,
+            CypherExecutionBudget(maxWorkUnits = DEFAULT_SERVER_WORK_BUDGET)
+        ).execute(
+            "MATCH (a:BooleanConstant)-[:DATAFLOW*1..8]->(b:IntConstant {value: -1}) " +
+                "RETURN b.id LIMIT 1"
+        )
+
+        assertEquals(listOf("b.id"), result.columns)
         assertTrue(result.rows.isEmpty())
     }
 
@@ -173,6 +187,33 @@ class FilteredRelationshipMemoryTest {
         ).count()
 
         assertEquals(0, matches)
+    }
+
+    private fun reconvergentGraph(allDescendantsAreInt: Boolean = false): Graph {
+        val source = BooleanConstant(NodeId(20), true)
+        val layers = (0 until RECONVERGENT_LAYER_COUNT).map { layer ->
+            (0 until RECONVERGENT_LAYER_WIDTH).map { index ->
+                val id = NodeId(21 + layer * RECONVERGENT_LAYER_WIDTH + index)
+                if (allDescendantsAreInt || layer == RECONVERGENT_LAYER_COUNT - 1) {
+                    IntConstant(id, index)
+                } else {
+                    BooleanConstant(id, true)
+                }
+            }
+        }
+        val builder = DefaultGraph.Builder().addNode(source)
+        layers.flatten().forEach(builder::addNode)
+        layers.first().forEach { target ->
+            builder.addEdge(DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN))
+        }
+        layers.zipWithNext().forEach { (fromLayer, toLayer) ->
+            fromLayer.forEach { from ->
+                toLayer.forEach { to ->
+                    builder.addEdge(DataFlowEdge(from.id, to.id, DataFlowKind.ASSIGN))
+                }
+            }
+        }
+        return builder.build()
     }
 
     private companion object {

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/FilteredRelationshipMemoryTest.kt
@@ -59,25 +59,39 @@ class FilteredRelationshipMemoryTest {
     }
 
     @Test
-    fun `zero-hit filtered one-hop variable path does not retain frontier states`() {
+    fun `zero-hit filtered variable path does not retain a distinct wide traversal`() {
         val source = IntConstant(NodeId(5), 5)
-        val target = IntConstant(NodeId(6), 6)
         val base = DefaultGraph.Builder()
             .addNode(source)
-            .addNode(target)
             .build()
         val virtualGraph = object : Graph by base {
+            override fun node(id: NodeId) = when {
+                id == source.id -> source
+                id.value in TARGET_ID_OFFSET until TARGET_ID_OFFSET + VARIABLE_PATH_EDGE_COUNT ->
+                    IntConstant(id, id.value)
+                else -> null
+            }
+
             override fun outgoing(id: NodeId): Sequence<Edge> =
                 if (id == source.id) {
-                    generateSequence { DataFlowEdge(source.id, target.id, DataFlowKind.ASSIGN) }
-                        .take(VARIABLE_PATH_EDGE_COUNT)
+                    sequence {
+                        repeat(VARIABLE_PATH_EDGE_COUNT) { index ->
+                            yield(
+                                DataFlowEdge(
+                                    source.id,
+                                    NodeId(TARGET_ID_OFFSET + index),
+                                    DataFlowKind.ASSIGN
+                                )
+                            )
+                        }
+                    }
                 } else {
                     emptySequence()
                 }
         }
 
         val result = CypherExecutor(virtualGraph).execute(
-            "MATCH (a:IntConstant)-[:DATAFLOW*1..1]->(b:IntConstant) " +
+            "MATCH (a:IntConstant)-[:DATAFLOW*1..2]->(b:IntConstant) " +
                 "WHERE b.value = -1 RETURN b.id ORDER BY b.id LIMIT 1"
         )
 
@@ -87,5 +101,6 @@ class FilteredRelationshipMemoryTest {
     private companion object {
         const val EDGE_COUNT = 4_000_000
         const val VARIABLE_PATH_EDGE_COUNT = 10_000_000
+        const val TARGET_ID_OFFSET = 1_000_000
     }
 }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/NodePropertyAccessorTest.kt
@@ -376,6 +376,10 @@ class NodePropertyAccessorTest {
     @Test
     fun `resolveEdgeType returns null for unknown types`() {
         assertNull(NodePropertyAccessor.resolveEdgeType("UNKNOWN"))
+        assertNull(NodePropertyAccessor.resolveEdgeType("D_A_T_A_F_L_O_W"))
+        assertNull(NodePropertyAccessor.resolveEdgeType("C_A_L_L"))
+        assertNull(NodePropertyAccessor.resolveEdgeType("T_Y_P_E"))
+        assertNull(NodePropertyAccessor.resolveEdgeType("RESOURCE_EDGE"))
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
@@ -194,6 +194,53 @@ class PathFinderTest {
     }
 
     @Test
+    fun `lazy match evicts old expansion memo entries after its fixed capacity`() {
+        val source = IntConstant(NodeId.next(), 40)
+        val middleIdOffset = 100_000
+        val targetIdOffset = 200_000
+        val width = 16_385
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .build()
+        val virtualGraph = object : Graph by base {
+            override fun node(id: NodeId): Node? = when (id.value) {
+                source.id.value -> source
+                in middleIdOffset until middleIdOffset + width -> IntConstant(id, id.value)
+                in targetIdOffset until targetIdOffset + width -> IntConstant(id, id.value)
+                else -> null
+            }
+
+            override fun outgoing(id: NodeId): Sequence<Edge> = when (id.value) {
+                source.id.value -> (0 until width).asSequence().map { index ->
+                    DataFlowEdge(source.id, NodeId(middleIdOffset + index), DataFlowKind.ASSIGN)
+                }
+                in middleIdOffset until middleIdOffset + width -> sequenceOf(
+                    DataFlowEdge(
+                        id,
+                        NodeId(targetIdOffset + id.value - middleIdOffset),
+                        DataFlowKind.ASSIGN
+                    )
+                )
+                else -> emptySequence()
+            }
+        }
+
+        val matches = PathFinder.findPathMatches(
+            virtualGraph,
+            setOf(source.id),
+            PathFinder.SearchOptions(
+                targets = null,
+                edgeType = DataFlowEdge::class.java,
+                minDepth = 2,
+                maxDepth = 2,
+                direction = PathFinder.Direction.OUTGOING
+            )
+        ).count()
+
+        assertEquals(width, matches)
+    }
+
+    @Test
     fun `shallower revisit expands a node again within the remaining depth`() {
         val source = IntConstant(NodeId.next(), 20)
         val detour = IntConstant(NodeId.next(), 21)

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
@@ -119,6 +119,39 @@ class PathFinderTest {
     }
 
     @Test
+    fun `public path search returns targets in breadth first order`() {
+        val source = IntConstant(NodeId.next(), 30)
+        val middle = IntConstant(NodeId.next(), 31)
+        val directTarget = IntConstant(NodeId.next(), 32)
+        val deepTarget = IntConstant(NodeId.next(), 33)
+        val sourceToMiddle = DataFlowEdge(source.id, middle.id, DataFlowKind.ASSIGN)
+        val sourceToDirectTarget = DataFlowEdge(source.id, directTarget.id, DataFlowKind.ASSIGN)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(middle)
+            .addNode(directTarget)
+            .addNode(deepTarget)
+            .addEdge(DataFlowEdge(middle.id, deepTarget.id, DataFlowKind.ASSIGN))
+            .build()
+        val longBranchFirst = object : Graph by base {
+            override fun outgoing(id: NodeId): Sequence<Edge> =
+                if (id == source.id) sequenceOf(sourceToMiddle, sourceToDirectTarget) else base.outgoing(id)
+        }
+
+        val paths = PathFinder.findPaths(
+            longBranchFirst,
+            sources = setOf(source.id),
+            targets = setOf(directTarget.id, deepTarget.id),
+            edgeType = DataFlowEdge::class.java,
+            minDepth = 1,
+            maxDepth = 2
+        )
+
+        assertEquals(listOf(1, 2), paths.map { it.edges.size })
+        assertEquals(listOf(directTarget.id, deepTarget.id), paths.map { it.nodes.last().id })
+    }
+
+    @Test
     fun `lazy match descends before retaining a wide sibling frontier`() {
         val source = IntConstant(NodeId.next(), 10)
         val middle = IntConstant(NodeId.next(), 11)

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
@@ -119,6 +119,90 @@ class PathFinderTest {
     }
 
     @Test
+    fun `lazy match descends before retaining a wide sibling frontier`() {
+        val source = IntConstant(NodeId.next(), 10)
+        val middle = IntConstant(NodeId.next(), 11)
+        val target = IntConstant(NodeId.next(), 12)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(middle)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, middle.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(middle.id, target.id, DataFlowKind.ASSIGN))
+            .build()
+        val guarded = object : Graph by base {
+            override fun outgoing(id: NodeId): Sequence<Edge> =
+                if (id == source.id) {
+                    sequence {
+                        yieldAll(base.outgoing(id))
+                        error("Lazy traversal consumed the source's sibling frontier before the first deep match")
+                    }
+                } else {
+                    base.outgoing(id)
+                }
+        }
+
+        val match = PathFinder.findPathMatches(
+            guarded,
+            setOf(source.id),
+            PathFinder.SearchOptions(
+                targets = setOf(target.id),
+                edgeType = DataFlowEdge::class.java,
+                minDepth = 2,
+                maxDepth = 2,
+                direction = PathFinder.Direction.OUTGOING
+            )
+        ).first()
+
+        assertEquals(
+            listOf(source.id, middle.id, target.id),
+            match.materialize(null).nodes.map(Node::id)
+        )
+    }
+
+    @Test
+    fun `shallower revisit expands a node again within the remaining depth`() {
+        val source = IntConstant(NodeId.next(), 20)
+        val detour = IntConstant(NodeId.next(), 21)
+        val junction = IntConstant(NodeId.next(), 22)
+        val predecessor = IntConstant(NodeId.next(), 23)
+        val target = IntConstant(NodeId.next(), 24)
+        val sourceToDetour = DataFlowEdge(source.id, detour.id, DataFlowKind.ASSIGN)
+        val sourceToJunction = DataFlowEdge(source.id, junction.id, DataFlowKind.ASSIGN)
+        val base = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(detour)
+            .addNode(junction)
+            .addNode(predecessor)
+            .addNode(target)
+            .addEdge(DataFlowEdge(detour.id, junction.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(junction.id, predecessor.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(predecessor.id, target.id, DataFlowKind.ASSIGN))
+            .build()
+        val longBranchFirst = object : Graph by base {
+            override fun outgoing(id: NodeId): Sequence<Edge> =
+                if (id == source.id) sequenceOf(sourceToDetour, sourceToJunction) else base.outgoing(id)
+        }
+
+        val path = PathFinder.findPathMatches(
+            longBranchFirst,
+            setOf(source.id),
+            PathFinder.SearchOptions(
+                targets = setOf(target.id),
+                edgeType = DataFlowEdge::class.java,
+                minDepth = 1,
+                maxDepth = 3,
+                direction = PathFinder.Direction.OUTGOING
+            )
+        ).single().materialize(null)
+
+        assertEquals(
+            listOf(source.id, junction.id, predecessor.id, target.id),
+            path.nodes.map(Node::id)
+        )
+    }
+
+    @Test
     fun `depth limit prevents finding distant nodes`() {
         val paths = PathFinder.findPaths(
             graph, setOf(nodeA), setOf(nodeD),

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
@@ -70,6 +70,22 @@ class PathFinderTest {
     }
 
     @Test
+    fun `depth zero returns the source and default bounds still find direct paths`() {
+        val zeroDepth = PathFinder.findPaths(
+            graph, setOf(nodeA), setOf(nodeA),
+            edgeType = DataFlowEdge::class.java,
+            minDepth = 0, maxDepth = 0
+        )
+        val defaultBounds = PathFinder.findPaths(
+            graph, setOf(nodeA), setOf(nodeB),
+            edgeType = DataFlowEdge::class.java
+        )
+
+        assertEquals(listOf(nodeA), zeroDepth.single().nodes.map(Node::id))
+        assertEquals(listOf(nodeA, nodeB), defaultBounds.single().nodes.map(Node::id))
+    }
+
+    @Test
     fun `find multi-hop paths`() {
         val paths = PathFinder.findPaths(
             graph, setOf(nodeA), setOf(nodeD),

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
@@ -234,11 +234,12 @@ class PathFinderTest {
                 edgeType = DataFlowEdge::class.java,
                 minDepth = 2,
                 maxDepth = 2,
-                direction = PathFinder.Direction.OUTGOING
+                direction = PathFinder.Direction.OUTGOING,
+                nodePredicate = { false }
             )
         ).count()
 
-        assertEquals(width, matches)
+        assertEquals(0, matches)
     }
 
     @Test
@@ -341,6 +342,36 @@ class PathFinderTest {
         )
 
         assertEquals(listOf(mapOf("id" to target.id.value)), result.rows)
+    }
+
+    @Test
+    fun `reconvergent prefixes preserve distinct relationship path rows`() {
+        val source = BooleanConstant(NodeId.next(), true)
+        val left = BooleanConstant(NodeId.next(), true)
+        val right = BooleanConstant(NodeId.next(), true)
+        val junction = BooleanConstant(NodeId.next(), true)
+        val target = IntConstant(NodeId.next(), 43)
+        val graph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(left)
+            .addNode(right)
+            .addNode(junction)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, left.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(source.id, right.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(left.id, junction.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(right.id, junction.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(junction.id, target.id, DataFlowKind.ASSIGN))
+            .build()
+
+        val result = CypherExecutor(graph).execute(
+            "MATCH (a:BooleanConstant)-[:DATAFLOW*3..3]->(b:IntConstant) RETURN b.id AS id"
+        )
+
+        assertEquals(
+            listOf(mapOf("id" to target.id.value), mapOf("id" to target.id.value)),
+            result.rows
+        )
     }
 
     @Test

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/PathFinderTest.kt
@@ -1,5 +1,6 @@
 package io.johnsonlee.graphite.cypher
 
+import io.johnsonlee.graphite.core.BooleanConstant
 import io.johnsonlee.graphite.core.CallEdge
 import io.johnsonlee.graphite.core.CallSiteNode
 import io.johnsonlee.graphite.core.DataFlowEdge
@@ -280,6 +281,66 @@ class PathFinderTest {
             listOf(source.id, junction.id, predecessor.id, target.id),
             path.nodes.map(Node::id)
         )
+    }
+
+    @Test
+    fun `deeper revisit expands a node again for exact depth matches`() {
+        val source = IntConstant(NodeId.next(), 25)
+        val detour = IntConstant(NodeId.next(), 26)
+        val junction = IntConstant(NodeId.next(), 27)
+        val target = IntConstant(NodeId.next(), 28)
+        val graph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(detour)
+            .addNode(junction)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, junction.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(source.id, detour.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(detour.id, junction.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(junction.id, target.id, DataFlowKind.ASSIGN))
+            .build()
+
+        val path = PathFinder.findPathMatches(
+            graph,
+            setOf(source.id),
+            PathFinder.SearchOptions(
+                targets = setOf(target.id),
+                edgeType = DataFlowEdge::class.java,
+                minDepth = 3,
+                maxDepth = 3,
+                direction = PathFinder.Direction.OUTGOING
+            )
+        ).single().materialize(null)
+
+        assertEquals(listOf(source.id, detour.id, junction.id, target.id), path.nodes.map(Node::id))
+    }
+
+    @Test
+    fun `revisited node expands when a different ancestor set makes its suffix legal`() {
+        val source = BooleanConstant(NodeId.next(), true)
+        val ancestor = BooleanConstant(NodeId.next(), true)
+        val alternate = BooleanConstant(NodeId.next(), true)
+        val junction = BooleanConstant(NodeId.next(), true)
+        val target = IntConstant(NodeId.next(), 42)
+        val graph = DefaultGraph.Builder()
+            .addNode(source)
+            .addNode(ancestor)
+            .addNode(alternate)
+            .addNode(junction)
+            .addNode(target)
+            .addEdge(DataFlowEdge(source.id, ancestor.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(source.id, alternate.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(ancestor.id, junction.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(ancestor.id, target.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(alternate.id, junction.id, DataFlowKind.ASSIGN))
+            .addEdge(DataFlowEdge(junction.id, ancestor.id, DataFlowKind.ASSIGN))
+            .build()
+
+        val result = CypherExecutor(graph).execute(
+            "MATCH (a:BooleanConstant)-[:DATAFLOW*4..4]->(b:IntConstant) RETURN b.id AS id"
+        )
+
+        assertEquals(listOf(mapOf("id" to target.id.value)), result.rows)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- stream filtered relationship matches through WHERE, projection, DISTINCT, ORDER BY, SKIP, and LIMIT instead of retaining every intermediate binding
- keep ORDER BY memory bounded to O(SKIP + LIMIT) with a stable top-k heap after WHERE filtering, including hidden sort expressions omitted from RETURN
- prune unrelated graph sources when WHERE contains an exact source graphId equality
- keep fixed-hop and variable-length adjacency traversal lazy, and expand later patterns from their declared source variable
- traverse variable-length paths depth-first with an O(maxDepth) retained frame stack and a fixed-capacity dead-suffix memo that caches only zero-result, cycle-independent suffixes
- apply the target node pattern to variable-length endpoints even without WHERE, and additionally push the final WHERE only when all required relationship bindings are available
- preserve relationship-path multiplicity at reconvergence and preserve cycle-dependent paths under different ancestor contexts
- preserve the public `PathFinder.findPaths` breadth-first/shortest-first contract while keeping Cypher on its separate bounded lazy traversal
- apply relationship type unions, aliases, invalid-type rejection, and inline relationship properties to every variable-length hop
- support explicit aliases such as DATA_FLOW/DATAFLOW and CONTROL_FLOW/CONTROLFLOW; malformed underscore spellings remain unknown

## Verification

Exact candidate: `ab80322`.

- `./gradlew :cypher:test :cypher:detekt :cypher:filteredRelationshipMemoryTest :cypher:koverVerify :cypher:koverLog :cypher:jmhJar --no-daemon --rerun-tasks`
  - 1,054 regular tests and 7 isolated heap/budget tests, 0 failures
  - detekt clean
  - 98.0914% Cypher line coverage
  - JMH jar built successfully
- `git diff --check`
- GitHub unit/coverage workflow: PASS
- [Required benchmark-regression gate: PASS on base `b5808cd` and PR `ab80322`](https://github.com/johnsonlee/graphite/pull/102#issuecomment-5462688519)

The isolated `FilteredRelationshipMemoryTest` always runs with `-Xmx256m`. It covers:

- 4,000,000 generated single-hop DATAFLOW edges with zero WHERE hits
- 10,000,000 distinct generated variable-path targets with zero WHERE hits
- a 65-node/456-edge, 8-layer × 8-wide reconvergent DAG under the normal 250,000-work budget
- the same reconvergent DAG with no WHERE and an absent target label
- the same reconvergent DAG with no WHERE and an absent inline target property
- a 3,000-node chain whose terminal points back to every ancestor, preventing quadratic retained cycle-blocker state

Correctness controls cover DATAFLOW aliases/types, lazy LIMIT behavior, exact-depth revisits, cyclic ancestor-context changes, bounded memo eviction, public BFS order, and a diamond that must return two relationship-path rows without DISTINCT. A relationship-variable regression also verifies that WHERE is evaluated only after the path binding exists.

## Benchmark conclusions

The required gate runs base and PR on the same GitHub runners and publishes commands, environment, confidence handling, raw reports, and artifacts in the linked comment/run.

- Method-level: PASS. `CypherBenchmark.filteredVariableLengthPath` improved from 360.206 to 348.807 us/op (-3.2%); `filteredSingleHopRelationship` improved by 65.9%. No method-level row produced a confirmed blocking regression.
- End-to-end: PASS. All real-corpus JAR → build → save → mapped-load → Cypher rows passed. The 36-real-graph wrapped zero-hit query improved 4.336 → 4.188 s/op (-3.4%) versus current base and retained the required fixed-baseline speedup.
- Resources: PASS without threshold changes. On the 36-real-graph probe, allocation was +2.1%, query GC count +8.3%, query GC time +13.3%, retained heap delta -0.7%, and peak used heap -0.1%; all were inside the existing gate.
