### PR TITLE
Bound and accelerate broad Cypher searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ graphite serve --data /data/graphs \
   --graph billing:/data/billing-graph \
   --topology /rules/company-topology.cypher \
   --max-concurrent-cypher 4 \
-  --cypher-work-budget 1000000 \
+  --cypher-max-timeout-ms 60000 \
   --port 8080
 
 # Hot-load or replace a graph without restarting the server
@@ -287,20 +287,23 @@ A global discovery query belongs on `/api/cypher`. Enumerating `/api/graphs`
 and then calling `/api/graphs/{graphId}/cypher` for each entry performs
 client-side fan-out and repeats HTTP and Cypher parsing overhead.
 
-Cypher endpoints admit at most four executing queries by default and stop a
-query after 1,000,000 graph work units. Graph-node candidate inspections and materialized
-path elements consume work units. Configure these bounds with
-`--max-concurrent-cypher` and `--cypher-work-budget`. A rejected request returns
-HTTP 429 with `code` set to `cypher_concurrency_limit` or
-`cypher_work_budget_exceeded`. Result `LIMIT` controls returned rows; it does not
-replace this execution budget for aggregations that must scan before limiting.
-Streaming `Method` metadata reads poll cancellation but do not spend graph work
-units, so complete multi-graph method discovery does not depend on descriptor count.
+Cypher endpoints admit at most four executing queries by default and enforce a
+60-second maximum request timeout. Configure these bounds with
+`--max-concurrent-cypher` and `--cypher-max-timeout-ms`. Clients may request a
+shorter positive `timeoutMs` in the query string or JSON body; the effective
+timeout is the smaller of the client value and the server maximum. A timeout
+automatically cancels and interrupts the corresponding query, returning HTTP
+504 with `code` set to `cypher_query_timeout`. Concurrency rejection returns
+HTTP 429 with `code` set to `cypher_concurrency_limit`.
+
+`--cypher-work-budget` is deprecated and ignored. It remains accepted for
+command-line compatibility but no longer constrains server requests. Core
+library callers may still use `CypherExecutionBudget` directly.
 The `=~` operator preserves Java `Pattern` syntax, including backreferences,
 look-around, possessive quantifiers, character-class intersections, and Java's
-default line-terminator behavior. Budgeted execution polls cancellation through
+default line-terminator behavior. Server execution polls cancellation through
 the matcher's input without changing the accepted pattern language.
-An executing query is cancelled only when the server observes an actual connection close,
+An executing query is also cancelled when the server observes an actual connection close,
 TCP reset, or socket error. Jetty's connection idle clock is suspended while Cypher is
 executing, because a query can legitimately perform no socket I/O for longer than the
 connector's default 30-second idle timeout. A clean input FIN is not treated as cancellation:

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/CypherExecutionBudget.kt
@@ -4,6 +4,7 @@ import io.johnsonlee.graphite.graph.GraphWorkConsumer
 import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 internal const val CANCELLATION_POLL_MASK = 1_023
 
@@ -38,18 +39,31 @@ class CypherCancellationSignal(
     private val checkObserver: (() -> Unit)? = null
 ) {
     private val cancelled = AtomicBoolean()
+    private val cancellation = AtomicReference<CypherQueryCancelledException?>()
 
     val isCancelled: Boolean get() = cancelled.get()
 
-    fun cancel(): Boolean = cancelled.compareAndSet(false, true)
+    fun cancel(): Boolean = cancel(CypherQueryCancelledException())
+
+    fun cancel(reason: CypherQueryCancelledException): Boolean {
+        if (!cancellation.compareAndSet(null, reason)) return false
+        cancelled.set(true)
+        return true
+    }
+
+    fun cancellationException(): CypherQueryCancelledException =
+        cancellation.get() ?: CypherQueryCancelledException()
 
     fun throwIfCancelled() {
         checkObserver?.invoke()
-        if (isCancelled) throw CypherQueryCancelledException()
+        if (isCancelled) throw cancellationException()
     }
 }
 
-class CypherQueryCancelledException : CancellationException("Cypher query cancelled")
+open class CypherQueryCancelledException(message: String = "Cypher query cancelled") : CancellationException(message)
+
+class CypherQueryTimeoutException(val timeoutMillis: Long) :
+    CypherQueryCancelledException("Cypher query timed out after $timeoutMillis ms")
 
 class CypherBudgetExceededException(
     val maxWorkUnits: Long

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -766,17 +766,54 @@ class QueryPipeline private constructor(
                 limitCount
             )
         }
