### PR TITLE
Preserve Cypher responses past connection idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,14 @@ The `=~` operator preserves Java `Pattern` syntax, including backreferences,
 look-around, possessive quantifiers, character-class intersections, and Java's
 default line-terminator behavior. Budgeted execution polls cancellation through
 the matcher's input without changing the accepted pattern language.
-An executing query is cancelled when the server observes a TCP reset, servlet timeout,
-or Jetty connection error. A clean input FIN is not treated as cancellation: TCP exposes
-both a full client `close()` and a valid request-side `SHUT_WR` as the same input
-half-close until the server attempts to write the response.
+An executing query is cancelled only when the server observes an actual connection close,
+TCP reset, or socket error. Jetty's connection idle clock is suspended while Cypher is
+executing, because a query can legitimately perform no socket I/O for longer than the
+connector's default 30-second idle timeout. A clean input FIN is not treated as cancellation:
+TCP exposes both a full client `close()` and a valid request-side `SHUT_WR` as the same input
+half-close until the server attempts to write the response. A server-side cancellation on a
+still-connected client returns HTTP 503 with `code` set to `cypher_query_cancelled`; it is
+never reported as an empty HTTP 200 response.
 
 Start the server with `--metrics` to expose Prometheus output at `/metrics`.
 Metrics are opt-in, so the default request path has no Micrometer instrumentation cost.

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherClientCancellation.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherClientCancellation.kt
@@ -2,8 +2,6 @@ package io.johnsonlee.graphite.cli
 
 import io.javalin.http.Context
 import io.johnsonlee.graphite.cypher.CypherCancellationSignal
-import jakarta.servlet.AsyncEvent
-import jakarta.servlet.AsyncListener
 import org.eclipse.jetty.io.AbstractEndPoint
 import org.eclipse.jetty.io.Connection
 import org.eclipse.jetty.io.SocketChannelEndPoint
