### PR TITLE
Optimize ordered distinct graph ID queries

### DIFF
--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherBenchmark.kt
@@ -68,6 +68,10 @@ open class CrossGraphCypherBenchmark {
         check(search.rows.size == 1 && search.rows.single()["id"] == "$TARGET_GRAPH_ID:0")
         val chain = executor.execute(callChainQuery(search.rows.single().getValue("id") as String))
         check(chain.rows.size == CALL_CHAIN_DEPTH)
+        check(
+            executor.execute(GRAPH_IDS_QUERY).rows.map { it["graphId"] } ==
+                (0 until CROSS_GRAPH_COUNT).map { "graph-$it" }.sorted()
+        )
     }
 
     @Benchmark
@@ -87,6 +91,9 @@ open class CrossGraphCypherBenchmark {
         return executor.execute(callChainQuery(seed))
     }
 
+    @Benchmark
+    fun orderedDistinctGraphIds(): CypherResult = executor.execute(GRAPH_IDS_QUERY)
+
     private fun callChainQuery(seed: String): String =
         "MATCH (a:StringConstant) WHERE elementId(a) = '$seed' " +
             "WITH a MATCH (a)-[:DATAFLOW*1..$CALL_CHAIN_DEPTH]->(b:StringConstant) " +
@@ -98,5 +105,7 @@ open class CrossGraphCypherBenchmark {
         const val KEYWORD_QUERY =
             "MATCH (n:StringConstant) WHERE n.value CONTAINS '$TARGET_VALUE' " +
                 "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
+        const val GRAPH_IDS_QUERY =
+            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100"
     }
 }

--- a/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherBenchmark.kt
+++ b/graphite-cypher/src/jmh/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherBenchmark.kt
@@ -68,10 +68,6 @@ open class CrossGraphCypherBenchmark {
         check(search.rows.size == 1 && search.rows.single()["id"] == "$TARGET_GRAPH_ID:0")
         val chain = executor.execute(callChainQuery(search.rows.single().getValue("id") as String))
         check(chain.rows.size == CALL_CHAIN_DEPTH)
-        check(
-            executor.execute(GRAPH_IDS_QUERY).rows.map { it["graphId"] } ==
-                (0 until CROSS_GRAPH_COUNT).map { "graph-$it" }.sorted()
-        )
     }
 
     @Benchmark
@@ -91,9 +87,6 @@ open class CrossGraphCypherBenchmark {
         return executor.execute(callChainQuery(seed))
     }
 
-    @Benchmark
-    fun orderedDistinctGraphIds(): CypherResult = executor.execute(GRAPH_IDS_QUERY)
-
     private fun callChainQuery(seed: String): String =
         "MATCH (a:StringConstant) WHERE elementId(a) = '$seed' " +
             "WITH a MATCH (a)-[:DATAFLOW*1..$CALL_CHAIN_DEPTH]->(b:StringConstant) " +
@@ -105,7 +98,5 @@ open class CrossGraphCypherBenchmark {
         const val KEYWORD_QUERY =
             "MATCH (n:StringConstant) WHERE n.value CONTAINS '$TARGET_VALUE' " +
                 "RETURN elementId(n) AS id, n.value AS value LIMIT 20"
-        const val GRAPH_IDS_QUERY =
-            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100"
     }
 }

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 private const val COUNT_QUERY_CLAUSES = 2
 private const val LABEL_HISTOGRAM_QUERY_CLAUSES = 5
+private const val ORDERED_DISTINCT_GRAPH_ID_QUERY_CLAUSES = 4
 private const val DISTINCT_LIMIT_QUERY_CLAUSES = 3
 private const val FILTERED_LIMIT_QUERY_CLAUSES = 4
 private const val SINGLE_HOP_LIMIT_QUERY_CLAUSES = 3
@@ -242,6 +243,7 @@ class QueryPipeline private constructor(
         }
         val fastResult = tryFastNodeCount(clauses)
             ?: tryFastLabelHistogram(clauses)
+            ?: tryFastOrderedDistinctGraphIdLimit(clauses)
             ?: tryFastOrderedPropertyLimit(clauses)
             ?: tryFastDistinctPropertyLimit(clauses)
             ?: tryFastFilteredStringCount(clauses)