-        if (ret.distinct && nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()) {
+        if (nodePattern.labels.size <= 1 && nodePattern.properties.isEmpty()) {
             val directStringDisjunction = DirectStringDisjunction.compile(where.condition, variable)
             if (directStringDisjunction != null) {
-                return executeDirectStringDisjunction(
-                    nodeClass,
-                    variable,
-                    directStringDisjunction,
-                    ret.items,
-                    columns,
-                    limitCount
-                )
+                return if (ret.distinct) {
+                    executeDirectStringDisjunction(
+                        nodeClass,
+                        variable,
+                        directStringDisjunction,
+                        ret.items,
+                        columns,
+                        limitCount
+                    )
+                } else {
+                    executeDirectStringDisjunctionRows(
+                        nodeClass,
+                        variable,
+                        directStringDisjunction,
+                        ret.items,
+                        columns,
+                        limitCount
+                    )
+                }
+            }
+            val directStringConjunction = DirectStringConjunction.compile(where.condition, variable)
+            if (directStringConjunction != null) {
+                val candidates = DirectStringDisjunction(listOf(directStringConjunction.required))
+                val predicate = directStringConjunction::matches
+                return if (ret.distinct) {
+                    executeDirectStringDisjunction(
+                        nodeClass,
+                        variable,
+                        candidates,
+                        ret.items,
+                        columns,
+                        limitCount,
+                        predicate
+                    )
+                } else {
+                    executeDirectStringDisjunctionRows(
+                        nodeClass,
+                        variable,
+                        candidates,
+                        ret.items,
+                        columns,
+                        limitCount,
+                        predicate
+                    )
+                }
             }
         }
 
@@ -881,7 +918,8 @@ class QueryPipeline private constructor(
         filter: DirectStringDisjunction,
         items: List<ReturnItem>,
         columns: List<String>,
-        limit: Int
+        limit: Int,
+        nodePredicate: ((Node) -> Boolean)? = null
     ): CypherResult {
         if (canExecuteDirectStringDisjunctionInParallel(nodeClass, variable, filter, items)) {
             return executeDirectStringDisjunctionInParallel(
@@ -890,10 +928,65 @@ class QueryPipeline private constructor(
                 filter,
                 items,
                 columns,
-                limit
+                limit,
+                nodePredicate
             )
         }
-        return executeDirectStringDisjunctionSerial(nodeClass, variable, filter, items, columns, limit)
+        return executeDirectStringDisjunctionSerial(
+            nodeClass,
+            variable,
+            filter,
+            items,
+            columns,
+            limit,
+            nodePredicate
+        )
+    }
+
+    @Suppress("NestedBlockDepth", "ReturnCount")
+    private fun executeDirectStringDisjunctionRows(
+        nodeClass: Class<out Node>,
+        variable: String,
+        filter: DirectStringDisjunction,
+        items: List<ReturnItem>,
+        columns: List<String>,
+        limit: Int,
+        nodePredicate: ((Node) -> Boolean)? = null
+    ): CypherResult {
+        if (!canExecuteDirectStringDisjunctionInParallel(nodeClass, variable, filter, items)) {
+            val rows = mutableListOf<Map<String, Any?>>()
+            for (source in sources) {
+                val candidates = directStringCandidates(source.graph, nodeClass, filter)
+                    .let { nodes -> nodePredicate?.let { predicate -> nodes.filter(predicate) } ?: nodes }
+                for (node in candidates) {
+                    val candidate = nodeValue(source, node)
+                    val bindings = mutableMapOf<String, Any?>(variable to candidate)
+                    addProvenance(bindings, candidate)
+                    rows += projectRow(items, columns, bindings)
+                    if (rows.size >= limit) return CypherResult(columns, rows)
+                }
+            }
+            return CypherResult(columns, rows)
+        }
+
+        val tracker = if (workTrackingEnabled) activeWorkTracker.get() else null
+        val scanners = sources.map { source ->
+            DirectStringSourceScanner(source, nodeClass, filter, variable, items, columns, tracker, nodePredicate)
+        }
+        val rows = mutableListOf<Map<String, Any?>>()
+        var waveStart = 0
+        while (waveStart < scanners.size && rows.size < limit) {
+            val wave = scanners.subList(waveStart, minOf(scanners.size, waveStart + directStringParallelism))
+            val batches = runDirectStringTasks(wave.map { scanner ->
+                { scanner.nextRows(limit) }
+            })
+            batches.forEach { batch ->
+                val remaining = limit - rows.size
+                if (remaining > 0) rows += batch.take(remaining)
+            }
+            waveStart += wave.size
+        }
+        return CypherResult(columns, rows)
     }
 
     private fun executeDirectStringDisjunctionSerial(
@@ -902,11 +995,14 @@ class QueryPipeline private constructor(
         filter: DirectStringDisjunction,
         items: List<ReturnItem>,
         columns: List<String>,
-        limit: Int
+        limit: Int,
+        nodePredicate: ((Node) -> Boolean)?
     ): CypherResult {
         val rows = LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>()
         for (source in sources) {
-            for (node in directStringCandidates(source.graph, nodeClass, filter)) {
+            val candidates = directStringCandidates(source.graph, nodeClass, filter)
+                .let { nodes -> nodePredicate?.let { predicate -> nodes.filter(predicate) } ?: nodes }
+            for (node in candidates) {
                 val candidate = nodeValue(source, node)
                 val bindings = mutableMapOf<String, Any?>(variable to candidate)
                 addProvenance(bindings, candidate)
@@ -959,11 +1055,12 @@ class QueryPipeline private constructor(
         filter: DirectStringDisjunction,
         items: List<ReturnItem>,
         columns: List<String>,
-        limit: Int
+        limit: Int,
+        nodePredicate: ((Node) -> Boolean)?
     ): CypherResult {
         val tracker = if (workTrackingEnabled) activeWorkTracker.get() else null
         val scanners = sources.map { source ->
-            DirectStringSourceScanner(source, nodeClass, filter, variable, items, columns, tracker)
+            DirectStringSourceScanner(source, nodeClass, filter, variable, items, columns, tracker, nodePredicate)
         }
         val rows = LinkedHashMap<Map<String, Any?>, MutableMap<String, Any?>>()
         var waveStart = 0
@@ -1087,12 +1184,15 @@ class QueryPipeline private constructor(
         private val variable: String,
         private val items: List<ReturnItem>,
         private val columns: List<String>,
-        private val tracker: CypherWorkTracker?
+        private val tracker: CypherWorkTracker?,
+        private val nodePredicate: ((Node) -> Boolean)? = null
     ) {
         private val graphLock = directStringGraphLock(source.graph)
         private val localRows = HashSet<Map<String, Any?>>()
         private val iterator by lazy {
-            directStringCandidates(source.graph, nodeClass, filter, tracker).iterator()
+            directStringCandidates(source.graph, nodeClass, filter, tracker)
+                .let { nodes -> nodePredicate?.let { predicate -> nodes.filter(predicate) } ?: nodes }
+                .iterator()
         }
         private var exhausted = false
         private var inspected = 0
@@ -1110,6 +1210,19 @@ class QueryPipeline private constructor(
                 pollInterrupted()
             }
             DirectStringScanBatch(rows, exhausted)
+        }
+
+        fun nextRows(maxRows: Int): List<Map<String, Any?>> = withGraphLock {
+            val rows = mutableListOf<Map<String, Any?>>()
+            while (!exhausted && rows.size < maxRows) {
+                if (!iterator.hasNext()) {
+                    exhausted = true
+                    break
+                }
+                rows += projectParallelSafeNode(iterator.next())
+                pollInterrupted()
+            }
+            rows
         }
 
         fun collectRemainingSelectedRows(
@@ -1439,6 +1552,33 @@ class QueryPipeline private constructor(
                 val argument = call.args.singleOrNull() as? CypherExpr.Property ?: return false
                 return argument.expression == CypherExpr.Variable(variable) && argument.propertyName == property
             }
+        }
+    }
+
+    private data class DirectStringConjunction(
+        val required: DirectStringFilter,
+        val anyOf: DirectStringDisjunction
+    ) {
+        fun matches(node: Node): Boolean = required.matches(node) && anyOf.matches(node)
+
+        companion object {
+            fun compile(expression: CypherExpr, variable: String): DirectStringConjunction? {
+                val and = expression as? CypherExpr.And ?: return null
+                return compile(and.left, and.right, variable) ?: compile(and.right, and.left, variable)
+            }
+
+            private fun compile(
+                requiredExpression: CypherExpr,
+                disjunctionExpression: CypherExpr,
+                variable: String
+            ): DirectStringConjunction? = DirectStringFilter.compile(requiredExpression, variable)
+                ?.takeIf { required ->
+                    DIRECT_STRING_NODE_PROPERTIES.any { (_, properties) -> required.property in properties }
+                }
+                ?.let { required ->
+                    DirectStringDisjunction.compile(disjunctionExpression, variable)
+                        ?.let { anyOf -> DirectStringConjunction(required, anyOf) }
+                }
         }
     }
 

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -620,6 +620,139 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `non distinct broad discovery scans graphs concurrently and preserves source rows`() {
+        if (Runtime.getRuntime().availableProcessors() < 2) return
+        val active = AtomicInteger()
+        val maximumActive = AtomicInteger()
+        val workersReady = CyclicBarrier(2)
+        val returnType = TypeDescriptor("void")
+
+        fun backingGraph(graphId: String): Graph = DefaultGraph.Builder().apply {
+                repeat(2) { index ->
+                    addNode(
+                        CallSiteNode(
+                            NodeId(index),
+                            MethodDescriptor(
+                                TypeDescriptor("example.$graphId.Target"),
+                                "call$index",
+                                emptyList(),
+                                returnType
+                            ),
+                            MethodDescriptor(TypeDescriptor("example.Repository"), "load", emptyList(), returnType),
+                            index,
+                            null,
+                            emptyList()
+                        )
+                    )
+                }
+            }.build()
+
+        fun parallelGraph(graphId: String): Graph {
+            val backing = backingGraph(graphId)
+            return object : Graph by backing, StringPropertyDisjunctionLookup {
+                override fun <T : Node> nodesByStringPropertyDisjunction(
+                    type: Class<T>,
+                    predicates: List<StringPropertyPredicate>,
+                    limit: Int
+                ): Sequence<T> = sequence {
+                    if (type != CallSiteNode::class.java) return@sequence
+                    val now = active.incrementAndGet()
+                    maximumActive.accumulateAndGet(now, ::maxOf)
+                    try {
+                        workersReady.await(2, TimeUnit.SECONDS)
+                        @Suppress("UNCHECKED_CAST")
+                        for (node in backing.nodes(CallSiteNode::class.java).take(limit)) yield(node as T)
+                    } finally {
+                        active.decrementAndGet()
+                    }
+                }
+            }
+        }
+
+        val result = executor(
+            "orders" to parallelGraph("orders"),
+            "billing" to parallelGraph("billing")
+        ).execute(
+            "MATCH (n:CallSiteNode) WHERE " +
+                "n.caller_class CONTAINS 'Target' OR n.callee_class CONTAINS 'Target' " +
+                "RETURN n.graphId AS graph, n.caller_name AS caller LIMIT 3"
+        )
+
+        assertEquals(listOf("orders", "orders", "billing"), result.rows.map { it["graph"] })
+        assertEquals(listOf("call0", "call1", "call0"), result.rows.map { it["caller"] })
+        assertEquals(listOf(listOf("orders"), listOf("orders"), listOf("billing")), result.rows.map(::graphIds))
+        assertEquals(2, maximumActive.get())
+
+        val serialResult = executor("catalog" to backingGraph("catalog")).execute(
+            "MATCH (n:CallSiteNode) WHERE " +
+                "n.caller_class CONTAINS 'Target' OR n.callee_class CONTAINS 'Target' " +
+                "RETURN n.graphId AS graph, n.caller_name AS caller LIMIT 3"
+        )
+        assertEquals(listOf("catalog", "catalog"), serialResult.rows.map { it["graph"] })
+        assertEquals(listOf("call0", "call1"), serialResult.rows.map { it["caller"] })
+        assertEquals(listOf(listOf("catalog"), listOf("catalog")), serialResult.rows.map(::graphIds))
+    }
+
+    @Test
+    fun `direct string conjunction pushes down its required predicate and applies residual disjunction`() {
+        val lookupCalls = AtomicInteger()
+        val returnType = TypeDescriptor("void")
+
+        fun indexedGraph(): Graph {
+            val backing = DefaultGraph.Builder().apply {
+                listOf("Keep", "Drop").forEachIndexed { index, methodName ->
+                    addNode(
+                        CallSiteNode(
+                            NodeId(index),
+                            MethodDescriptor(TypeDescriptor("example.Target"), methodName, emptyList(), returnType),
+                            MethodDescriptor(TypeDescriptor("example.Repository"), "load", emptyList(), returnType),
+                            index,
+                            null,
+                            emptyList()
+                        )
+                    )
+                }
+            }.build()
+            return object : Graph by backing, StringPropertyDisjunctionLookup {
+                override fun <T : Node> nodesByStringPropertyDisjunction(
+                    type: Class<T>,
+                    predicates: List<StringPropertyPredicate>,
+                    limit: Int
+                ): Sequence<T> {
+                    if (type != CallSiteNode::class.java) return emptySequence()
+                    lookupCalls.incrementAndGet()
+                    assertEquals(listOf("caller_class"), predicates.map { it.property })
+                    @Suppress("UNCHECKED_CAST")
+                    return backing.nodes(CallSiteNode::class.java).take(limit) as Sequence<T>
+                }
+            }
+        }
+
+        val queryExecutor = executor(
+            "orders" to indexedGraph(),
+            "billing" to indexedGraph()
+        )
+        val result = queryExecutor.execute(
+            "MATCH (n:CallSiteNode) WHERE n.caller_class CONTAINS 'Target' AND " +
+                "(n.caller_name CONTAINS 'Keep' OR n.callee_name CONTAINS 'Keep') " +
+                "RETURN DISTINCT n.caller_name AS caller LIMIT 10"
+        )
+
+        assertEquals(listOf("Keep"), result.rows.map { it["caller"] })
+        assertEquals(listOf("billing", "orders"), graphIds(result.rows.single()))
+
+        val sourceRows = queryExecutor.execute(
+            "MATCH (n:CallSiteNode) WHERE n.caller_class CONTAINS 'Target' AND " +
+                "(n.caller_name CONTAINS 'Keep' OR n.callee_name CONTAINS 'Keep') " +
+                "RETURN n.graphId AS graph, n.caller_name AS caller LIMIT 10"
+        )
+        assertEquals(listOf("orders", "billing"), sourceRows.rows.map { it["graph"] })
+        assertEquals(listOf("Keep", "Keep"), sourceRows.rows.map { it["caller"] })
+        assertEquals(listOf(listOf("orders"), listOf("billing")), sourceRows.rows.map(::graphIds))
+        assertEquals(4, lookupCalls.get())
+    }
+
+    @Test
     fun `broad discovery query preserves dynamic annotation properties`() {
         val annotation = AnnotationNode(
             NodeId(1),

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CypherExecutorTest.kt
@@ -366,6 +366,22 @@ class CypherExecutorTest {
     }
 
     @Test
+    fun `cancellation signal preserves the first cancellation reason`() {
+        val cancellation = CypherCancellationSignal()
+        assertEquals("Cypher query cancelled", cancellation.cancellationException().message)
+
+        val timeout = CypherQueryTimeoutException(25)
+        assertTrue(cancellation.cancel(timeout))
+        assertFalse(cancellation.cancel())
+        assertTrue(cancellation.isCancelled)
+        assertTrue(cancellation.cancellationException() === timeout)
+
+        val thrown = assertFailsWith<CypherQueryTimeoutException> { cancellation.throwIfCancelled() }
+        assertTrue(thrown === timeout)
+        assertEquals(25, thrown.timeoutMillis)
+    }
+
+    @Test
     fun `execution context cancellation remains active across sequential executors`() {
         val cancellation = CypherCancellationSignal()
         val context = CypherExecutionContext(CypherExecutionBudget(maxWorkUnits = 10), cancellation)

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuard.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuard.kt
@@ -5,11 +5,14 @@ import io.johnsonlee.graphite.cypher.CypherBudgetExceededException
 import io.johnsonlee.graphite.cypher.CypherExecutionBudget
 import io.johnsonlee.graphite.cypher.CypherExecutionContext
 import io.johnsonlee.graphite.cypher.CypherQueryCancelledException
+import io.johnsonlee.graphite.cypher.CypherQueryTimeoutException
 import java.io.Closeable
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.Semaphore
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ThreadPoolExecutor
@@ -20,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 internal const val DEFAULT_MAX_CONCURRENT_CYPHER = 4
 internal const val DEFAULT_CYPHER_WORK_BUDGET = 1_000_000L
+internal const val DEFAULT_CYPHER_MAX_TIMEOUT_MILLIS = 60_000L
 private const val CYPHER_GUARD_CLOSED = "Cypher query guard is closed"
 
 internal class CypherConcurrencyLimitException(maxConcurrent: Int) : RuntimeException(
@@ -29,16 +33,19 @@ internal class CypherConcurrencyLimitException(maxConcurrent: Int) : RuntimeExce
 internal class CypherQueryGuard(
     private val maxConcurrent: Int = DEFAULT_MAX_CONCURRENT_CYPHER,
     maxWorkUnits: Long = DEFAULT_CYPHER_WORK_BUDGET,
-    private val performance: CypherPerformanceRecorder = NoOpCypherPerformanceRecorder
+    private val performance: CypherPerformanceRecorder = NoOpCypherPerformanceRecorder,
+    private val maxTimeoutMillis: Long = DEFAULT_CYPHER_MAX_TIMEOUT_MILLIS
 ) : Closeable {
     private val permits: Semaphore
     private val executionBudget = CypherExecutionBudget(maxWorkUnits)
     private val closed = AtomicBoolean()
     private val executor: ThreadPoolExecutor
+    private val timeoutExecutor: ScheduledThreadPoolExecutor
     private val active = ConcurrentHashMap.newKeySet<CypherQueryWork<*>>()
 
     init {
         require(maxConcurrent > 0) { "maxConcurrent must be positive" }
+        require(maxTimeoutMillis > 0) { "maxTimeoutMillis must be positive" }
         permits = Semaphore(maxConcurrent)
         executor = ThreadPoolExecutor(
             maxConcurrent,
@@ -48,6 +55,9 @@ internal class CypherQueryGuard(
             LinkedBlockingQueue(maxConcurrent),
             CypherThreadFactory()
         )
+        timeoutExecutor = ScheduledThreadPoolExecutor(1, CypherTimeoutThreadFactory()).apply {
+            removeOnCancelPolicy = true
+        }
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -74,10 +84,13 @@ internal class CypherQueryGuard(
 
     fun <T> submit(
         cancellationSignal: CypherCancellationSignal,
+        clientTimeoutMillis: Long? = null,
         continuation: (Result<T>) -> Unit = {},
         block: (CypherExecutionContext) -> T
     ): CypherQueryTask<T> {
         check(!closed.get()) { CYPHER_GUARD_CLOSED }
+        require(clientTimeoutMillis == null || clientTimeoutMillis > 0) { "clientTimeoutMillis must be positive" }
+        val effectiveTimeoutMillis = minOf(clientTimeoutMillis ?: maxTimeoutMillis, maxTimeoutMillis)
         if (!permits.tryAcquire()) {
             performance.reject()
             throw CypherConcurrencyLimitException(maxConcurrent)
@@ -86,6 +99,13 @@ internal class CypherQueryGuard(
         val work = CypherQueryWork(cancellationSignal, block, continuation, performance.start())
         active.add(work)
         try {
+            work.bindTimeout(
+                timeoutExecutor.schedule(
+                    { work.timeout(effectiveTimeoutMillis) },
+                    effectiveTimeoutMillis,
+                    TimeUnit.MILLISECONDS
+                )
+            )
             executor.execute(work)
         } catch (error: RejectedExecutionException) {
             performance.reject()
@@ -97,6 +117,7 @@ internal class CypherQueryGuard(
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         active.forEach { it.cancel() }
+        timeoutExecutor.shutdownNow()
         executor.shutdownNow().filterIsInstance<CypherQueryWork<*>>().forEach {
             it.reject(RejectedExecutionException(CYPHER_GUARD_CLOSED))
         }
@@ -111,20 +132,21 @@ internal class CypherQueryGuard(
         val completion = CompletableFuture<T>()
         private val lifecycleLock = Any()
         private val runner = AtomicReference<Thread?>()
+        private val timeoutFuture = AtomicReference<ScheduledFuture<*>?>()
         private val finishStarted = AtomicBoolean()
         private val finished = AtomicBoolean()
 
         override fun run() {
             runner.set(Thread.currentThread())
             val outcome = runCatching {
-                if (cancellationSignal.isCancelled) throw CypherQueryCancelledException()
+                if (cancellationSignal.isCancelled) throw cancellationException()
                 block(CypherExecutionContext(executionBudget, cancellationSignal)).also {
-                    if (cancellationSignal.isCancelled) throw CypherQueryCancelledException()
+                    if (cancellationSignal.isCancelled) throw cancellationException()
                 }
             }.fold(
                 onSuccess = { Result.success(it) },
                 onFailure = { error ->
-                    Result.failure(if (cancellationSignal.isCancelled) CypherQueryCancelledException() else error)
+                    Result.failure(if (cancellationSignal.isCancelled) cancellationException() else error)
                 }
             )
             try {
@@ -135,12 +157,21 @@ internal class CypherQueryGuard(
             }
         }
 
-        fun cancel() {
+        fun bindTimeout(future: ScheduledFuture<*>) {
+            timeoutFuture.set(future)
+            if (finished.get()) timeoutFuture.getAndSet(null)?.cancel(false)
+        }
+
+        fun cancel() = cancel(CypherQueryCancelledException())
+
+        fun timeout(timeoutMillis: Long) = cancel(CypherQueryTimeoutException(timeoutMillis))
+
+        private fun cancel(error: CypherQueryCancelledException) {
             val shouldInterrupt = synchronized(lifecycleLock) {
                 if (finished.get()) {
                     false
                 } else {
-                    cancellationSignal.cancel()
+                    cancellationSignal.cancel(error)
                     true
                 }
             }
@@ -156,7 +187,7 @@ internal class CypherQueryGuard(
             if (!finishStarted.compareAndSet(false, true)) return
             val continuationOutcome = synchronized(lifecycleLock) {
                 if (cancellationSignal.isCancelled && outcome.isSuccess) {
-                    Result.failure(CypherQueryCancelledException())
+                    Result.failure(cancellationException())
                 } else {
                     outcome
                 }
@@ -172,7 +203,7 @@ internal class CypherQueryGuard(
                         continuationResult.exceptionOrNull().isCancellationFailure()
                     )
                 val finalOutcome = if (cancellationWon) {
-                    Result.failure(CypherQueryCancelledException())
+                    Result.failure(cancellationException())
                 } else {
                     continuationResult
                 }
@@ -180,6 +211,7 @@ internal class CypherQueryGuard(
                 finalOutcome to (finalOutcome.exceptionOrNull()?.toQueryOutcome() ?: CypherQueryOutcome.SUCCESS)
             }
             try {
+                timeoutFuture.getAndSet(null)?.cancel(false)
                 active.remove(this)
                 performance.stop(startedAtNanos, queryOutcome)
             } finally {
@@ -187,6 +219,9 @@ internal class CypherQueryGuard(
             }
             publishedOutcome.fold(completion::complete, completion::completeExceptionally)
         }
+
+        private fun cancellationException(): CypherQueryCancelledException =
+            cancellationSignal.cancellationException()
     }
 }
 
@@ -208,18 +243,27 @@ private class CypherThreadFactory : ThreadFactory {
     }
 }
 
+private class CypherTimeoutThreadFactory : ThreadFactory {
+    override fun newThread(task: Runnable): Thread = Thread(task, "graphite-cypher-timeout").apply {
+        isDaemon = true
+    }
+}
+
 private val NEXT_CYPHER_THREAD = AtomicInteger()
 
 private fun Throwable?.isCancellationFailure(): Boolean {
     var current = this
     while (current != null) {
-        if (current is CypherQueryCancelledException || current is InterruptedException) return true
+        if (current is CypherQueryCancelledException || current is CypherQueryTimeoutException ||
+            current is InterruptedException
+        ) return true
         current = current.cause
     }
     return false
 }
 
 private fun Throwable.toQueryOutcome(): CypherQueryOutcome = when (this) {
+    is CypherQueryTimeoutException -> CypherQueryOutcome.TIMEOUT
     is CypherQueryCancelledException -> CypherQueryOutcome.CANCELLED
     is CypherBudgetExceededException -> CypherQueryOutcome.BUDGET_EXCEEDED
     else -> CypherQueryOutcome.FAILED

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreApiFields.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreApiFields.kt
@@ -50,6 +50,7 @@ internal const val API_PARAM_MODE = "mode"
 internal const val API_PARAM_PER_GRAPH_LIMIT = "perGraphLimit"
 internal const val API_PARAM_PATTERN = "pattern"
 internal const val API_PARAM_QUERY = "query"
+internal const val API_PARAM_TIMEOUT_MILLIS = "timeoutMs"
 
 internal const val API_ERROR_INVALID_NODE_ID = "Invalid node ID"
 internal const val API_ERROR_INVALID_NODE_ID_OPENAPI = "Invalid node id"

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreCommand.kt
@@ -63,9 +63,16 @@ open class ServeCommand : Callable<Int> {
 
     @Option(
         names = ["--cypher-work-budget"],
-        description = ["Maximum graph work units per Cypher request"]
+        description = ["Deprecated and ignored; Cypher execution is limited by timeout instead"]
     )
+    @Deprecated("Ignored; configure --cypher-max-timeout-ms instead")
     var cypherWorkBudget: Long = DEFAULT_CYPHER_WORK_BUDGET
+
+    @Option(
+        names = ["--cypher-max-timeout-ms"],
+        description = ["Maximum Cypher request timeout in milliseconds"]
+    )
+    var cypherMaxTimeoutMillis: Long = DEFAULT_CYPHER_MAX_TIMEOUT_MILLIS
 
     @Option(
         names = ["--metrics"],
@@ -75,8 +82,8 @@ open class ServeCommand : Callable<Int> {
 
     @Suppress("ReturnCount", "TooGenericExceptionCaught")
     override fun call(): Int {
-        if (maxConcurrentCypher <= 0 || cypherWorkBudget <= 0) {
-            System.err.println("Error: Cypher concurrency and work budget must be positive")
+        if (maxConcurrentCypher <= 0 || cypherMaxTimeoutMillis <= 0) {
+            System.err.println("Error: Cypher concurrency and maximum timeout must be positive")
             return 1
         }
         val hasInitialGraphs = graphDir != null || graphSpecs.isNotEmpty()
@@ -125,7 +132,7 @@ open class ServeCommand : Callable<Int> {
                     "${topologySummary.relationCount} relations"
             )
             System.err.println(
-                "Cypher limits: $maxConcurrentCypher concurrent, $cypherWorkBudget work units per request"
+                "Cypher limits: $maxConcurrentCypher concurrent, ${cypherMaxTimeoutMillis}ms maximum timeout"
             )
             System.err.println("Press Ctrl+C to stop")
 
@@ -140,7 +147,13 @@ open class ServeCommand : Callable<Int> {
     }
 
     internal fun registerApiRoutes(app: Javalin, graph: Graph) {
-        ExploreRoutes(CypherQueryGuard(maxConcurrentCypher, cypherWorkBudget)).register(app, graph)
+        ExploreRoutes(
+            CypherQueryGuard(
+                maxConcurrent = maxConcurrentCypher,
+                maxWorkUnits = Long.MAX_VALUE,
+                maxTimeoutMillis = cypherMaxTimeoutMillis
+            )
+        ).register(app, graph)
     }
 
     internal fun registerApiRoutes(
@@ -150,7 +163,14 @@ open class ServeCommand : Callable<Int> {
         performanceMetrics: ServerPerformanceMetrics? = null
     ) {
         val recorder = performanceMetrics?.cypherRecorder(maxConcurrentCypher) ?: NoOpCypherPerformanceRecorder
-        ExploreRoutes(CypherQueryGuard(maxConcurrentCypher, cypherWorkBudget, recorder)).register(app, registry, topology)
+        ExploreRoutes(
+            CypherQueryGuard(
+                maxConcurrent = maxConcurrentCypher,
+                maxWorkUnits = Long.MAX_VALUE,
+                performance = recorder,
+                maxTimeoutMillis = cypherMaxTimeoutMillis
+            )
+        ).register(app, registry, topology)
     }
 
     internal fun buildSubgraph(graph: Graph, center: NodeId, depth: Int): Map<String, Any> =

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
@@ -16,6 +16,7 @@ import io.johnsonlee.graphite.cypher.CypherExecutionContext
 import io.johnsonlee.graphite.cypher.CypherExecutor
 import io.johnsonlee.graphite.cypher.CypherGraph
 import io.johnsonlee.graphite.cypher.CypherQueryCancelledException
+import io.johnsonlee.graphite.cypher.CypherQueryTimeoutException
 import io.johnsonlee.graphite.graph.ClassDependency
 import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.Graph
@@ -505,6 +506,12 @@ internal class ExploreRoutes(
         execute: (List<GraphLease>, CypherExecutionContext) -> T,
         respond: (T, CypherCancellationSignal) -> Unit
     ): CompletableFuture<Unit> {
+        val clientTimeoutMillis = try {
+            parseClientCypherTimeoutMillis(ctx)
+        } catch (error: IllegalArgumentException) {
+            respondCypherError(ctx, error)
+            return CompletableFuture.completedFuture(Unit)
+        }
         val cancellationSignal = cancellationSignalFactory()
         val clientCancellation = clientCancellationObserver(ctx, cancellationSignal)
         val leases = try {
@@ -518,6 +525,7 @@ internal class ExploreRoutes(
         val task = try {
             cypherGuard.submit(
                 cancellationSignal,
+                clientTimeoutMillis = clientTimeoutMillis,
                 continuation = { outcome ->
                     try {
                         val error = unwrapCompletionFailure(outcome.exceptionOrNull())
@@ -690,6 +698,25 @@ internal class ExploreRoutes(
         return query.trim()
     }
 
+    private fun parseClientCypherTimeoutMillis(ctx: Context): Long? {
+        val body = ctx.body().trim()
+        val bodyTimeout = if (body.isEmpty()) {
+            null
+        } else {
+            JsonParser.parseString(body).asJsonObject.get(API_PARAM_TIMEOUT_MILLIS)
+                ?.takeUnless { it.isJsonNull }
+                ?.let { value ->
+                    require(value.isJsonPrimitive) { "'$API_PARAM_TIMEOUT_MILLIS' must be a positive integer" }
+                    value.asString
+                }
+        }
+        val raw = bodyTimeout ?: ctx.queryParam(API_PARAM_TIMEOUT_MILLIS) ?: return null
+        val timeoutMillis = raw.toLongOrNull()
+            ?: throw IllegalArgumentException("'$API_PARAM_TIMEOUT_MILLIS' must be a positive integer")
+        require(timeoutMillis > 0) { "'$API_PARAM_TIMEOUT_MILLIS' must be a positive integer" }
+        return timeoutMillis
+    }
+
     private fun respondCypherError(ctx: Context, error: Throwable) {
         if (error is GraphNotLoadedException) {
             ctx.status(HTTP_NOT_FOUND).json(mapOf(API_FIELD_ERROR to error.message))
@@ -698,20 +725,23 @@ internal class ExploreRoutes(
         val code = when (error) {
             is CypherConcurrencyLimitException -> "cypher_concurrency_limit"
             is CypherBudgetExceededException -> "cypher_work_budget_exceeded"
+            is CypherQueryTimeoutException -> "cypher_query_timeout"
             is CypherQueryCancelledException -> "cypher_query_cancelled"
             else -> "cypher_query_failed"
         }
         val status = when (code) {
             "cypher_query_failed" -> HTTP_BAD_REQUEST
+            "cypher_query_timeout" -> HTTP_GATEWAY_TIMEOUT
             "cypher_query_cancelled" -> HTTP_SERVICE_UNAVAILABLE
             else -> HTTP_TOO_MANY_REQUESTS
         }
         if (error is CypherConcurrencyLimitException) ctx.header("Retry-After", "1")
         ctx.status(status).json(
-            mapOf(
-                API_FIELD_ERROR to (error.message ?: "Query execution failed"),
-                "code" to code
-            )
+            buildMap<String, Any?> {
+                put(API_FIELD_ERROR, error.message ?: "Query execution failed")
+                put("code", code)
+                if (error is CypherQueryTimeoutException) put(API_PARAM_TIMEOUT_MILLIS, error.timeoutMillis)
+            }
         )
     }
 
@@ -1166,6 +1196,7 @@ internal class ExploreRoutes(
         private const val HTTP_NOT_FOUND = 404
         private const val HTTP_PAYLOAD_TOO_LARGE = 413
         private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val HTTP_GATEWAY_TIMEOUT = 504
         private const val HTTP_SERVICE_UNAVAILABLE = 503
 
         private const val DEFAULT_EDGE_LIMIT = 200

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
@@ -467,22 +467,39 @@ internal class OpenApiSpecBuilder {
         API_PARAM_TIMEOUT_MILLIS,
         TYPE_INTEGER,
         false,
-        CYPHER_TIMEOUT_DESCRIPTION
+        CYPHER_TIMEOUT_DESCRIPTION,
+        minimum = 1
     )
 
-    private fun queryParameter(name: String, type: String, required: Boolean, description: String): Map<String, Any?> =
-        parameter("query", name, type, required, description)
+    private fun queryParameter(
+        name: String,
+        type: String,
+        required: Boolean,
+        description: String,
+        minimum: Int? = null
+    ): Map<String, Any?> = parameter("query", name, type, required, description, minimum)
 
     private fun pathParameter(name: String, type: String, description: String): Map<String, Any?> =
         parameter("path", name, type, true, description)
 
-    private fun parameter(location: String, name: String, type: String, required: Boolean, description: String): Map<String, Any?> =
+    private fun parameter(
+        location: String,
+        name: String,
+        type: String,
+        required: Boolean,
+        description: String,
+        minimum: Int? = null
+    ): Map<String, Any?> =
         mapOf(
             "in" to location,
             API_FIELD_NAME to name,
             FIELD_REQUIRED to required,
             FIELD_DESCRIPTION to description,
-            "schema" to mapOf(API_FIELD_TYPE to type)
+            "schema" to if (minimum == null) {
+                mapOf(API_FIELD_TYPE to type)
+            } else {
+                mapOf(API_FIELD_TYPE to type, "minimum" to minimum)
+            }
         )
 
     private fun response(description: String): Map<String, Any?> =

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
@@ -60,12 +60,14 @@ internal class OpenApiSpecBuilder {
                     parameters = listOf(
                         pathParameter(API_FIELD_GRAPH_ID, TYPE_STRING, "Unique graph id"),
                         queryParameter(API_PARAM_QUERY, TYPE_STRING, true, "Cypher query text"),
-                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows")
+                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows"),
+                        cypherTimeoutParameter()
                     ),
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "429" to response("Cypher concurrency limit exceeded"),
+                        "504" to response("Cypher query timeout exceeded"),
                         "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Graph not loaded")
                     )
@@ -74,13 +76,15 @@ internal class OpenApiSpecBuilder {
                     "Execute a Cypher query against a specific graph",
                     parameters = listOf(
                         pathParameter(API_FIELD_GRAPH_ID, TYPE_STRING, "Unique graph id"),
-                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows")
+                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows"),
+                        cypherTimeoutParameter()
                     ),
                     requestBody = cypherRequestBody(),
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "429" to response("Cypher concurrency limit exceeded"),
+                        "504" to response("Cypher query timeout exceeded"),
                         "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Graph not loaded")
                     )
@@ -95,6 +99,7 @@ internal class OpenApiSpecBuilder {
                         queryParameter(API_PARAM_GRAPH, TYPE_STRING, false, "Graph id selection; repeat or comma-separate"),
                         queryParameter(API_PARAM_MODE, TYPE_STRING, false, "cross-graph (default) or fanout"),
                         queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Maximum total result rows across queried graphs"),
+                        cypherTimeoutParameter(),
                         queryParameter(API_PARAM_PER_GRAPH_LIMIT, TYPE_INTEGER, false, "Optional maximum result rows per graph"),
                         queryParameter(
                             API_PARAM_INCLUDE_GRAPH_ROWS,
@@ -106,7 +111,8 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Multi-graph Cypher result with graphId-tagged rows"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "429" to response("Cypher concurrency limit exceeded"),
+                        "504" to response("Cypher query timeout exceeded"),
                         "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Requested graph not loaded")
                     )
@@ -115,6 +121,7 @@ internal class OpenApiSpecBuilder {
                     "Execute one cross-graph query or explicit fanout over selected graphs",
                     parameters = listOf(
                         queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Maximum total result rows across queried graphs"),
+                        cypherTimeoutParameter(),
                         queryParameter(API_PARAM_PER_GRAPH_LIMIT, TYPE_INTEGER, false, "Optional maximum result rows per graph"),
                         queryParameter(
                             API_PARAM_INCLUDE_GRAPH_ROWS,
@@ -127,7 +134,8 @@ internal class OpenApiSpecBuilder {
                     responses = mapOf(
                         "200" to response("Multi-graph Cypher result with graphId-tagged rows"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "429" to response("Cypher concurrency limit exceeded"),
+                        "504" to response("Cypher query timeout exceeded"),
                         "503" to response("Cypher cancelled while the client remained connected"),
                         "404" to response("Requested graph not loaded")
                     )
@@ -259,25 +267,29 @@ internal class OpenApiSpecBuilder {
                     "Execute one query over the union of all loaded graphs",
                     parameters = listOf(
                         queryParameter(API_PARAM_QUERY, TYPE_STRING, true, "Cypher query text"),
-                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows")
+                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows"),
+                        cypherTimeoutParameter()
                     ),
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "429" to response("Cypher concurrency limit exceeded"),
+                        "504" to response("Cypher query timeout exceeded"),
                         "503" to response("Cypher cancelled while the client remained connected")
                     )
                 ),
                 "post" to operation(
                     "Execute one query over the union of all loaded graphs",
                     parameters = listOf(
-                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows")
+                        queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, "Server-side maximum result rows"),
+                        cypherTimeoutParameter()
                     ),
                     requestBody = cypherRequestBody(),
                     responses = mapOf(
                         "200" to response("Cypher result"),
                         "400" to response("Missing or invalid query"),
-                        "429" to response("Cypher concurrency or work budget exceeded"),
+                        "429" to response("Cypher concurrency limit exceeded"),
+                        "504" to response("Cypher query timeout exceeded"),
                         "503" to response("Cypher cancelled while the client remained connected")
                     )
                 )
@@ -371,6 +383,11 @@ internal class OpenApiSpecBuilder {
                 API_PARAM_QUERY to mapOf(
                     API_FIELD_TYPE to TYPE_STRING,
                     FIELD_DESCRIPTION to "Cypher query text"
+                ),
+                API_PARAM_TIMEOUT_MILLIS to mapOf(
+                    API_FIELD_TYPE to TYPE_INTEGER,
+                    FIELD_DESCRIPTION to CYPHER_TIMEOUT_DESCRIPTION,
+                    "minimum" to 1
                 )
             ),
             listOf(API_PARAM_QUERY)
@@ -422,6 +439,11 @@ internal class OpenApiSpecBuilder {
                 API_PARAM_INCLUDE_GRAPH_ROWS to mapOf(
                     API_FIELD_TYPE to TYPE_BOOLEAN,
                     FIELD_DESCRIPTION to "Include duplicate per-graph row arrays in graph summaries"
+                ),
+                API_PARAM_TIMEOUT_MILLIS to mapOf(
+                    API_FIELD_TYPE to TYPE_INTEGER,
+                    FIELD_DESCRIPTION to CYPHER_TIMEOUT_DESCRIPTION,
+                    "minimum" to 1
                 )
             ),
             listOf(API_PARAM_QUERY)
@@ -440,6 +462,13 @@ internal class OpenApiSpecBuilder {
                 )
             )
         )
+
+    private fun cypherTimeoutParameter(): Map<String, Any?> = queryParameter(
+        API_PARAM_TIMEOUT_MILLIS,
+        TYPE_INTEGER,
+        false,
+        CYPHER_TIMEOUT_DESCRIPTION
+    )
 
     private fun queryParameter(name: String, type: String, required: Boolean, description: String): Map<String, Any?> =
         parameter("query", name, type, required, description)
@@ -466,6 +495,8 @@ internal class OpenApiSpecBuilder {
         private const val TYPE_INTEGER = "integer"
         private const val TYPE_OBJECT = "object"
         private const val TYPE_STRING = "string"
+        private const val CYPHER_TIMEOUT_DESCRIPTION =
+            "Positive client timeout in milliseconds, capped by the server maximum"
         private val GRAPH_LOCAL_ID_PATHS = listOf(
             "/api/node/{id}",
             "/api/node/{id}/outgoing",

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ServerPerformanceMetrics.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ServerPerformanceMetrics.kt
@@ -107,6 +107,7 @@ private object PerformanceHistogramFilter : MeterFilter {
 internal enum class CypherQueryOutcome(val tagValue: String) {
     SUCCESS("success"),
     CANCELLED("cancelled"),
+    TIMEOUT("timeout"),
     BUDGET_EXCEEDED("budget_exceeded"),
     FAILED("failed")
 }

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuardTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/CypherQueryGuardTest.kt
@@ -3,6 +3,7 @@ package io.johnsonlee.graphite.cli
 import io.johnsonlee.graphite.cypher.CypherCancellationSignal
 import io.johnsonlee.graphite.cypher.CypherExecutionContext
 import io.johnsonlee.graphite.cypher.CypherQueryCancelledException
+import io.johnsonlee.graphite.cypher.CypherQueryTimeoutException
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutionException
@@ -24,6 +25,58 @@ class CypherQueryGuardTest {
         }
         assertFailsWith<IllegalArgumentException> {
             CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            CypherQueryGuard(maxConcurrent = 1, maxTimeoutMillis = 0)
+        }
+        assertEquals(60_000L, DEFAULT_CYPHER_MAX_TIMEOUT_MILLIS)
+    }
+
+    @Test
+    fun `guard applies shorter client timeout and caps longer client timeout`() {
+        fun timedOutAfter(guard: CypherQueryGuard, clientTimeoutMillis: Long): Long {
+            val started = CountDownLatch(1)
+            val interrupted = CountDownLatch(1)
+            val task = guard.submit(
+                CypherCancellationSignal(),
+                clientTimeoutMillis = clientTimeoutMillis
+            ) {
+                started.countDown()
+                try {
+                    CountDownLatch(1).await()
+                } catch (error: InterruptedException) {
+                    interrupted.countDown()
+                    throw error
+                }
+            }
+            assertTrue(started.await(5, TimeUnit.SECONDS))
+            val timeout = assertFailsWith<CypherQueryTimeoutException> {
+                task.completion.get(5, TimeUnit.SECONDS)
+            }
+            assertTrue(interrupted.await(5, TimeUnit.SECONDS))
+            return timeout.timeoutMillis
+        }
+
+        val guard = CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 10, maxTimeoutMillis = 100)
+        try {
+            assertEquals(25L, timedOutAfter(guard, 25))
+            assertEquals(100L, timedOutAfter(guard, 1_000))
+            assertEquals("next", executeWhenAvailable(guard) { "next" })
+        } finally {
+            guard.close()
+        }
+    }
+
+    @Test
+    fun `invalid client timeout does not consume a permit`() {
+        val guard = CypherQueryGuard(maxConcurrent = 1, maxWorkUnits = 10)
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                guard.submit(CypherCancellationSignal(), clientTimeoutMillis = 0) { "invalid" }
+            }
+            assertEquals("next", guard.execute { "next" })
+        } finally {
+            guard.close()
         }
     }
 

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -68,6 +68,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@Suppress("DEPRECATION")
 class ExploreCommandTest {
 
     companion object {
@@ -1507,10 +1508,13 @@ class ExploreCommandTest {
         @Suppress("UNCHECKED_CAST")
         val post = cypher["post"] as Map<String, Any?>
         assertTrue(post.containsKey("requestBody"))
+        assertTrue(post["requestBody"].toString().contains(API_PARAM_TIMEOUT_MILLIS))
         @Suppress("UNCHECKED_CAST")
         val responses = post["responses"] as Map<String, Any?>
         assertTrue(responses.containsKey("429"))
+        assertTrue(responses.containsKey("504"))
         assertTrue(responses.containsKey("503"))
+        assertFalse(responses.getValue("429").toString().contains("work budget"))
     }
 
     @Test
@@ -2089,6 +2093,7 @@ class ExploreCommandTest {
         assertEquals(1_000_000L, DEFAULT_CYPHER_WORK_BUDGET)
         assertEquals(4, explore.maxConcurrentCypher)
         assertEquals(1_000_000L, explore.cypherWorkBudget)
+        assertEquals(60_000L, explore.cypherMaxTimeoutMillis)
         assertFalse(explore.metricsEnabled)
     }
 
@@ -2102,17 +2107,30 @@ class ExploreCommandTest {
     }
 
     @Test
-    fun `serve rejects non-positive cypher limits`() {
+    fun `serve help marks cypher work budget deprecated and documents timeout replacement`() {
+        val usage = CommandLine(ServeCommand()).usageMessage
+
+        assertTrue(usage.contains("--cypher-work-budget"), usage)
+        assertTrue(usage.contains("Deprecated and ignored"), usage)
+        assertTrue(usage.contains("--cypher-max-timeout-ms"), usage)
+    }
+
+    @Test
+    fun `serve rejects non-positive active cypher limits and ignores deprecated work budget`() {
         val concurrency = ServeCommand().apply { maxConcurrentCypher = 0 }
+        val timeout = ServeCommand().apply { cypherMaxTimeoutMillis = 0 }
         val work = ServeCommand().apply { cypherWorkBudget = 0 }
 
         val (_, concurrencyError, concurrencyCode) = captureOutput { concurrency.call() }
+        val (_, timeoutError, timeoutCode) = captureOutput { timeout.call() }
         val (_, workError, workCode) = captureOutput { work.call() }
 
         assertEquals(1, concurrencyCode)
+        assertEquals(1, timeoutCode)
         assertEquals(1, workCode)
         assertTrue(concurrencyError.contains("must be positive"), concurrencyError)
-        assertTrue(workError.contains("must be positive"), workError)
+        assertTrue(timeoutError.contains("must be positive"), timeoutError)
+        assertTrue(workError.contains("--data"), workError)
     }
 
     @Test
@@ -3572,6 +3590,96 @@ class ExploreCommandTest {
             )
             assertEquals(200, metadataCode, metadataBody)
         }
+    }
+
+    @Test
+    fun `serve command accepts but ignores deprecated cypher work budget`() {
+        val graph = DefaultGraph.Builder()
+            .addNode(IntConstant(NodeId.next(), 1))
+            .addNode(IntConstant(NodeId.next(), 2))
+            .build()
+        val localApp = Javalin.create { config ->
+            config.jsonMapper(JavalinGson(GsonBuilder().setPrettyPrinting().create()))
+        }.start(0)
+        try {
+            ServeCommand().apply {
+                cypherWorkBudget = 1
+                registerApiRoutes(localApp, graph)
+            }
+            val (code, body) = post(
+                localApp.port(),
+                "/api/cypher",
+                """{"query":"MATCH (n) RETURN n.id"}"""
+            )
+            assertEquals(200, code, body)
+            val response: Map<String, Any?> = parseJson(body)
+            assertEquals(2.0, response[API_FIELD_ROW_COUNT])
+        } finally {
+            localApp.stop()
+        }
+    }
+
+    @Test
+    fun `cypher endpoint caps client timeout cancels work and releases capacity`() {
+        val started = CountDownLatch(1)
+        val interrupted = CountDownLatch(1)
+        val blockFirstScan = AtomicBoolean(true)
+        val backing = DefaultGraph.Builder().addNode(IntConstant(NodeId.next(), 1)).build()
+        val blockingGraph = object : Graph by backing {
+            override fun <T : Node> nodes(type: Class<T>): Sequence<T> = sequence {
+                if (blockFirstScan.compareAndSet(true, false)) {
+                    started.countDown()
+                    try {
+                        CountDownLatch(1).await()
+                    } catch (error: InterruptedException) {
+                        interrupted.countDown()
+                        throw error
+                    }
+                }
+                yieldAll(backing.nodes(type))
+            }
+        }
+        val routes = ExploreRoutes(
+            CypherQueryGuard(
+                maxConcurrent = 1,
+                maxWorkUnits = Long.MAX_VALUE,
+                maxTimeoutMillis = 50
+            )
+        )
+
+        withExploreApp(blockingGraph, routes) { targetPort ->
+            val (timeoutCode, timeoutBody) = post(
+                targetPort,
+                "/api/cypher",
+                """{"query":"MATCH (n) WHERE n.missing IS NOT NULL RETURN n.id","timeoutMs":500}"""
+            )
+            assertEquals(504, timeoutCode, timeoutBody)
+            assertTrue(timeoutBody.contains("cypher_query_timeout"), timeoutBody)
+            val timeoutResponse: Map<String, Any?> = parseJson(timeoutBody)
+            assertEquals(50.0, timeoutResponse[API_PARAM_TIMEOUT_MILLIS])
+            assertTrue(started.await(5, TimeUnit.SECONDS))
+            assertTrue(interrupted.await(5, TimeUnit.SECONDS))
+
+            val (nextCode, nextBody) = post(
+                targetPort,
+                "/api/cypher",
+                """{"query":"MATCH (n) RETURN n.id LIMIT 1"}"""
+            )
+            assertEquals(200, nextCode, nextBody)
+        }
+    }
+
+    @Test
+    fun `cypher endpoint rejects invalid timeout before consuming capacity`() {
+        val (invalidCode, invalidBody) = post(
+            "/api/cypher",
+            """{"query":"RETURN 1","timeoutMs":0}"""
+        )
+        assertEquals(400, invalidCode, invalidBody)
+        assertTrue(invalidBody.contains("timeoutMs"), invalidBody)
+
+        val (nextCode, nextBody) = post("/api/cypher", """{"query":"RETURN 1"}""")
+        assertEquals(200, nextCode, nextBody)
     }
 
     @Test

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -1509,6 +1509,19 @@ class ExploreCommandTest {
         val post = cypher["post"] as Map<String, Any?>
         assertTrue(post.containsKey("requestBody"))
         assertTrue(post["requestBody"].toString().contains(API_PARAM_TIMEOUT_MILLIS))
+        listOf("/api/cypher", "/api/cypher/graphs", "/api/graphs/{graphId}/cypher").forEach { path ->
+            @Suppress("UNCHECKED_CAST")
+            val operations = paths.getValue(path) as Map<String, Map<String, Any?>>
+            operations.forEach { (method, operation) ->
+                @Suppress("UNCHECKED_CAST")
+                val parameters = operation.getValue("parameters") as List<Map<String, Any?>>
+                val timeout = parameters.single { it[API_FIELD_NAME] == API_PARAM_TIMEOUT_MILLIS }
+                @Suppress("UNCHECKED_CAST")
+                val schema = timeout.getValue("schema") as Map<String, Any?>
+                assertEquals("integer", schema[API_FIELD_TYPE], "$method $path timeout schema type")
+                assertEquals(1.0, schema["minimum"], "$method $path timeout schema minimum")
+            }
+        }
         @Suppress("UNCHECKED_CAST")
         val responses = post["responses"] as Map<String, Any?>
         assertTrue(responses.containsKey("429"))

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ServerPerformanceMetricsTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ServerPerformanceMetricsTest.kt
@@ -4,6 +4,7 @@ import io.javalin.Javalin
 import io.johnsonlee.graphite.cypher.CypherBudgetExceededException
 import io.johnsonlee.graphite.cypher.CypherCancellationSignal
 import io.johnsonlee.graphite.cypher.CypherQueryCancelledException
+import io.johnsonlee.graphite.cypher.CypherQueryTimeoutException
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -83,6 +84,13 @@ class ServerPerformanceMetricsTest {
             task.cancel()
             release.countDown()
             assertFailsWith<CypherQueryCancelledException> { task.completion.get(5, TimeUnit.SECONDS) }
+            val timeoutTask = guard.submit(
+                CypherCancellationSignal(),
+                clientTimeoutMillis = 25
+            ) {
+                CountDownLatch(1).await()
+            }
+            assertFailsWith<CypherQueryTimeoutException> { timeoutTask.completion.get(5, TimeUnit.SECONDS) }
             assertEquals("ok", guard.execute { "ok" })
             assertFailsWith<CypherBudgetExceededException> {
                 guard.execute { throw CypherBudgetExceededException(it.executionBudget.maxWorkUnits) }
@@ -96,6 +104,7 @@ class ServerPerformanceMetricsTest {
             assertEquals(1.0, metrics.registry.get("graphite.cypher.queries.rejected").counter().count())
             assertTimerCount(metrics, CypherQueryOutcome.SUCCESS, 1)
             assertTimerCount(metrics, CypherQueryOutcome.CANCELLED, 1)
+            assertTimerCount(metrics, CypherQueryOutcome.TIMEOUT, 1)
             assertTimerCount(metrics, CypherQueryOutcome.BUDGET_EXCEEDED, 1)
             assertTimerCount(metrics, CypherQueryOutcome.FAILED, 1)
             assertTrue(metrics.registry.scrape().contains("graphite_cypher_query_duration_seconds_bucket"))

--- a/graphite-mcp/src/index.ts
+++ b/graphite-mcp/src/index.ts
@@ -113,12 +113,14 @@ server.tool(
       .describe("One union query across graphs, or independent per-graph fan-out"),
     limit: z.number().optional()
       .describe("Maximum total result rows for the request"),
+    timeout_ms: z.number().int().positive().optional()
+      .describe("Client timeout in milliseconds, capped by the server maximum (60 seconds by default)"),
     per_graph_limit: z.number().optional()
       .describe("Optional maximum result rows per graph for multi-graph queries"),
     include_graph_rows: z.boolean().optional().default(false)
       .describe("Include duplicate per-graph row arrays in multi-graph responses"),
   },
-  async ({ query, graph_id, all_graphs, graphs, mode, limit, per_graph_limit, include_graph_rows }) => {
+  async ({ query, graph_id, all_graphs, graphs, mode, limit, timeout_ms, per_graph_limit, include_graph_rows }) => {
     const selectedGraphs = graphs?.filter((graph: string) => graph.trim().length > 0);
     if (graph_id && (all_graphs || (selectedGraphs && selectedGraphs.length > 0))) {
       throw new Error("graph_id is mutually exclusive with all_graphs and graphs");
@@ -138,6 +140,7 @@ server.tool(
     }
     const queryParams: Record<string, string> = {};
     if (limit !== undefined) queryParams.limit = String(limit);
+    if (timeout_ms !== undefined) queryParams.timeoutMs = String(timeout_ms);
     if (per_graph_limit !== undefined) queryParams.perGraphLimit = String(per_graph_limit);
     if (include_graph_rows) queryParams.includeGraphRows = "true";
     if (graph_id) {

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/MappedWebGraphBackedGraph.kt
@@ -710,21 +710,30 @@ internal class RawStringMatchStates(
     private val maxRetainedBytes: Long = MAX_RAW_STRING_MATCH_STATE_BYTES.toLong(),
     private val maxEntries: Int = MAX_RAW_STRING_MATCH_STATES
 ) {
-    private val states = LinkedHashMap<RawStringMatchKey, ByteArray>()
+    private val states = LinkedHashMap<RawStringMatchKey, ByteArray>(
+        maxEntries.coerceAtLeast(1) + 1,
+        STRING_PROPERTY_INDEX_LOAD_FACTOR,
+        true
+    )
     private var bytes = 0L
 
     @Synchronized
     fun stateFor(key: RawStringMatchKey, stringCount: Int): ByteArray? {
-        val existing = states[key]
+        var state = states[key]
         val requiredBytes = estimatedRawStringMatchStateBytes(key, stringCount)
-        return when {
-            existing != null -> existing
-            states.size >= maxEntries || requiredBytes > maxRetainedBytes - bytes -> null
-            else -> ByteArray(stringCount).also { state ->
-                states[key] = state
-                bytes += requiredBytes
+        if (state == null && maxEntries > 0 && requiredBytes <= maxRetainedBytes) {
+            while (states.isNotEmpty() &&
+                (states.size >= maxEntries || requiredBytes > maxRetainedBytes - bytes)
+            ) {
+                val eldest = states.entries.iterator().next()
+                bytes -= estimatedRawStringMatchStateBytes(eldest.key, eldest.value.size)
+                states.remove(eldest.key)
             }
+            state = ByteArray(stringCount)
+            states[key] = state
+            bytes += requiredBytes
         }
+        return state
     }
 
     @Synchronized

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -736,32 +736,35 @@ class GraphStoreTest {
     }
 
     @Test
-    fun `raw string match states enforce one aggregate graph memory bound`() {
+    fun `raw string match states evict least recently used entries within graph memory bound`() {
         val states = RawStringMatchStates(maxRetainedBytes = 512, maxEntries = 8)
         val property = StringPropertyKey(StringConstant::class.java, "value")
+        val firstKey =
+            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "first")
+        val secondKey =
+            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "second")
+        val thirdKey =
+            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "third")
 
-        val first = states.stateFor(
-            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "first"),
-            stringCount = 40
-        )
-        val second = states.stateFor(
-            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "second"),
-            stringCount = 40
-        )
-        val overflow = states.stateFor(
-            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "third"),
-            stringCount = 40
-        )
+        val first = states.stateFor(firstKey, stringCount = 40)
+        val second = states.stateFor(secondKey, stringCount = 40)
 
         assertNotNull(first)
         assertNotNull(second)
-        assertNull(overflow)
+        assertTrue(states.stateFor(firstKey, stringCount = 40) === first)
+        val third = states.stateFor(thirdKey, stringCount = 40)
+        assertNotNull(third)
         assertEquals(2, states.size())
-        assertEquals(442L, states.retainedBytes())
-        assertTrue(states.stateFor(
-            RawStringMatchKey(property, StringValueTransform.LOWERCASE, StringMatchMode.CONTAINS, "first"),
-            stringCount = 40
-        ) === first)
+        assertEquals(440L, states.retainedBytes())
+        fun predicate(expected: String) = StringPropertyPredicate(
+            "value",
+            StringValueTransform.LOWERCASE,
+            StringMatchMode.CONTAINS,
+            expected
+        )
+        assertTrue(states.contains(StringConstant::class.java, predicate("first")))
+        assertTrue(!states.contains(StringConstant::class.java, predicate("second")))
+        assertTrue(states.contains(StringConstant::class.java, predicate("third")))
 
         val oversizedKeyStates = RawStringMatchStates(maxRetainedBytes = 256, maxEntries = 8)
         assertNull(oversizedKeyStates.stateFor(


### PR DESCRIPTION
## Summary

- add cross-graph fast paths for the non-`DISTINCT` broad string-disjunction searches seen in production, plus `A AND (B OR C)` pushdown while preserving source order, duplicates, provenance, and `LIMIT`
- make mapped raw string-match state a bounded access-order LRU so long backtests do not fall off a cache-capacity cliff after many unique predicates
- replace server work-unit limiting with a 60-second maximum timeout; clients can request `timeoutMs`, with `effectiveTimeout = min(clientTimeout, serverMaxTimeout)`, and timed-out work is cancelled/interrupted with HTTP 504
- keep `--cypher-work-budget` parseable but deprecated and ignored by `serve`; direct library callers retain finite `CypherExecutionBudget` behavior
- expose timeout configuration through CLI, OpenAPI, metrics, README, and the MCP `timeout_ms` argument

## Verification

- `JAVA_OPTS='-Xmx3g -XX:MaxMetaspaceSize=1g' ./gradlew check --no-daemon` — passed, including detekt, coverage verification, unit/integration tests, and Tika/Hive/Kotlin large-corpus gates
- `npm ci && npx tsc --noEmit && npm run build` in `graphite-mcp` — passed
- `node --test graphite-explore/src/test/js/ui-state.test.js` — 7 passed
- `node --test .github/scripts/benchmark-gate.test.mjs` — 46 passed
- final head `38479a3`: full `:explore:test`, `:explore:detekt`, and all 26 GitHub checks passed

## Performance evidence

Environment: Apple Silicon macOS, OpenJDK 17.0.18, JMH 1.37, one fork/thread, `main` at `1c41db2` and candidate at `472a23a`, run sequentially on the same host.

Targeted command (identical temporary harness on both revisions):

```text
JAVA_OPTS='-Xmx3g -XX:MaxMetaspaceSize=1g' ./gradlew :cypher:jmh -Pjmh.filter='.*CrossGraphSearchBenchmark.*' --no-daemon
```

| Benchmark | main (ms/op) | candidate (ms/op) | change |
| --- | ---: | ---: | ---: |
| `CrossGraphSearchBenchmark.nonDistinctBroadOrZeroHit` | 161.732 | 22.392 | -86.2% |
| `CrossGraphSearchBenchmark.requiredPredicateWithResidualOrZeroHit` | 117.089 | 37.082 | -68.3% |

The targeted method-level comparison shows a large improvement and no regression for the changed search shapes.

Required repository `CypherBenchmark` command, shortened locally to reduce duplicate CI time:

```text
java -jar graphite-cypher/build/libs/cypher-1.0.0-SNAPSHOT-jmh.jar '^io\.johnsonlee\.graphite\.cypher\.CypherBenchmark\..*$' -wi 1 -i 2 -w 500ms -r 500ms -f 1
```

| Benchmark | main (us/op) | candidate (us/op) | change |
| --- | ---: | ---: | ---: |
| `aggregationCountGroupBy` | 32.562 | 33.493 | +2.9% |
| `countStar` | 2.725 | 3.033 | +11.3% |
| `filteredSingleHopRelationship` | 57.722 | 57.285 | -0.8% |
| `filteredVariableLengthPath` | 176.590 | 175.447 | -0.6% |
| `functionCalls` | 27.511 | 27.693 | +0.7% |
| `nodeMatchWithWhere` | 58.948 | 59.254 | +0.5% |
| `orderedFilteredSingleHopRelationship` | 252.152 | 251.988 | -0.1% |
| `regexFilter` | 24.905 | 24.979 | +0.3% |
| `returnDistinct` | 113.841 | 113.058 | -0.7% |
| `simpleNodeMatch` | 23.263 | 22.629 | -2.7% |
| `singleHopRelationship` | 34.929 | 37.061 | +6.1% |
| `variableLengthPath` | 32.509 | 33.271 | +2.3% |
| `withPipeline` | 86.887 | 86.391 | -0.6% |

The short local general-purpose suite is mixed around run-to-run noise and does not indicate a coherent method-level regression; the protected `benchmark-regression-gate` with its full repetitions and confirmation rules is authoritative.

The first CI runs exposed and confirmed a finite-budget hot-loop regression after cancellation started carrying a typed cause. The current revision keeps the original atomic-boolean hot poll and stores the first typed cause on the cold cancellation path; the unlimited-budget shortcut was also removed. The exact protected collection filter was then rerun locally with its full 2 forks, 3 warmups, and 5 measurements:

| Benchmark | main (us/op) | candidate (us/op) | change |
| --- | ---: | ---: | ---: |
| `BudgetedCypherBenchmark.budgetedListConcatenation` | 280.678 | 273.156 | -2.7% |
| `BudgetedCypherBenchmark.budgetedListMembership` | 386.099 | 382.600 | -0.9% |

The corrected finite-budget path shows no collection-latency regression; the final same-runner CI rerun on `38479a3` is authoritative.

End-to-end conclusion: local candidate large-corpus gates passed (`queryMs`: Hive 1604, Kotlin compiler 1086, Tika 1288). The required same-runner base/candidate [`benchmark-regression-gate`](https://github.com/johnsonlee/graphite/pull/107#issuecomment-5467506108) also passed all method-level, real-corpus, latency, capacity, and resource checks. It indicates no method-level or end-to-end performance regression.