@@ -20,6 +18,7 @@ import java.lang.invoke.MethodHandles
 import java.lang.invoke.MethodType
 import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -27,10 +26,13 @@ import java.util.concurrent.atomic.AtomicReference
 internal class CypherClientCancellation private constructor(
     private val cancellationSignal: CypherCancellationSignal,
     private val cancelTask: AtomicReference<(() -> Unit)?>,
+    private val disconnected: AtomicBoolean,
     private val connection: Connection,
     private val connectionListener: Connection.Listener,
     private val disconnectMonitor: DisconnectMonitor
 ) : Closeable {
+
+    val isClientDisconnected: Boolean get() = disconnected.get()
 
     fun bind(task: CypherQueryTask<*>) {
         cancelTask.set(task::cancel)
@@ -38,8 +40,11 @@ internal class CypherClientCancellation private constructor(
     }
 
     override fun close() {
-        disconnectMonitor.close()
-        connection.removeEventListener(connectionListener)
+        try {
+            disconnectMonitor.close()
+        } finally {
+            connection.removeEventListener(connectionListener)
+        }
     }
 
     companion object {
@@ -53,12 +58,13 @@ internal class CypherClientCancellation private constructor(
             onBackpressure: () -> Unit
         ): CypherClientCancellation {
             val cancelTask = AtomicReference<(() -> Unit)?>(null)
+            val disconnected = AtomicBoolean()
             val cancel: () -> Unit = {
+                disconnected.set(true)
                 cancellationSignal.cancel()
                 cancelTask.get()?.invoke()
                 Unit
             }
-            val asyncListener = CypherCancellationAsyncListener(cancel)
             val channel = Request.getBaseRequest(ctx.req()).httpChannel
             val connection = channel.connection
             val connectionListener = CypherCancellationConnectionListener(cancel)
@@ -69,28 +75,28 @@ internal class CypherClientCancellation private constructor(
                 onBackpressure
             )
 
-            ctx.req().asyncContext.addListener(asyncListener)
             connection.addEventListener(connectionListener)
-            disconnectMonitor.start()
+            try {
+                disconnectMonitor.start()
+            } catch (error: RejectedExecutionException) {
+                try {
+                    disconnectMonitor.close()
+                } finally {
+                    connection.removeEventListener(connectionListener)
+                }
+                throw error
+            }
 
             return CypherClientCancellation(
                 cancellationSignal,
                 cancelTask,
+                disconnected,
                 connection,
                 connectionListener,
                 disconnectMonitor
             )
         }
     }
-}
-
-internal class CypherCancellationAsyncListener(
-    private val cancel: () -> Unit
-) : AsyncListener {
-    override fun onComplete(event: AsyncEvent) = Unit
-    override fun onStartAsync(event: AsyncEvent) = event.asyncContext.addListener(this)
-    override fun onError(event: AsyncEvent) = cancel()
-    override fun onTimeout(event: AsyncEvent) = cancel()
 }
 
 internal class CypherCancellationConnectionListener(
@@ -104,9 +110,11 @@ internal class DisconnectMonitor(
     private val scheduler: Scheduler,
     private val connection: HttpConnection?,
     private val cancel: () -> Unit,
-    private val onBackpressure: () -> Unit = {}
+    private val onBackpressure: () -> Unit = {},
+    monitoredEndPoint: AbstractEndPoint? = null
 ) : Runnable, Closeable {
-    private val endPoint = connection?.endPoint as? AbstractEndPoint
+    private val endPoint = monitoredEndPoint ?: connection?.endPoint as? AbstractEndPoint
+    private val connectionIdleTimeout = endPoint?.idleTimeout
     private val lock = Any()
     private val ownsReadInterest = AtomicBoolean()
     @Volatile
@@ -201,7 +209,13 @@ internal class DisconnectMonitor(
         return expandedCapacity - bufferedBytes
     }
 
-    fun start() = schedule(DISCONNECT_READ_INTEREST_DELAY_MILLIS)
+    fun start() {
+        // A Cypher request can legitimately perform no socket I/O for longer than Jetty's
+        // default 30-second connection idle timeout. The read interest below still detects
+        // a real peer disconnect, so suspend only the idle clock while this request is active.
+        endPoint?.idleTimeout = 0L
+        schedule(DISCONNECT_READ_INTEREST_DELAY_MILLIS)
+    }
 
     override fun run() {
         synchronized(lock) {
@@ -236,6 +250,21 @@ internal class DisconnectMonitor(
             ownsReadInterest.compareAndSet(true, false)
         }
         if (clearReadInterest) endPoint?.fillInterest?.onFail(DISCONNECT_MONITOR_CLOSED)
+        restoreConnectionIdleTimeout()
+    }
+
+    @Suppress("SwallowedException")
+    private fun restoreConnectionIdleTimeout() {
+        val idleTimeout = connectionIdleTimeout ?: return
+        val monitoredEndPoint = endPoint ?: return
+        monitoredEndPoint.notIdle()
+        try {
+            // Jetty updates the timeout value before scheduling its next idle check. A shutting-down
+            // scheduler can reject only that check; cleanup must still complete with the value restored.
+            monitoredEndPoint.idleTimeout = idleTimeout
+        } catch (_: RejectedExecutionException) {
+            Unit
+        }
     }
 
     private fun schedule(delayMillis: Long) {

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherResponseSerializer.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherResponseSerializer.kt
@@ -11,7 +11,7 @@ import java.io.Writer
 internal val GRAPHITE_GSON: Gson = GsonBuilder().setPrettyPrinting().create()
 
 internal fun interface CypherResponseSerializer {
-    fun write(ctx: Context, value: Any, cancellationSignal: CypherCancellationSignal)
+    fun write(ctx: Context, value: Map<String, Any?>, cancellationSignal: CypherCancellationSignal)
 }
 
 internal class GsonCypherResponseSerializer(
@@ -19,7 +19,14 @@ internal class GsonCypherResponseSerializer(
     private val progress: () -> Unit = {}
 ) : CypherResponseSerializer {
 
-    override fun write(ctx: Context, value: Any, cancellationSignal: CypherCancellationSignal) {
+    override fun write(
+        ctx: Context,
+        value: Map<String, Any?>,
+        cancellationSignal: CypherCancellationSignal
+    ) {
+        require(value[API_FIELD_ROW_COUNT] is Number) {
+            "A successful Cypher response must contain a numeric rowCount"
+        }
         ctx.contentType(ContentType.APPLICATION_JSON)
             .result(serialize(value, cancellationSignal))
     }

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
@@ -550,8 +550,17 @@ internal class ExploreRoutes(
                     try {
                         val error = unwrapCompletionFailure(outcome.exceptionOrNull())
                         if (error == null) {
-                            respond(outcome.getOrThrow(), cancellationSignal)
-                        } else if (error !is CypherQueryCancelledException) {
+                            try {
+                                respond(outcome.getOrThrow(), cancellationSignal)
+                            } catch (cancelled: CypherQueryCancelledException) {
+                                if (!clientCancellation.isClientDisconnected) {
+                                    respondCypherError(ctx, cancelled)
+                                }
+                            }
+                        } else if (
+                            error !is CypherQueryCancelledException ||
+                            !clientCancellation.isClientDisconnected
+                        ) {
                             respondCypherError(ctx, error)
                         }
                     } finally {
@@ -724,10 +733,12 @@ internal class ExploreRoutes(
         val code = when (error) {
             is CypherConcurrencyLimitException -> "cypher_concurrency_limit"
             is CypherBudgetExceededException -> "cypher_work_budget_exceeded"
+            is CypherQueryCancelledException -> "cypher_query_cancelled"
             else -> "cypher_query_failed"
         }
         val status = when (code) {
             "cypher_query_failed" -> HTTP_BAD_REQUEST
+            "cypher_query_cancelled" -> HTTP_SERVICE_UNAVAILABLE
             else -> HTTP_TOO_MANY_REQUESTS
         }
         if (error is CypherConcurrencyLimitException) ctx.header("Retry-After", "1")
@@ -1190,6 +1201,7 @@ internal class ExploreRoutes(
         private const val HTTP_NOT_FOUND = 404
         private const val HTTP_PAYLOAD_TOO_LARGE = 413
         private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val HTTP_SERVICE_UNAVAILABLE = 503
 
         private const val DEFAULT_ENTITY_LIMIT = 50
         private const val DEFAULT_EDGE_LIMIT = 200

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
@@ -66,6 +66,7 @@ internal class OpenApiSpecBuilder {
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
                         "429" to response("Cypher concurrency or work budget exceeded"),
+                        "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Graph not loaded")
                     )
                 ),
@@ -80,6 +81,7 @@ internal class OpenApiSpecBuilder {
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
                         "429" to response("Cypher concurrency or work budget exceeded"),
+                        "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Graph not loaded")
                     )
                 )
@@ -105,6 +107,7 @@ internal class OpenApiSpecBuilder {
                         "200" to response("Multi-graph Cypher result with graphId-tagged rows"),
                         "400" to response("Missing or invalid query"),
                         "429" to response("Cypher concurrency or work budget exceeded"),
+                        "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Requested graph not loaded")
                     )
                 ),
@@ -125,6 +128,7 @@ internal class OpenApiSpecBuilder {
                         "200" to response("Multi-graph Cypher result with graphId-tagged rows"),
                         "400" to response("Missing or invalid query"),
                         "429" to response("Cypher concurrency or work budget exceeded"),
+                        "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Requested graph not loaded")
                     )
                 )
@@ -271,7 +275,8 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded")
+                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "503" to response("Cypher cancelled while the client remained connected")
                     )
                 ),
                 "post" to operation(
@@ -283,7 +288,8 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded")
+                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "503" to response("Cypher cancelled while the client remained connected")
                     )
                 )
             ),

