### PR TITLE
Always write resource stores and diagnose missing sidecars

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ For LLMs, this difference is critical. A syntax tree tells you what code *looks 
 ```bash
 # Install via Homebrew
 brew tap johnsonlee/tap
-brew install graphite
+brew install johnsonlee/tap/graphite
+graphite --version
 
 # Build a graph from your JAR
 graphite build app.jar -o /data/app-graph --include com.example
@@ -98,6 +99,21 @@ graphite serve --data /data/graphs \
 curl -X PUT http://localhost:8080/api/graphs/orders \
   -H 'Content-Type: application/json' \
   -d '{"path":"/data/graphs/orders-graph-v2"}'
+```
+
+### Upgrading a legacy installation
+
+An older installer may have placed `~/.graphite/bin/graphite` before Homebrew in `PATH`. In that case, installing or
+upgrading the formula does not change the executable invoked by `graphite`. Move the legacy installation aside,
+refresh command lookup, and rebuild saved graphs so they contain the current resource store:
+
+```bash
+type -a graphite
+mv ~/.graphite ~/.graphite.legacy
+hash -r
+brew upgrade johnsonlee/tap/graphite
+graphite --version
+graphite build app.jar -o /data/app-graph --include com.example
 ```
 
 For APK inputs, Graphite uses Android platform jars to resolve the APK's target

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -15,6 +15,7 @@ graph-dir/
 ├── graph.typeindex    Mmap node type -> Node ID ranges lookup
 ├── graph.metadata     Methods, type hierarchy, enums, annotations, branch scopes
 ├── graph.classoverview Persisted explorer overview summary
+├── graph.resources    Persisted text resources, including an explicit empty store
 └── graph.comparisons  BranchComparison data for ControlFlowEdges
 ```
 
@@ -42,8 +43,11 @@ transpose construction during load.
 | graph.typeindex | `GRT` | `0x47525403` |
 | graph.classoverview | `GRO` | `0x47524F03` |
 | graph.comparisons | `GRC` | `0x47524303` |
+| graph.resources | `GRR` | `0x47525201` |
 
-Current writers emit version `3`. Readers accept legacy version `1` and transitional version `2` data from stable releases and decode legacy annotation payloads, but any graph re-saved by a current build is upgraded to version `3`.
+Current node and metadata writers emit version `3`. Their readers accept legacy version `1` and transitional
+version `2` data from stable releases and decode legacy annotation payloads, but any graph re-saved by a current
+build is upgraded to version `3`. The independent `graph.resources` format remains at version `1`.
 
 ### Edge Label Encoding (8-bit)
 
@@ -67,6 +71,7 @@ SootUpAdapter                  GraphStore.save()                 GraphStore.load
                                  5. Labels + label prefix + comparisons write
                                  6. Nodedata + node indexes write
                                  7. Metadata write
+                                 8. Class overview + resource store write
 ```
 
 ### Save Flow
@@ -84,6 +89,7 @@ graph TD
     E --> F[5. Write labels + label prefix + comparisons]
     F --> G["6. Write nodedata + nodeindex + mmap node indexes"]
     G --> H[7. Write metadata]