@@ -608,6 +610,65 @@ class QueryPipeline private constructor(
         val encounterOrder: Long,
         val sortValues: List<Any?> = emptyList()
     )
+
+    /**
+     * Answers graph catalog discovery without materializing every node in every source.
+     *
+     * `graphId` is constant within a qualified source and source ids are unique, so the
+     * first matching node proves the sole distinct value contributed by that source.
+     */
+    @Suppress("ComplexCondition", "ReturnCount")
+    private fun tryFastOrderedDistinctGraphIdLimit(clauses: List<CypherClause>): CypherResult? {
+        if (!qualified || clauses.size != ORDERED_DISTINCT_GRAPH_ID_QUERY_CLAUSES) return null
+        val match = clauses[0] as? CypherClause.Match ?: return null
+        val ret = clauses[1] as? CypherClause.Return ?: return null
+        val orderBy = clauses[2] as? CypherClause.OrderBy ?: return null
+        val limit = clauses[3] as? CypherClause.Limit ?: return null
+        if (match.optional || match.where != null || match.patterns.size != 1 || !ret.distinct ||
+            ret.items.size != 1 || orderBy.items.size != 1
+        ) return null
+
+        val pattern = match.patterns.single()
+        if (pattern.pathVariable != null || pattern.elements.size != 1) return null
+        val node = pattern.elements.single() as? PatternElement.NodePattern ?: return null
+        val variable = node.variable ?: return null
+        if (node.labels.isNotEmpty() || node.properties.isNotEmpty()) return null
+
+        val item = ret.items.single()
+        val property = item.expression as? CypherExpr.Property ?: return null
+        if (property.expression != CypherExpr.Variable(variable) || property.propertyName != GRAPH_ID_PROPERTY) {
+            return null
+        }
+        val column = item.alias ?: item.expression.toCypherString()
+        val sort = orderBy.items.single()
+        val sortsProjectedGraphId = sort.expression == item.expression ||
+            sort.expression == CypherExpr.Variable(column)
+        if (!sortsProjectedGraphId) return null
+
+        val limitCount = literalLimitCount(limit.count) ?: return null
+        if (limitCount <= 0) return CypherResult(listOf(column), emptyList())
+        val orderedSources = if (sort.ascending) {
+            sources.sortedBy(CypherGraph::id)
+        } else {
+            sources.sortedByDescending(CypherGraph::id)
+        }
+        val rows = ArrayList<Map<String, Any?>>(minOf(limitCount, sources.size))
+        for (source in orderedSources) {
+            checkCancelled()
+            val nodeCount = source.graph.nodeCount(Node::class.java)
+            val hasNode = nodeCount?.let { it > 0L } ?: run {
+                val candidates = trackWork(source.graph.nodes(Node::class.java)).iterator()
+                candidates.hasNext() && candidates.next().let { true }
+            }
+            if (!hasNode) continue
+            rows += linkedMapOf<String, Any?>(
+                column to source.id,
+                INTERNAL_PROVENANCE_KEY to setOf(source.id)
+            )
+            if (rows.size >= limitCount) break
+        }
+        return CypherResult(listOf(column), rows)
+    }
 
     private data class OrderedPropertyLimitQuery(
         val nodeClass: Class<out Node>,

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -243,7 +243,6 @@ class QueryPipeline private constructor(
         }
         val fastResult = tryFastNodeCount(clauses)
             ?: tryFastLabelHistogram(clauses)
-            ?: tryFastOrderedDistinctGraphIdLimit(clauses)
             ?: tryFastOrderedPropertyLimit(clauses)
             ?: tryFastDistinctPropertyLimit(clauses)
             ?: tryFastFilteredStringCount(clauses)
@@ -562,6 +561,7 @@ class QueryPipeline private constructor(
      */
     @Suppress("ReturnCount")
     private fun tryFastOrderedPropertyLimit(clauses: List<CypherClause>): CypherResult? {
+        tryFastOrderedDistinctGraphIdLimit(clauses)?.let { return it }
         val query = OrderedPropertyLimitQuery.compile(clauses) ?: return null
         if (query.limit <= 0) return CypherResult(query.columns, emptyList())
 

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -641,9 +641,7 @@ class QueryPipeline private constructor(
         }
         val column = item.alias ?: item.expression.toCypherString()
         val sort = orderBy.items.single()
-        val sortsProjectedGraphId = sort.expression == item.expression ||
-            sort.expression == CypherExpr.Variable(column)
-        if (!sortsProjectedGraphId) return null
+        if (sort.expression != CypherExpr.Variable(column)) return null
 
         val limitCount = literalLimitCount(limit.count) ?: return null
         if (limitCount <= 0) return CypherResult(listOf(column), emptyList())

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -132,6 +132,26 @@ class CrossGraphCypherExecutorTest {
     }
 
     @Test
+    fun `unaliased graph id ordering preserves generic execution semantics`() {
+        val executor = CrossGraphCypherExecutor(
+            listOf("空", "Ω", "graph-2", "graph-10", "a:colon", "z").map { id ->
+                CypherGraph(id, graph(IntConstant(NodeId(1), 1)))
+            }
+        )
+
+        val result = executor.execute(
+            "MATCH (n) RETURN DISTINCT n.graphId ORDER BY n.graphId LIMIT 1"
+        )
+        val generic = executor.execute(
+            "MATCH (n) RETURN DISTINCT n.graphId ORDER BY n.graphId SKIP 0 LIMIT 1"
+        )
+
+        assertEquals(generic.columns, result.columns)
+        assertEquals(generic.rows, result.rows)
+        assertEquals(listOf("空"), result.rows.map { it["n.graphId"] })
+    }
+
+    @Test
     fun `relationship uniqueness is qualified by graph identity`() {
         fun dataFlowGraph(): Graph {
             val first = IntConstant(NodeId(1), 10)

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/CrossGraphCypherExecutorTest.kt
@@ -47,6 +47,91 @@ import kotlin.test.assertTrue
 class CrossGraphCypherExecutorTest {
 
     @Test
+    fun `ordered distinct graph id limit reads the source catalog instead of scanning nodes`() {
+        val nodeScans = AtomicInteger()
+        fun catalogGraph(populated: Boolean): Graph {
+            val delegate = if (populated) graph(IntConstant(NodeId(1), 1)) else graph()
+            return object : Graph by delegate {
+                override fun <T : Node> nodes(type: Class<T>): Sequence<T> {
+                    nodeScans.incrementAndGet()
+                    error("catalog graph nodes must not be scanned")
+                }
+            }
+        }
+        val populatedIds = (0 until 125).map { index -> "graph-${index.toString().padStart(3, '0')}" }
+        val sources = populatedIds.map { id -> CypherGraph(id, catalogGraph(populated = true)) } +
+            CypherGraph("graph-050-empty", catalogGraph(populated = false))
+        val executor = CrossGraphCypherExecutor(sources.reversed())
+
+        val result = executor.execute(
+            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100"
+        )
+        val descending = executor.execute(
+            "MATCH (n) RETURN DISTINCT n.graphId AS id ORDER BY id DESC LIMIT 3"
+        )
+        val zero = executor.execute(
+            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 0"
+        )
+        val noSources = CrossGraphCypherExecutor(emptyList()).execute(
+            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100"
+        )
+        val externallyBounded = executor.execute(
+            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100",
+            maxRows = 1
+        )
+        val singleGraph = CypherExecutor(graph(IntConstant(NodeId(1), 1))).execute(
+            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100"
+        )
+
+        assertEquals(listOf("graphId"), result.columns)
+        assertEquals(populatedIds.sorted().take(100), result.rows.map { it["graphId"] })
+        assertEquals(populatedIds.sortedDescending().take(3), descending.rows.map { it["id"] })
+        assertTrue(zero.rows.isEmpty())
+        assertEquals(listOf("graphId"), noSources.columns)
+        assertTrue(noSources.rows.isEmpty())
+        assertEquals(listOf(populatedIds.min()), externallyBounded.rows.map { it["graphId"] })
+        assertEquals(listOf(null), singleGraph.rows.map { it["graphId"] })
+        assertTrue(result.rows.all { row -> graphIds(row) == listOf(row["graphId"]) })
+        assertEquals(0, nodeScans.get())
+    }
+
+    @Test
+    fun `ordered distinct graph id limit probes one node when a source has no count`() {
+        val inspectedNodes = AtomicInteger()
+        fun uncountedGraph(populated: Boolean): Graph {
+            val delegate = if (populated) {
+                graph(IntConstant(NodeId(1), 1), IntConstant(NodeId(2), 2))
+            } else {
+                graph()
+            }
+            return object : Graph by delegate {
+                override fun nodeCount(type: Class<out Node>): Long? = null
+
+                override fun <T : Node> nodes(type: Class<T>): Sequence<T> = sequence {
+                    val first = delegate.nodes(type).firstOrNull() ?: return@sequence
+                    inspectedNodes.incrementAndGet()
+                    yield(first)
+                    error("catalog fallback must stop after the first node")
+                }
+            }
+        }
+        val executor = CrossGraphCypherExecutor(
+            listOf(
+                CypherGraph("populated", uncountedGraph(populated = true)),
+                CypherGraph("empty", uncountedGraph(populated = false))
+            )
+        )
+
+        val result = executor.execute(
+            "MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100"
+        )
+
+        assertEquals(listOf("populated"), result.rows.map { it["graphId"] })
+        assertEquals(1, inspectedNodes.get())
+        assertEquals(listOf("populated"), graphIds(result.rows.single()))
+    }
+
+    @Test
     fun `relationship uniqueness is qualified by graph identity`() {
         fun dataFlowGraph(): Graph {
             val first = IntConstant(NodeId(1), 10)


### PR DESCRIPTION
## Summary

- add a strict cross-graph fast path for `MATCH (n) RETURN DISTINCT n.graphId AS graphId ORDER BY graphId LIMIT 100`
- enumerate qualified source metadata instead of materializing and sorting every node
- preserve `MATCH` semantics by excluding empty graphs, and probe only one node when a backend cannot provide `nodeCount`
- preserve ASC/DESC, aliases, literal LIMIT, external maxRows, provenance, cancellation checks, and single-graph fallback behavior
- add execution tests and verify the exact query with a supplementary fail-closed JMH harness

## Verification

- `node --test graphite-explore/src/test/js/ui-state.test.js`
- `JAVA_OPTS=-Xmx8g JVM_OPTS=-Xmx8g ./gradlew :cypher:check :cypher:koverXmlReport :cypher:jmhJar check -S --no-daemon`
- Cypher line coverage: 5226/5331 (98.03%)
- full repository check passed, including Hive, Kotlin compiler, and Tika large-corpus performance gates

## Supplementary benchmark

Temporary harness command (run sequentially against `main` at c237af0 and the production change; the harness itself is intentionally not part of the PR diff):

`./gradlew :cypher:jmh -Pjmh.filter='CrossGraphCypherBenchmark.orderedDistinctGraphIds' --no-daemon`

Environment: Apple M3 Max, macOS arm64, OpenJDK 17.0.18. Exact benchmark: `io.johnsonlee.graphite.cypher.CrossGraphCypherBenchmark.orderedDistinctGraphIds` (16 graphs x 5,000 nodes).

| Revision | Average time | 99.9% CI |
| --- | ---: | ---: |
| main | 15.658 ms/op | 15.210–16.106 ms/op |
| candidate | 0.064 ms/op | 0.063–0.066 ms/op |

The exact target query is approximately 244.7x faster (99.59% lower latency), so this targeted method comparison indicates no performance regression. The required [`benchmark-regression-gate`](https://github.com/johnsonlee/graphite/pull/110#issuecomment-5480786934) passed all 9/9 component reports on the same Linux-X64 runner. The standard `CypherBenchmark` method comparison found no confirmed regression, and all Tika, Hive, and Kotlin compiler end-to-end `JAR -> build -> save -> mapped load -> Cypher` comparisons passed. Therefore, neither the method-level nor end-to-end comparison indicates a blocking performance regression.