--- a/graphite-explore/src/main/resources/web/app.js
+++ b/graphite-explore/src/main/resources/web/app.js
@@ -477,6 +477,9 @@ async function fetchJson(url, options) {
         const message = data && data.error ? data.error : response.status + ' ' + response.statusText;
         throw new Error(message);
     }
+    if (data === null) {
+        throw new Error('Invalid empty JSON response for HTTP ' + response.status);
+    }
     return data;
 }
 

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherCancellationContractTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherCancellationContractTest.kt
@@ -1,0 +1,163 @@
+package io.johnsonlee.graphite.cli
+
+import com.google.gson.GsonBuilder
+import io.javalin.Javalin
+import io.javalin.http.Context
+import io.javalin.json.JavalinGson
+import io.johnsonlee.graphite.core.IntConstant
+import io.johnsonlee.graphite.core.Node
+import io.johnsonlee.graphite.core.NodeId
+import io.johnsonlee.graphite.cypher.CypherCancellationSignal
+import io.johnsonlee.graphite.graph.DefaultGraph
+import io.johnsonlee.graphite.graph.Graph
+import org.eclipse.jetty.server.AbstractConnector
+import java.lang.reflect.Proxy
+import java.net.HttpURLConnection
+import java.net.URI
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CypherCancellationContractTest {
+
+    @Test
+    fun `successful response serializer requires rowCount`() {
+        val context = Proxy.newProxyInstance(
+            Context::class.java.classLoader,
+            arrayOf(Context::class.java)
+        ) { _, _, _ -> error("Context must not be used before response validation") } as Context
+
+        assertFailsWith<IllegalArgumentException> {
+            GsonCypherResponseSerializer().write(
+                context,
+                mapOf(API_FIELD_ROWS to emptyList<Any>()),
+                CypherCancellationSignal()
+            )
+        }
+    }
+
+    @Test
+    fun `server-side cancellation is never reported as an empty success`() {
+        lateinit var cancellationSignal: CypherCancellationSignal
+        cancellationSignal = CypherCancellationSignal { cancellationSignal.cancel() }
+        val routes = ExploreRoutes(
+            CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = Long.MAX_VALUE),
+            cancellationSignalFactory = { cancellationSignal }
+        )
+        val app = testApp()
+
+        try {
+            routes.register(app, DefaultGraph.Builder().build())
+            val (status, body) = post(
+                app.port(),
+                """{"query":"RETURN size(range(1, 5000000)) AS n"}"""
+            )
+
+            assertEquals(503, status)
+            assertTrue(body.contains("cypher_query_cancelled"), body)
+        } finally {
+            app.stop()
+        }
+    }
+
+    @Test
+    fun `cancellation during response serialization returns an HTTP error`() {
+        lateinit var cancellationSignal: CypherCancellationSignal
+        cancellationSignal = CypherCancellationSignal()
+        val serializer = GsonCypherResponseSerializer { cancellationSignal.cancel() }
+        val routes = ExploreRoutes(
+            CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = Long.MAX_VALUE),
+            cancellationSignalFactory = { cancellationSignal },
+            cypherResponseSerializer = serializer
+        )
+        val app = testApp()
+
+        try {
+            routes.register(app, DefaultGraph.Builder().build())
+            val (status, body) = post(
+                app.port(),
+                """{"query":"RETURN range(1, 10000) AS values"}"""
+            )
+
+            assertEquals(503, status)
+            assertTrue(body.contains("cypher_query_cancelled"), body)
+        } finally {
+            app.stop()
+        }
+    }
+
+    @Test
+    fun `active Cypher query outlives the Jetty connection idle timeout`() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val node = IntConstant(NodeId.next(), 1)
+        val backing = DefaultGraph.Builder().addNode(node).build()
+        val blockingGraph = object : Graph by backing {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> = sequence {
+                if (type.isAssignableFrom(IntConstant::class.java)) {
+                    started.countDown()
+                    check(release.await(5, TimeUnit.SECONDS))
+                    @Suppress("UNCHECKED_CAST")
+                    yield(node as T)
+                }
+            }
+        }
+        val routes = ExploreRoutes(CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = Long.MAX_VALUE))
+        val app = testApp()
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            routes.register(app, blockingGraph)
+            app.jettyServer().server().connectors
+                .filterIsInstance<AbstractConnector>()
+                .forEach { it.idleTimeout = TEST_CONNECTION_IDLE_TIMEOUT_MILLIS }
+            val response = executor.submit<Pair<Int, String>> {
+                post(
+                    app.port(),
+                    """{"query":"MATCH (n:IntConstant) WHERE n.value + 0 = 1 RETURN n.value LIMIT 1"}"""
+                )
+            }
+            assertTrue(started.await(5, TimeUnit.SECONDS), "The query did not start")
+            Thread.sleep(TEST_QUERY_DELAY_MILLIS)
+            release.countDown()
+
+            val (status, body) = response.get(5, TimeUnit.SECONDS)
+            assertEquals(200, status)
+            assertTrue(body.contains("\"rowCount\": 1"), body)
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+            app.stop()
+        }
+    }
+
+    private fun testApp(): Javalin = Javalin.create { config ->
+        config.jsonMapper(JavalinGson(GsonBuilder().create()))
+    }.start(0)
+
+    private fun post(port: Int, body: String): Pair<Int, String> {
+        val connection = URI("http://127.0.0.1:$port/api/cypher").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Content-Type", "application/json")
+        connection.setRequestProperty("Connection", "close")
+        connection.connectTimeout = 1_000
+        connection.readTimeout = 5_000
+        connection.doOutput = true
+        connection.outputStream.bufferedWriter().use { it.write(body) }
+
+        return try {
+            val status = connection.responseCode
+            val stream = if (status >= 400) connection.errorStream else connection.inputStream
+            status to stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+        } finally {
+            connection.disconnect()
+        }
+    }
+}
+
+private const val TEST_CONNECTION_IDLE_TIMEOUT_MILLIS = 100L
+private const val TEST_QUERY_DELAY_MILLIS = 300L

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherClientCancellationTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherClientCancellationTest.kt
@@ -10,9 +10,7 @@ import io.johnsonlee.graphite.cypher.CypherCancellationSignal
 import io.johnsonlee.graphite.cypher.CypherQueryCancelledException
 import io.johnsonlee.graphite.graph.DefaultGraph
 import io.johnsonlee.graphite.graph.Graph