+    H --> I[8. Write class overview + resource store]
 ```
 
 ### Load Flow

--- a/docs/webgraph-storage.md
+++ b/docs/webgraph-storage.md
@@ -49,6 +49,11 @@ Current node and metadata writers emit version `3`. Their readers accept legacy 
 version `2` data from stable releases and decode legacy annotation payloads, but any graph re-saved by a current
 build is upgraded to version `3`. The independent `graph.resources` format remains at version `1`.
 
+Current builds always write `graph.resources`, including a valid zero-entry store when no supported text resources
+exist. Its absence therefore identifies a graph produced without resource persistence (for example by a legacy CLI),
+not an empty resource set. Other graph APIs remain available, while resource HTTP endpoints return `409` with an
+instruction to rebuild the graph using the current CLI.
+
 ### Edge Label Encoding (8-bit)
 
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 fastutil = { module = "it.unimi.dsi:fastutil", version.ref = "fastutil" }
 ff4j-core = { module = "org.ff4j:ff4j-core", version.ref = "ff4j" }
 spring-web = { module = "org.springframework:spring-web", version.ref = "spring" }
+spring-jcl = { module = "org.springframework:spring-jcl", version.ref = "spring" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ResourceAccessor.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ResourceAccessor.kt
@@ -11,16 +11,6 @@ import java.io.InputStream
  * Spring Boot fat JAR / WAR.
  */
 interface ResourceAccessor {
-
-    /**
-     * Explains why resources cannot be queried, or `null` when this accessor is usable.
-     *
-     * An available accessor may still contain no matching resources. This distinction lets
-     * persisted graphs report a missing legacy resource store instead of silently appearing empty.
-     */
-    val unavailableReason: String?
-        get() = null
-
     /**
      * List resource entries matching a glob pattern.
      *
@@ -43,6 +33,25 @@ interface ResourceAccessor {
     @Throws(java.io.IOException::class)
     fun open(path: String): InputStream
 }
+
+/**
+ * Capability implemented by accessors that cannot serve resources.
+ *
+ * This is deliberately separate from [ResourceAccessor] so implementations compiled against an
+ * older Graphite release remain binary compatible.
+ */
+interface UnavailableResourceAccessor {
+    val unavailableReason: String
+}
+
+/**
+ * Explains why resources cannot be queried, or `null` when this accessor is usable.
+ *
+ * An available accessor may still contain no matching resources. This distinction lets persisted
+ * graphs report a missing legacy resource store instead of silently appearing empty.
+ */
+val ResourceAccessor.unavailableReason: String?
+    get() = (this as? UnavailableResourceAccessor)?.unavailableReason
 
 /**
  * A resource file entry within a project archive.

--- a/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ResourceAccessor.kt
+++ b/graphite-core/src/main/kotlin/io/johnsonlee/graphite/input/ResourceAccessor.kt
@@ -13,6 +13,15 @@ import java.io.InputStream
 interface ResourceAccessor {
 
     /**
+     * Explains why resources cannot be queried, or `null` when this accessor is usable.
+     *
+     * An available accessor may still contain no matching resources. This distinction lets
+     * persisted graphs report a missing legacy resource store instead of silently appearing empty.
+     */
+    val unavailableReason: String?
+        get() = null
+
+    /**
      * List resource entries matching a glob pattern.
      *
      * Supported patterns:

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/ResourceAccessorTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/ResourceAccessorTest.kt
@@ -1,5 +1,8 @@
 package io.johnsonlee.graphite.input
 
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -18,6 +21,79 @@ class ResourceAccessorTest {
     @Test
     fun `EmptyResourceAccessor open throws IOException`() {
         assertFailsWith<java.io.IOException> { EmptyResourceAccessor.open("any/path.txt") }
+    }
+
+    @Test
+    fun `implementation compiled against old accessor ABI remains compatible`() {
+        assertEquals(setOf("list", "open"), ResourceAccessor::class.java.declaredMethods.map { it.name }.toSet())
+        val root = Files.createTempDirectory("legacy-resource-accessor-test")
+        val sources = root.resolve("sources")
+        val classes = root.resolve("classes")
+        try {
+            val oldApi = sources.resolve("io/johnsonlee/graphite/input/ResourceAccessor.java")
+            val legacyImplementation = sources.resolve("fixture/LegacyAccessor.java")
+            Files.createDirectories(oldApi.parent)
+            Files.createDirectories(legacyImplementation.parent)
+            Files.createDirectories(classes)
+            Files.writeString(
+                oldApi,
+                """
+                package io.johnsonlee.graphite.input;
+
+                public interface ResourceAccessor {
+                    kotlin.sequences.Sequence<ResourceEntry> list(String pattern);
+                    java.io.InputStream open(String path) throws java.io.IOException;
+                }
+                """.trimIndent()
+            )
+            Files.writeString(
+                legacyImplementation,
+                """
+                package fixture;
+
+                public final class LegacyAccessor implements io.johnsonlee.graphite.input.ResourceAccessor {
+                    public kotlin.sequences.Sequence<io.johnsonlee.graphite.input.ResourceEntry> list(String pattern) {
+                        return null;
+                    }
+
+                    public java.io.InputStream open(String path) throws java.io.IOException {
+                        throw new java.io.IOException(path);
+                    }
+                }
+                """.trimIndent()
+            )
+
+            val compiler = requireNotNull(javax.tools.ToolProvider.getSystemJavaCompiler())
+            val compileClasspath = listOf(ResourceEntry::class.java, Sequence::class.java)
+                .map { type -> File(requireNotNull(type.protectionDomain.codeSource).location.toURI()).path }
+                .distinct()
+                .joinToString(File.pathSeparator)
+            assertEquals(
+                0,
+                compiler.run(
+                    null,
+                    null,
+                    null,
+                    "-classpath",
+                    compileClasspath,
+                    "-d",
+                    classes.toString(),
+                    oldApi.toString(),
+                    legacyImplementation.toString()
+                ),
+                "Legacy accessor fixture should compile against the old two-method interface"
+            )
+
+            Files.delete(classes.resolve("io/johnsonlee/graphite/input/ResourceAccessor.class"))
+            URLClassLoader(arrayOf(classes.toUri().toURL()), javaClass.classLoader).use { loader ->
+                val accessor = loader.loadClass("fixture.LegacyAccessor")
+                    .getDeclaredConstructor()
+                    .newInstance() as ResourceAccessor
+                assertNull(accessor.unavailableReason)
+            }
+        } finally {
+            root.toFile().deleteRecursively()
+        }
     }
 
     @Test

--- a/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/ResourceAccessorTest.kt
+++ b/graphite-core/src/test/kotlin/io/johnsonlee/graphite/input/ResourceAccessorTest.kt
@@ -3,6 +3,7 @@ package io.johnsonlee.graphite.input
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ResourceAccessorTest {
@@ -11,6 +12,7 @@ class ResourceAccessorTest {
     fun `EmptyResourceAccessor list returns empty sequence`() {
         val result = EmptyResourceAccessor.list("**/*.json").toList()
         assertTrue(result.isEmpty())
+        assertNull(EmptyResourceAccessor.unavailableReason)
     }
 
     @Test

--- a/graphite-explore/build.gradle.kts
+++ b/graphite-explore/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.registry.prometheus)
 
+    testImplementation(project(":query"))
+
     add(integrationFixtures.name, libs.android.all)
 
     jmh(project(":sootup"))

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
@@ -21,6 +21,7 @@ import io.johnsonlee.graphite.graph.ClassDependency
 import io.johnsonlee.graphite.graph.ClassOverview
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.input.ResourceEntry
+import io.johnsonlee.graphite.input.unavailableReason
 import io.johnsonlee.graphite.webgraph.GraphStore
 import java.io.IOException
 import java.nio.file.Path

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/ExploreRoutes.kt
@@ -191,6 +191,7 @@ internal class ExploreRoutes(
             val pattern = ctx.queryParam(API_PARAM_PATTERN) ?: "**"
             val limit = boundedLimit(ctx, DEFAULT_RESOURCE_LIMIT, MAX_RESOURCE_LIMIT)
             withAllGraphs(ctx, acquire) { leases ->
+                if (!requireResourceStores(ctx, leases)) return@withAllGraphs
                 val limits = distributedLimits(leases.size, limit)
                 val results = leases.mapIndexed { index, lease ->
                     val graphLimit = limits[index]
@@ -216,6 +217,7 @@ internal class ExploreRoutes(
                 return@get
             }
             withAllGraphs(ctx, acquire) { leases ->
+                if (!requireResourceStores(ctx, leases)) return@withAllGraphs
                 try {
                     var remainingBytes = MAX_RESOURCE_BYTES
                     val results = leases.mapNotNull { lease ->
@@ -339,6 +341,7 @@ internal class ExploreRoutes(
 
         app.get("$prefix/resources") { ctx ->
             withGraph(ctx, provider) { graph ->
+                if (!requireResourceStore(ctx, graph)) return@withGraph
                 val pattern = ctx.queryParam(API_PARAM_PATTERN) ?: "**"
                 val limit = boundedLimit(ctx, DEFAULT_RESOURCE_LIMIT, MAX_RESOURCE_LIMIT)
                 val resources = listResources(graph, pattern, limit)
@@ -355,6 +358,7 @@ internal class ExploreRoutes(
 
         app.get("$prefix/resources/<path>") { ctx ->
             withGraph(ctx, provider) { graph ->
+                if (!requireResourceStore(ctx, graph)) return@withGraph
                 val path = ctx.pathParam("path").trimStart('/')
                 if (path.isBlank()) {
                     ctx.status(HTTP_NOT_FOUND).result(API_ERROR_RESOURCE_NOT_FOUND)
@@ -1068,6 +1072,28 @@ internal class ExploreRoutes(
     private fun resolveResourceEntry(graph: Graph, path: String): ResourceEntry? =
         graph.resources.list("**").firstOrNull { it.path == path }
 
+    private fun requireResourceStore(ctx: Context, graph: Graph): Boolean {
+        val reason = graph.resources.unavailableReason ?: return true
+        ctx.status(HTTP_CONFLICT).json(mapOf(API_FIELD_ERROR to reason))
+        return false
+    }
+
+    private fun requireResourceStores(ctx: Context, leases: List<GraphLease>): Boolean {
+        val unavailable = leases.mapNotNull { lease ->
+            lease.graph.resources.unavailableReason?.let { reason ->
+                mapOf(API_FIELD_GRAPH_ID to lease.id, API_FIELD_ERROR to reason)
+            }
+        }
+        if (unavailable.isEmpty()) return true
+        ctx.status(HTTP_CONFLICT).json(
+            mapOf(
+                API_FIELD_ERROR to "Persisted resources are unavailable for one or more graphs",
+                API_FIELD_RESULTS to unavailable
+            )
+        )
+        return false
+    }
+
     private fun listResources(graph: Graph, pattern: String, limit: Int): List<Map<String, Any?>> {
         return graph.resources.list(pattern)
             .map { entry ->
@@ -1193,6 +1219,7 @@ internal class ExploreRoutes(
         private const val API_ROOT = "/api"
         private const val HTTP_NO_CONTENT = 204
         private const val HTTP_BAD_REQUEST = 400
+        private const val HTTP_CONFLICT = 409
         private const val HTTP_NOT_FOUND = 404
         private const val HTTP_PAYLOAD_TOO_LARGE = 413
         private const val HTTP_TOO_MANY_REQUESTS = 429

--- a/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
+++ b/graphite-explore/src/main/kotlin/io/johnsonlee/graphite/cli/OpenApiSpecBuilder.kt
@@ -200,7 +200,10 @@ internal class OpenApiSpecBuilder {
                         queryParameter(API_PARAM_PATTERN, TYPE_STRING, false, "Glob pattern, defaults to **"),
                         queryParameter(API_PARAM_LIMIT, TYPE_INTEGER, false, API_OPENAPI_MAX_RESULTS)
                     ),
-                    responses = mapOf("200" to response("Resource listing"))
+                    responses = mapOf(
+                        "200" to response("Resource listing"),
+                        "409" to response("Graph was built without a persisted resource store and must be rebuilt")
+                    )
                 )
             ),
             "/api/resources/{path}" to mapOf(
@@ -211,6 +214,7 @@ internal class OpenApiSpecBuilder {
                     ),
                     responses = mapOf(
                         "200" to response("Raw resource content"),
+                        "409" to response("Graph was built without a persisted resource store and must be rebuilt"),
                         "413" to response("Resource exceeds maximum response size"),
                         "404" to response(API_ERROR_RESOURCE_NOT_FOUND)
                     )

--- a/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
+++ b/graphite-explore/src/test/kotlin/io/johnsonlee/graphite/cli/ExploreCommandTest.kt
@@ -52,6 +52,7 @@ import org.junit.AfterClass
 import org.junit.BeforeClass
 import picocli.CommandLine
 import java.io.ByteArrayInputStream
+import java.io.Closeable
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URI
@@ -62,6 +63,9 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import javax.tools.ToolProvider
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -1415,6 +1419,128 @@ class ExploreCommandTest {
     // ========================================================================
 
     @Test
+    fun `real jar build persists and serves resource content`() {
+        val root = Files.createTempDirectory("explore-jar-resource-test")
+        val classesDir = Files.createDirectories(root.resolve("classes"))
+        val graphOutput = root.resolve("graph")
+        val fixtureJar = root.resolve("resource-fixture.jar")
+        val resourcePath = "config/application.properties"
+        val resourceContent = "feature.mode=jar-e2e\n"
+        try {
+            val javaSource = root.resolve("ResourceSample.java")
+            Files.writeString(
+                javaSource,
+                """
+                package sample;
+                public class ResourceSample {
+                    public String mode() { return "jar-e2e"; }
+                }
+                """.trimIndent()
+            )
+            val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
+            assertEquals(
+                0,
+                compiler.run(null, null, null, "-d", classesDir.toString(), javaSource.toString()),
+                "Java fixture compilation should succeed"
+            )
+
+            JarOutputStream(Files.newOutputStream(fixtureJar)).use { jar ->
+                jar.putNextEntry(JarEntry("sample/ResourceSample.class"))
+                Files.copy(classesDir.resolve("sample/ResourceSample.class"), jar)
+                jar.closeEntry()
+                jar.putNextEntry(JarEntry(resourcePath))
+                jar.write(resourceContent.toByteArray())
+                jar.closeEntry()
+            }
+
+            val build = BuildCommand().apply {
+                input = fixtureJar
+                output = graphOutput
+                includePackages = listOf("sample")
+            }
+            val (_, error, code) = captureOutput { build.call() }
+            assertEquals(0, code, "JAR graph build should succeed, stderr: $error")
+            assertTrue(Files.isRegularFile(graphOutput.resolve("graph.resources")))
+
+            val loaded = GraphStore.loadMapped(graphOutput)
+            try {
+                withExploreApp(loaded) { targetPort ->
+                    val (status, body) = get(targetPort, "/api/resources/$resourcePath")
+                    assertEquals(200, status, "Expected persisted JAR resource, body: $body")
+                    val result: Map<String, Any?> = parseJson(body)
+                    assertEquals(resourcePath, result["path"])
+                    assertEquals(fixtureJar.fileName.toString(), result["source"])
+                    assertEquals(false, result["derived"])
+                    assertEquals(resourceContent, result["content"])
+                }
+            } finally {
+                (loaded as? Closeable)?.close()
+            }
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `resources API distinguishes an empty store from a missing legacy store`() {
+        val root = Files.createTempDirectory("explore-resource-store-state-test")
+        val currentDir = root.resolve("current")
+        val legacyDir = root.resolve("legacy")
+        try {
+            val emptyGraph = DefaultGraph.Builder().build()
+            GraphStore.save(emptyGraph, currentDir)
+            GraphStore.save(emptyGraph, legacyDir)
+            Files.delete(legacyDir.resolve("graph.resources"))
+
+            val current = GraphStore.loadMapped(currentDir)
+            try {
+                withExploreApp(current) { targetPort ->
+                    val (status, body) = get(targetPort, "/api/resources")
+                    assertEquals(200, status, "Current empty resource store should remain queryable: $body")
+                    val result: Map<String, Any?> = parseJson(body)
+                    assertEquals(0.0, result["count"])
+                }
+            } finally {
+                (current as Closeable).close()
+            }
+
+            val legacy = GraphStore.loadMapped(legacyDir)
+            try {
+                withExploreApp(legacy) { targetPort ->
+                    val (listStatus, listBody) = get(targetPort, "/api/resources")
+                    assertEquals(409, listStatus, "Missing resource store must not appear empty: $listBody")
+                    assertTrue(listBody.contains("graph.resources is missing"))
+                    assertTrue(listBody.contains("rebuild this graph"))
+
+                    val (readStatus, readBody) = get(targetPort, "/api/resources/application.properties")
+                    assertEquals(409, readStatus, "Missing resource store must explain failed reads: $readBody")
+                    assertTrue(readBody.contains("rebuild this graph"))
+                }
+            } finally {
+                (legacy as Closeable).close()
+            }
+
+            val registry = GraphRegistry(Files.createDirectories(root.resolve("registry")), GraphStore.LoadMode.MAPPED)
+            registry.load("current", currentDir)
+            registry.load("legacy", legacyDir)
+            withRegistryApp(registry) { targetPort ->
+                val (rootStatus, rootBody) = get(targetPort, "/api/resources")
+                assertEquals(409, rootStatus, "All-graph resources must identify unavailable stores: $rootBody")
+                assertTrue(rootBody.contains("legacy"))
+                assertTrue(rootBody.contains("rebuild this graph"))
+
+                val (currentStatus, currentBody) = get(targetPort, "/api/graphs/current/resources")
+                assertEquals(200, currentStatus, "A current graph must remain independently queryable: $currentBody")
+
+                val (legacyStatus, legacyBody) = get(targetPort, "/api/graphs/legacy/resources")
+                assertEquals(409, legacyStatus, "A legacy graph must expose the rebuild instruction: $legacyBody")
+            }
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `GET api resources returns matching resources`() {
         val (code, body) = get("/api/resources?pattern=**&limit=10")
         assertEquals(200, code, "Expected 200, body: $body")
@@ -1735,6 +1861,9 @@ class ExploreCommandTest {
         @Suppress("UNCHECKED_CAST")
         val parameters = get["parameters"] as List<Map<String, Any?>>
         assertEquals("path", parameters.single()["name"])
+        @Suppress("UNCHECKED_CAST")
+        val responses = get["responses"] as Map<String, Any?>
+        assertTrue(responses.containsKey("409"))
         @Suppress("UNCHECKED_CAST")
         val c4 = paths["/api/architecture/c4"] as Map<String, Map<String, Any?>>
         @Suppress("UNCHECKED_CAST")

--- a/graphite-query/build.gradle.kts
+++ b/graphite-query/build.gradle.kts
@@ -11,6 +11,9 @@ application {
     applicationName = "graphite"
 }
 
+val resourceFixture: Configuration by configurations.creating
+resourceFixture.isTransitive = false
+
 dependencies {
     implementation(project(":core"))
     implementation(project(":cypher"))
@@ -19,6 +22,7 @@ dependencies {
     implementation(project(":webgraph"))
     implementation(libs.picocli)
     implementation(libs.gson)
+    add(resourceFixture.name, libs.spring.jcl)
 }
 
 tasks.jar {
@@ -71,6 +75,9 @@ kover {
 
 tasks.test {
     systemProperty("graphite.version", project.version.toString())
+    doFirst {
+        systemProperty("spring.jcl.jar.path", resourceFixture.singleFile.absolutePath)
+    }
     testLogging {
         events("passed", "skipped", "failed")
         showExceptions = true

--- a/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
+++ b/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
@@ -1,5 +1,6 @@
 package io.johnsonlee.graphite.cli
 
+import io.johnsonlee.graphite.input.unavailableReason
 import io.johnsonlee.graphite.webgraph.GraphStore
 import picocli.CommandLine
 import java.io.ByteArrayOutputStream

--- a/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
+++ b/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
@@ -7,8 +7,11 @@ import java.io.PrintStream
 import java.io.PrintWriter
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -143,6 +146,56 @@ class GraphiteCommandTest {
         } finally {
             classesDir.toFile().deleteRecursively()
             outputDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `build from jar without persistable resources writes loadable empty store`() {
+        val root = Files.createTempDirectory("build-empty-resource-jar-test")
+        val classesDir = Files.createDirectories(root.resolve("classes"))
+        val fixtureJar = root.resolve("class-only-fixture.jar")
+        val outputDir = root.resolve("graph")
+        try {
+            val javaFile = root.resolve("ClassOnlySample.java")
+            Files.writeString(
+                javaFile,
+                """
+                package sample;
+                public class ClassOnlySample {
+                    public int value() { return 42; }
+                }
+                """.trimIndent()
+            )
+            val compiler = requireNotNull(javax.tools.ToolProvider.getSystemJavaCompiler())
+            assertEquals(
+                0,
+                compiler.run(null, null, null, "-d", classesDir.toString(), javaFile.toString()),
+                "Java fixture compilation should succeed"
+            )
+
+            JarOutputStream(Files.newOutputStream(fixtureJar)).use { jar ->
+                jar.putNextEntry(JarEntry("sample/ClassOnlySample.class"))
+                Files.copy(classesDir.resolve("sample/ClassOnlySample.class"), jar)
+                jar.closeEntry()
+            }
+
+            val cmd = BuildCommand().apply {
+                input = fixtureJar
+                output = outputDir
+                includePackages = listOf("sample")
+            }
+            val (_, err, code) = captureOutput { cmd.call() }
+            assertEquals(0, code, "JAR graph build should succeed, stderr: $err")
+
+            val resourceStore = outputDir.resolve("graph.resources")
+            assertTrue(Files.isRegularFile(resourceStore))
+            assertEquals(8L, Files.size(resourceStore), "An empty persisted resource store is header-only")
+
+            val loaded = GraphStore.load(outputDir)
+            assertNull(loaded.resources.unavailableReason)
+            assertEquals(emptyList(), loaded.resources.list("**").toList())
+        } finally {
+            root.toFile().deleteRecursively()
         }
     }
 

--- a/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
+++ b/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
@@ -8,8 +8,10 @@ import java.io.PrintWriter
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.jar.JarEntry
+import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -196,6 +198,39 @@ class GraphiteCommandTest {
             assertEquals(emptyList(), loaded.resources.list("**").toList())
         } finally {
             root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `build from published jar preserves persisted resource bytes`() {
+        val fixtureJar = Path.of(requireNotNull(System.getProperty("spring.jcl.jar.path")))
+        val resourcePath = "META-INF/license.txt"
+        val expectedContent = JarFile(fixtureJar.toFile()).use { jar ->
+            val entry = requireNotNull(jar.getJarEntry(resourcePath)) {
+                "Published fixture does not contain $resourcePath"
+            }
+            jar.getInputStream(entry).use { it.readBytes() }
+        }
+        val outputDir = Files.createTempDirectory("build-published-resource-jar-test")
+        try {
+            val cmd = BuildCommand().apply {
+                input = fixtureJar
+                output = outputDir
+                includePackages = listOf("org.apache.commons.logging")
+            }
+            val (_, err, code) = captureOutput { cmd.call() }
+            assertEquals(0, code, "Published JAR graph build should succeed, stderr: $err")
+
+            val resourceStore = outputDir.resolve("graph.resources")
+            assertTrue(Files.size(resourceStore) > 8L, "Published JAR must produce a non-empty resource store")
+
+            val loaded = GraphStore.load(outputDir)
+            val entry = loaded.resources.list(resourcePath).single()
+            assertEquals(resourcePath, entry.path)
+            assertEquals(fixtureJar.fileName.toString(), entry.source)
+            assertContentEquals(expectedContent, loaded.resources.open(resourcePath).use { it.readBytes() })
+        } finally {
+            outputDir.toFile().deleteRecursively()
         }
     }
 

--- a/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
+++ b/graphite-query/src/test/kotlin/io/johnsonlee/graphite/cli/GraphiteCommandTest.kt
@@ -1,5 +1,6 @@
 package io.johnsonlee.graphite.cli
 
+import io.johnsonlee.graphite.webgraph.GraphStore
 import picocli.CommandLine
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
@@ -120,6 +121,7 @@ class GraphiteCommandTest {
             Files.createDirectories(sampleDir)
             val compileResult = compiler.run(null, null, null, "-d", classesDir.toString(), javaFile.toString())
             assertEquals(0, compileResult, "Java compilation should succeed")
+            Files.writeString(classesDir.resolve("application.properties"), "feature.mode=shadow\n")
 
             val cmd = BuildCommand()
             cmd.input = classesDir
@@ -132,6 +134,12 @@ class GraphiteCommandTest {
             assertTrue(err.contains("Graph built"), "Should show graph built message, got: $err")
             assertTrue(err.contains("Saving to"), "Should show saving message, got: $err")
             assertTrue(err.contains("Done"), "Should show done message, got: $err")
+            assertTrue(Files.isRegularFile(outputDir.resolve("graph.resources")))
+            val loaded = GraphStore.load(outputDir)
+            assertEquals(
+                "feature.mode=shadow\n",
+                loaded.resources.open("application.properties").bufferedReader().use { it.readText() }
+            )
         } finally {
             classesDir.toFile().deleteRecursively()
             outputDir.toFile().deleteRecursively()

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/GraphStore.kt
@@ -500,6 +500,7 @@ internal data class NodeIndexData(
  * - `graph.nodedata`           -- sequential binary node data with string table indices
  * - `graph.metadata`           -- methods, type hierarchy, enums, annotations, branch scopes (string table indices)
  * - `graph.classoverview`      -- class-level call counts and dependency weights
+ * - `graph.resources`          -- persisted text resources, including an explicit empty store when none exist
  */
 object GraphStore {
 

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
@@ -3,6 +3,7 @@ package io.johnsonlee.graphite.webgraph
 import io.johnsonlee.graphite.graph.Graph
 import io.johnsonlee.graphite.input.ResourceAccessor
 import io.johnsonlee.graphite.input.ResourceEntry
+import io.johnsonlee.graphite.input.UnavailableResourceAccessor
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.ByteArrayInputStream
@@ -36,7 +37,7 @@ internal class PersistedResourceAccessor(
             ?: throw java.io.IOException("Resource not found: $path")
 }
 
-internal object MissingPersistedResourceAccessor : ResourceAccessor {
+internal object MissingPersistedResourceAccessor : ResourceAccessor, UnavailableResourceAccessor {
     override val unavailableReason: String =
         "Persisted resources are unavailable because graph.resources is missing; " +
             "rebuild this graph with the current Graphite CLI"

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
@@ -1,7 +1,6 @@
 package io.johnsonlee.graphite.webgraph
 
 import io.johnsonlee.graphite.graph.Graph
-import io.johnsonlee.graphite.input.EmptyResourceAccessor
 import io.johnsonlee.graphite.input.ResourceAccessor
 import io.johnsonlee.graphite.input.ResourceEntry
 import java.io.BufferedInputStream
@@ -37,6 +36,16 @@ internal class PersistedResourceAccessor(
             ?: throw java.io.IOException("Resource not found: $path")
 }
 
+internal object MissingPersistedResourceAccessor : ResourceAccessor {
+    override val unavailableReason: String =
+        "Persisted resources are unavailable because graph.resources is missing; " +
+            "rebuild this graph with the current Graphite CLI"
+
+    override fun list(pattern: String): Sequence<ResourceEntry> = emptySequence()
+
+    override fun open(path: String): InputStream = throw java.io.IOException(unavailableReason)
+}
+
 internal object PersistedResourceStore {
     private const val FILE_NAME = "graph.resources"
     private const val MAGIC = 0x47525200 // "GRR" + version byte
@@ -60,7 +69,7 @@ internal object PersistedResourceStore {
 
     fun load(dir: Path): ResourceAccessor {
         val file = dir.resolve(FILE_NAME)
-        if (!Files.exists(file)) return EmptyResourceAccessor
+        if (!Files.exists(file)) return MissingPersistedResourceAccessor
         DataInputStream(BufferedInputStream(Files.newInputStream(file))).use { dis ->
             readHeader(dis)
             val count = dis.readInt()

--- a/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
+++ b/graphite-webgraph/src/main/kotlin/io/johnsonlee/graphite/webgraph/PersistedResourceAccessor.kt
@@ -45,7 +45,6 @@ internal object PersistedResourceStore {
 
     fun save(graph: Graph, dir: Path) {
         val resources = collect(graph)
-        if (resources.isEmpty()) return
 
         DataOutputStream(BufferedOutputStream(Files.newOutputStream(dir.resolve(FILE_NAME)))).use { dos ->
             writeHeader(dos)

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/AndroidSdkIntegrationTest.kt
@@ -10,7 +10,9 @@ import org.junit.Assume.assumeTrue
 import java.io.Closeable
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.jar.JarFile
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertTrue
 
 /**
@@ -64,15 +66,33 @@ class AndroidSdkIntegrationTest {
 
     @Test
     fun `save and load Android graph`() {
+        val resourcePath = "AndroidManifest.xml"
+        val expectedResource = JarFile(androidJar!!.toFile()).use { jar ->
+            val entry = requireNotNull(jar.getJarEntry(resourcePath)) {
+                "Android fixture does not contain $resourcePath"
+            }
+            jar.getInputStream(entry).use { it.readBytes() }
+        }
         val original = loadGraph()
         val dir = Files.createTempDirectory("android-webgraph")
         try {
+            assertContentEquals(
+                expectedResource,
+                original.resources.open(resourcePath).use { it.readBytes() },
+                "Source graph must expose the real Android fixture resource"
+            )
             GraphStore.save(original, dir)
+            assertTrue(Files.isRegularFile(dir.resolve("graph.resources")))
             val loaded = GraphStore.load(dir)
             try {
                 val originalCount = original.nodes(Node::class.java).count()
                 val loadedCount = loaded.nodes(Node::class.java).count()
                 assertTrue(loadedCount == originalCount, "Node count should match: $originalCount vs $loadedCount")
+                assertContentEquals(
+                    expectedResource,
+                    loaded.resources.open(resourcePath).use { it.readBytes() },
+                    "Persisted graph must preserve the real Android fixture resource"
+                )
             } finally {
                 closeQuietly(loaded)
             }

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -2822,6 +2822,29 @@ class GraphStoreTest {
         }
     }
 
+    @Test
+    fun `loading a graph without a resource store reports resources unavailable`() {
+        val dir = Files.createTempDirectory("webgraph-missing-resources-test")
+        try {
+            GraphStore.save(DefaultGraph.Builder().build(), dir)
+            Files.delete(dir.resolve("graph.resources"))
+
+            val loaded = GraphStore.load(dir)
+            assertTrue(loaded.resources.unavailableReason.orEmpty().contains("rebuild this graph"))
+            assertEquals(emptyList(), loaded.resources.list("**").toList())
+            assertFailsWith<java.io.IOException> { loaded.resources.open("application.properties") }
+
+            val mapped = GraphStore.loadMapped(dir)
+            try {
+                assertTrue(mapped.resources.unavailableReason.orEmpty().contains("rebuild this graph"))
+            } finally {
+                (mapped as Closeable).close()
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
     // ========================================================================
     // Type hierarchy on loaded graph
     // ========================================================================

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -59,6 +59,7 @@ import io.johnsonlee.graphite.graph.nodesByStringProperty
 import io.johnsonlee.graphite.graph.nodesByTransformedStringProperty
 import io.johnsonlee.graphite.input.ResourceAccessor
 import io.johnsonlee.graphite.input.ResourceEntry
+import io.johnsonlee.graphite.input.unavailableReason
 import it.unimi.dsi.fastutil.io.BinIO
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/GraphStoreTest.kt
@@ -2793,6 +2793,35 @@ class GraphStoreTest {
         }
     }
 
+    @Test
+    fun `saving a graph without resources writes an empty resource store`() {
+        val graph = DefaultGraph.Builder().build()
+        val dir = Files.createTempDirectory("webgraph-empty-resources-test")
+        try {
+            GraphStore.save(graph, dir)
+
+            assertTrue(Files.isRegularFile(dir.resolve("graph.resources")))
+            assertEquals(emptyList(), GraphStore.load(dir).resources.list("**").toList())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `saving a graph without resources replaces stale persisted resources`() {
+        val dir = Files.createTempDirectory("webgraph-stale-resources-test")
+        try {
+            GraphStore.save(buildTestGraph(), dir)
+            assertEquals(1, GraphStore.load(dir).resources.list("**").count())
+
+            GraphStore.save(DefaultGraph.Builder().build(), dir)
+
+            assertEquals(emptyList(), GraphStore.load(dir).resources.list("**").toList())
+        } finally {
+            dir.toFile().deleteRecursively()
+        }
+    }
+
     // ========================================================================
     // Type hierarchy on loaded graph
     // ========================================================================

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/LargeCorpusPerformanceGateTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/LargeCorpusPerformanceGateTest.kt
@@ -16,7 +16,6 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.jar.JarFile
 import org.junit.Test
 import kotlin.io.path.fileSize
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -36,7 +35,6 @@ data class CorpusBaseline(
     val persistedEdgeCount: Long,
     val methodCount: Long,
     val callSiteCount: Long,
-    val resourcePath: String,
     val maxPipelineMillis: Long
 )
 
@@ -53,7 +51,6 @@ private object CorpusBaselines {
         persistedEdgeCount = 4_342_382,
         methodCount = 312_788,
         callSiteCount = 1_002_088,
-        resourcePath = "log4j2_batch_process.properties",
         maxPipelineMillis = 120_000
     )
     val hive = CorpusBaseline(
@@ -68,7 +65,6 @@ private object CorpusBaselines {
         persistedEdgeCount = 6_161_463,
         methodCount = 404_016,
         callSiteCount = 1_437_647,
-        resourcePath = "hive-exec-log4j2.properties",
         maxPipelineMillis = 180_000
     )
     val kotlinCompiler = CorpusBaseline(
@@ -83,7 +79,6 @@ private object CorpusBaselines {
         persistedEdgeCount = 3_559_500,
         methodCount = 249_669,
         callSiteCount = 900_366,
-        resourcePath = "kotlinManifest.properties",
         maxPipelineMillis = 120_000
     )
 }
@@ -112,19 +107,15 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
         val jar = fixtureJar()
         assertEquals(baseline.jarBytes, jar.fileSize(), "Unexpected artifact size for ${baseline.coordinate}")
         assertEquals(baseline.sha256, sha256(jar), "Unexpected artifact checksum for ${baseline.coordinate}")
-        val expectedResource = JarFile(jar.toFile()).use { archive ->
+        JarFile(jar.toFile()).use { archive ->
             assertEquals(baseline.classCount, archive.entries().asSequence().count { it.name.endsWith(".class") }.toLong())
-            val resource = requireNotNull(archive.getJarEntry(baseline.resourcePath)) {
-                "Fixture resource not found in ${baseline.coordinate}: ${baseline.resourcePath}"
-            }
-            archive.getInputStream(resource).use { it.readBytes() }
         }
         assertTrue(
             Runtime.getRuntime().maxMemory() <= FOUR_GIB_BYTES,
             "Gate must run with at most 4 GiB heap; maxMemory=${Runtime.getRuntime().maxMemory()}"
         )
 
-        val measurement = PeakHeapSampler().use { sampler -> runPipeline(jar, expectedResource, sampler) }
+        val measurement = PeakHeapSampler().use { sampler -> runPipeline(jar, sampler) }
         println(measurement.baselineLine(baseline))
 
         assertEquals(baseline.nodeCount, measurement.nodes, "Node baseline changed for ${baseline.id}")
@@ -150,7 +141,7 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
         return Path.of(configured).also { require(Files.isRegularFile(it)) { "Fixture JAR not found at $it" } }
     }
 
-    private fun runPipeline(jar: Path, expectedResource: ByteArray, sampler: PeakHeapSampler): GateMeasurement {
+    private fun runPipeline(jar: Path, sampler: PeakHeapSampler): GateMeasurement {
         val output = Files.createTempDirectory("graphite-${baseline.id}-gate")
         var sourceGraph: Graph? = null
         var loadedGraph: Graph? = null
@@ -164,16 +155,10 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
                 )
             ).load(jar)
             val buildMillis = elapsedMillis(buildStart)
-            assertContentEquals(
-                expectedResource,
-                sourceGraph.resources.open(baseline.resourcePath).use { it.readBytes() },
-                "Source graph must expose ${baseline.resourcePath} from ${baseline.coordinate}"
-            )
 
             val saveStart = System.nanoTime()
             GraphStore.save(sourceGraph, output)
             val saveMillis = elapsedMillis(saveStart)
-            assertTrue(Files.isRegularFile(output.resolve("graph.resources")), "Persisted resource store must exist")
 
             val nodes = sourceGraph.nodes(Node::class.java).count().toLong()
             val edgeCounts = sourceEdgeCounts(sourceGraph)
@@ -199,11 +184,6 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
             }
             val mappedLoadMillis = mappedLoadSamples.sorted()[mappedLoadSamples.size / 2]
             val queryGraph = checkNotNull(loadedGraph) { "Mapped graph sample was not retained" }
-            assertContentEquals(
-                expectedResource,
-                queryGraph.resources.open(baseline.resourcePath).use { it.readBytes() },
-                "Mapped graph must preserve ${baseline.resourcePath} from ${baseline.coordinate}"
-            )
 
             val queryStart = System.nanoTime()
             val loadedCallSites = queryGraph.query(CALL_SITE_COUNT_QUERY)

--- a/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/LargeCorpusPerformanceGateTest.kt
+++ b/graphite-webgraph/src/test/kotlin/io/johnsonlee/graphite/webgraph/LargeCorpusPerformanceGateTest.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.jar.JarFile
 import org.junit.Test
 import kotlin.io.path.fileSize
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -35,6 +36,7 @@ data class CorpusBaseline(
     val persistedEdgeCount: Long,
     val methodCount: Long,
     val callSiteCount: Long,
+    val resourcePath: String,
     val maxPipelineMillis: Long
 )
 
@@ -51,6 +53,7 @@ private object CorpusBaselines {
         persistedEdgeCount = 4_342_382,
         methodCount = 312_788,
         callSiteCount = 1_002_088,
+        resourcePath = "log4j2_batch_process.properties",
         maxPipelineMillis = 120_000
     )
     val hive = CorpusBaseline(
@@ -65,6 +68,7 @@ private object CorpusBaselines {
         persistedEdgeCount = 6_161_463,
         methodCount = 404_016,
         callSiteCount = 1_437_647,
+        resourcePath = "hive-exec-log4j2.properties",
         maxPipelineMillis = 180_000
     )
     val kotlinCompiler = CorpusBaseline(
@@ -79,6 +83,7 @@ private object CorpusBaselines {
         persistedEdgeCount = 3_559_500,
         methodCount = 249_669,
         callSiteCount = 900_366,
+        resourcePath = "kotlinManifest.properties",
         maxPipelineMillis = 120_000
     )
 }
@@ -107,15 +112,19 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
         val jar = fixtureJar()
         assertEquals(baseline.jarBytes, jar.fileSize(), "Unexpected artifact size for ${baseline.coordinate}")
         assertEquals(baseline.sha256, sha256(jar), "Unexpected artifact checksum for ${baseline.coordinate}")
-        JarFile(jar.toFile()).use { archive ->
+        val expectedResource = JarFile(jar.toFile()).use { archive ->
             assertEquals(baseline.classCount, archive.entries().asSequence().count { it.name.endsWith(".class") }.toLong())
+            val resource = requireNotNull(archive.getJarEntry(baseline.resourcePath)) {
+                "Fixture resource not found in ${baseline.coordinate}: ${baseline.resourcePath}"
+            }
+            archive.getInputStream(resource).use { it.readBytes() }
         }
         assertTrue(
             Runtime.getRuntime().maxMemory() <= FOUR_GIB_BYTES,
             "Gate must run with at most 4 GiB heap; maxMemory=${Runtime.getRuntime().maxMemory()}"
         )
 
-        val measurement = PeakHeapSampler().use { sampler -> runPipeline(jar, sampler) }
+        val measurement = PeakHeapSampler().use { sampler -> runPipeline(jar, expectedResource, sampler) }
         println(measurement.baselineLine(baseline))
 
         assertEquals(baseline.nodeCount, measurement.nodes, "Node baseline changed for ${baseline.id}")
@@ -141,7 +150,7 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
         return Path.of(configured).also { require(Files.isRegularFile(it)) { "Fixture JAR not found at $it" } }
     }
 
-    private fun runPipeline(jar: Path, sampler: PeakHeapSampler): GateMeasurement {
+    private fun runPipeline(jar: Path, expectedResource: ByteArray, sampler: PeakHeapSampler): GateMeasurement {
         val output = Files.createTempDirectory("graphite-${baseline.id}-gate")
         var sourceGraph: Graph? = null
         var loadedGraph: Graph? = null
@@ -155,10 +164,16 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
                 )
             ).load(jar)
             val buildMillis = elapsedMillis(buildStart)
+            assertContentEquals(
+                expectedResource,
+                sourceGraph.resources.open(baseline.resourcePath).use { it.readBytes() },
+                "Source graph must expose ${baseline.resourcePath} from ${baseline.coordinate}"
+            )
 
             val saveStart = System.nanoTime()
             GraphStore.save(sourceGraph, output)
             val saveMillis = elapsedMillis(saveStart)
+            assertTrue(Files.isRegularFile(output.resolve("graph.resources")), "Persisted resource store must exist")
 
             val nodes = sourceGraph.nodes(Node::class.java).count().toLong()
             val edgeCounts = sourceEdgeCounts(sourceGraph)
@@ -184,6 +199,11 @@ abstract class LargeCorpusGate(private val baseline: CorpusBaseline) {
             }
             val mappedLoadMillis = mappedLoadSamples.sorted()[mappedLoadSamples.size / 2]
             val queryGraph = checkNotNull(loadedGraph) { "Mapped graph sample was not retained" }
+            assertContentEquals(
+                expectedResource,
+                queryGraph.resources.open(baseline.resourcePath).use { it.readBytes() },
+                "Mapped graph must preserve ${baseline.resourcePath} from ${baseline.coordinate}"
+            )
 
             val queryStart = System.nanoTime()
             val loadedCallSites = queryGraph.query(CALL_SITE_COUNT_QUERY)


### PR DESCRIPTION
## Summary

- always materialize `graph.resources`, including a valid zero-entry store for graphs without supported text resources
- distinguish a valid empty store from a graph whose persisted resource sidecar is missing
- return HTTP `409` with a rebuild instruction instead of silently reporting a missing store as empty
- preserve the existing two-method `ResourceAccessor` JVM ABI by exposing diagnostics through a separate capability
- cover both actual-JAR branches through `BuildCommand`: non-empty persisted content and an 8-byte loadable empty store
- verify the non-empty CLI path byte-for-byte with the published `spring-jcl-6.1.0.jar`

## Root cause

The behavior was introduced by `ca1870b093b851038863959399a2535b1ce73033` with the resource graph/API feature. It first shipped in `v1.2.0-alpha.1`, first appeared in a stable release in `v1.2.0`, and remained present through `v2.4.5`, including `v2.3.0`.

Version 2.3.0 invokes `PersistedResourceStore.save`, but that implementation returns before opening `graph.resources` whenever resource collection is empty. Collection only keeps `.properties`, `.yml`, `.yaml`, `.json`, `.xml`, and `.txt`, and read failures are silently dropped. Consequently, a successful 2.3.0 build can produce no `graph.resources` when its input has no matching readable entries.

Loading then compounded the problem: a missing sidecar was mapped to `EmptyResourceAccessor`, so the resources API could not distinguish a graph with zero resources from a graph whose resource store had never been written.

## Behavior

- graph with no supported resources: `graph.resources` exists as a valid 8-byte zero-entry store and `/api/resources` returns `200` with an empty result
- graph whose sidecar is missing: other graph APIs remain usable; resources endpoints return `409` with a current-CLI rebuild instruction
- graph built from a resource-bearing JAR: persisted content is returned by `/api/resources/{path}`

A graph without the sidecar cannot recover resource bytes that were never persisted; it must be rebuilt from its source archive with a fixed CLI.

## Verification

- final head `8d9a6c35b159`: required unit and benchmark checks pass
- old-binary/new-runtime compatibility: a committed test compiles an accessor against the old two-method API, loads it against the current runtime, and verifies resource availability lookup without `AbstractMethodError`; candidate `javap` exposes only `list` and `open`
- published non-empty JAR CLI E2E: `spring-jcl-6.1.0.jar` to `BuildCommand` to non-empty `graph.resources` to `GraphStore.load`; `META-INF/license.txt` path, source name, and bytes match the source JAR
- actual empty JAR E2E: compiled class-only JAR to `BuildCommand` to 8-byte `graph.resources` to `GraphStore.load`; resources are available and empty
- generated non-empty JAR API E2E: compiled fixture JAR to `BuildCommand` to MAPPED load to HTTP resource content
- published Android fixture: `android-all-14-robolectric-10818077.jar` to graph to save/load; `AndroidManifest.xml` matched byte-for-byte
- targeted compatibility, GraphStore, API, empty-JAR, and published-JAR tests pass in a clean clone
- all review threads and ordinary blocking comments are resolved

## Performance

Exact head `8d9a6c35b159` passed the required [benchmark regression gate](https://github.com/johnsonlee/graphite/actions/runs/33444863652), 9/9 component reports, against `main` at `e9410a4f7424`. A failed-job rerun cleared two isolated Method CPU measurements; all 12 Method shards and the aggregate gate finished green. Method-level and end-to-end results show no confirmed regression, and the large-corpus JAR-to-build-to-save-to-mapped-load-to-query gate passed.

Empty-resource saves add one 8-byte sequential sidecar write; no query execution path changes.