-import jakarta.servlet.AsyncContext
-import jakarta.servlet.AsyncEvent
-import jakarta.servlet.AsyncListener
+import org.eclipse.jetty.io.ByteArrayEndPoint
 import org.eclipse.jetty.io.Connection
 import org.eclipse.jetty.util.thread.Scheduler
 import java.io.ByteArrayOutputStream
@@ -27,6 +25,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
@@ -343,25 +342,6 @@ class CypherClientCancellationTest {
     }
 
     @Test
-    fun `servlet failures and timeouts cancel the query`() {
-        val cancellations = AtomicInteger()
-        val listener = CypherCancellationAsyncListener(cancellations::incrementAndGet)
-        val registered = arrayListOf<AsyncListener>()
-        val asyncContext = proxy<AsyncContext> { methodName, arguments ->
-            if (methodName == "addListener") registered += arguments.single() as AsyncListener
-            null
-        }
-        val event = AsyncEvent(asyncContext)
-
-        listener.onStartAsync(event)
-        listener.onError(event)
-        listener.onTimeout(event)
-
-        assertEquals(listOf<AsyncListener>(listener), registered)
-        assertEquals(2, cancellations.get())
-    }
-
-    @Test
     fun `closing the Jetty connection cancels the query`() {
         val cancellations = AtomicInteger()
         val listener = CypherCancellationConnectionListener(cancellations::incrementAndGet)
@@ -390,6 +370,35 @@ class CypherClientCancellationTest {
         scheduled.removeFirst().run()
         assertEquals(1, scheduled.size)
         monitor.close()
+    }
+
+    @Test
+    fun `disconnect monitor restores idle timeout when scheduler rejects cleanup`() {
+        val rejectScheduling = AtomicReference(false)
+        val scheduler = proxy<Scheduler> { methodName, _ ->
+            when (methodName) {
+                "schedule" -> {
+                    if (rejectScheduling.get()) throw RejectedExecutionException("scheduler stopped")
+                    proxy<Scheduler.Task> { taskMethod, _ -> taskMethod == "cancel" }
+                }
+                else -> null
+            }
+        }
+        val endPoint = ByteArrayEndPoint(scheduler, ORIGINAL_IDLE_TIMEOUT_MILLIS).apply { onOpen() }
+        val monitor = DisconnectMonitor(
+            scheduler,
+            connection = null,
+            cancel = {},
+            monitoredEndPoint = endPoint
+        )
+
+        monitor.start()
+        assertEquals(0L, endPoint.idleTimeout)
+        rejectScheduling.set(true)
+        monitor.close()
+
+        assertEquals(ORIGINAL_IDLE_TIMEOUT_MILLIS, endPoint.idleTimeout)
+        endPoint.close()
     }
 
     private fun verifyResetDisconnect(beforeReset: (Socket) -> Unit = {}) {
@@ -586,9 +595,12 @@ class CypherClientCancellationTest {
         val cancellationSignal = CypherCancellationSignal {
             if (checkpoints.incrementAndGet() == GRAPH_FREE_PROGRESS_CHECKPOINTS) progress.countDown()
         }
+        val createdSignals = AtomicInteger()
         val routes = ExploreRoutes(
             CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 1, performance = performance),
-            cancellationSignalFactory = { cancellationSignal }
+            cancellationSignalFactory = {
+                if (createdSignals.getAndIncrement() == 0) cancellationSignal else CypherCancellationSignal()
+            }
         )
         val app = Javalin.create { config ->
             config.jsonMapper(JavalinGson(GsonBuilder().create()))
@@ -738,6 +750,7 @@ private class DisconnectPerformanceRecorder : CypherPerformanceRecorder {
 }
 
 private const val MAX_DISCONNECT_LATENCY_MILLIS = 2_000L
+private const val ORIGINAL_IDLE_TIMEOUT_MILLIS = 30_000L
 private const val PIPELINED_REQUEST_BUFFER_MILLIS = 200L
 private const val LARGE_PIPELINE_REQUESTS = 150
 private const val VALID_PIPELINE_PADDING_BYTES = 550_000

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -1528,6 +1528,7 @@ class ExploreCommandTest {
         @Suppress("UNCHECKED_CAST")
         val responses = post["responses"] as Map<String, Any?>
         assertTrue(responses.containsKey("429"))
+        assertTrue(responses.containsKey("503"))
     }
 
     @Test
@@ -3522,6 +3523,19 @@ class ExploreCommandTest {
         val (code, body) = post("/api/cypher", """{"query": "MATCH (n:IntConstant) RETURN n.value"}""")
         assertEquals(200, code, "Expected 200, body: $body")
         assertTrue(body.contains("columns"), "Response should contain 'columns', body: $body")
+    }
+
+    @Test
+    fun `POST api cypher returns a structured empty result when nothing matches`() {
+        val (code, body) = post(
+            "/api/cypher",
+            """{"query":"MATCH (n:IntConstant) WHERE n.value = -1 RETURN n.value"}"""
+        )
+
+        assertEquals(200, code, body)
+        val result: Map<String, Any?> = parseJson(body)
+        assertEquals(0.0, result[API_FIELD_ROW_COUNT])
+        assertEquals(emptyList<Any>(), result[API_FIELD_ROWS])
     }
 
     @Test


### PR DESCRIPTION
## Summary

- suspend Jetty connection idle expiry only while an active Cypher request is running, while retaining explicit close/reset/socket-error detection
- distinguish a real client disconnect from server-side cancellation so a connected client receives HTTP 503 with code cypher_query_cancelled instead of HTTP 200 with an empty body
- require every successful Cypher response to contain a numeric rowCount, including rowCount 0 for no matches; reject null JSON success responses in the explorer UI
- document the contract and advertise the 503 response in OpenAPI

This fixes the regression introduced by the asynchronous request lifecycle in #96: a query that performed no socket I/O for Jetty's default 30-second idle interval could have its connection closed and its work cancelled before a client-side 60-second timeout. The cancellation was then suppressed, leaving Javalin to emit HTTP 200 with no body.

## Correctness contract

- A healthy, connected request is not cancelled merely because the connection is idle.
- An observed connection close, TCP reset, or socket error cancels in-flight work and releases its concurrency permit.
- A server-side cancellation while the client remains connected is an HTTP error, not an empty success.
- Every HTTP 2xx Cypher payload has a numeric rowCount; no matches are represented as rows: [] and rowCount: 0.

## Verification

- ./gradlew check -S --no-daemon
- ./gradlew :explore:detekt :explore:test :explore:koverLog -S --no-daemon --rerun-tasks
- node --test graphite-explore/src/test/js/ui-state.test.js (7/7)
- node --test .github/scripts/benchmark-gate.test.mjs (33/33)
- explore line coverage: 98.0066%
- independent final code review: no remaining merge blocker

Contract coverage includes a query outliving a deliberately short Jetty idle timeout, zero-row success shape, execution- and serialization-stage cancellation returning 503 to a connected client, reset/half-close/pipelining behavior, permit release, and idle-timeout restoration when the Jetty scheduler rejects cleanup scheduling.

## Performance

Environment: Apple M3 Max, Darwin 23.3.0 arm64, OpenJDK 17.0.18. Benchmark: io.johnsonlee.graphite.cli.CypherHttpBenchmark.connectedScalarQuery with metricsEnabled=false.

Initial command, run base then candidate:

    java -jar <revision>/graphite-explore/build/libs/explore-1.0.0-SNAPSHOT-jmh.jar io.johnsonlee.graphite.cli.CypherHttpBenchmark.connectedScalarQuery -p metricsEnabled=false -wi 3 -w 1s -i 8 -r 1s -f 1 -t 1 -foe true -rf json -rff <result.json>

Reverse-order confirmation, run candidate then base:

    java -jar <revision>/graphite-explore/build/libs/explore-1.0.0-SNAPSHOT-jmh.jar io.johnsonlee.graphite.cli.CypherHttpBenchmark.connectedScalarQuery -p metricsEnabled=false -wi 4 -w 1s -i 10 -r 1s -f 1 -t 1 -foe true -prof gc -rf json -rff <result.json>

| Round | Base | Candidate | Delta | Allocation |
| --- | ---: | ---: | ---: | ---: |
| Initial | 73.384 +/- 7.285 us/op | 104.318 +/- 39.829 us/op | +42.2% | not profiled |
| Reverse confirmation | 85.239 +/- 7.907 us/op | 74.793 +/- 4.748 us/op | -12.3% | base 39,215.389 B/op; candidate 39,246.326 B/op |

Method-level conclusion: the repository compare/confirm gate classifies the initial result as NOISE and passes the reverse confirmation; there is no confirmed >15% regression. Allocation changes by approximately +31 B/op.

End-to-end conclusion: the local full check and the required same-runner comparison against main both pass; all three LargeCorpusPerformanceGateTest corpora remain within their gates. The authoritative aggregate result is [Benchmark Regression Gate: PASS](https://github.com/johnsonlee/graphite/pull/103#issuecomment-5462964323).

Closes the HTTP null-body symptom associated with #96.