### PR TITLE
Cover the direct-string worker cancel-before-start branch deterministically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+.kotlin/

--- a/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
+++ b/graphite-cypher/src/main/kotlin/io/johnsonlee/graphite/cypher/QueryPipeline.kt
@@ -153,6 +153,25 @@ private val configuredDirectStringParallelism by lazy { System.getProperty(DIREC
 private val directStringExecutorParallelism: Int by lazy {
     resolveDirectStringExecutorParallelism(configuredGraphWorkers = configuredDirectStringParallelism)
 }
+/**
+ * Cancels a direct-string worker that has not started yet and releases its completion latch, so a
+ * query that stops early or fails does not wait on a worker the executor never ran. A worker that
+ * has already started (its [started] flag is set) keeps running to its own `finally`, and a future
+ * that can no longer be cancelled is left alone. Extracted so the not-started branch is covered
+ * deterministically rather than only when cancellation happens to win the race against worker start.
+ */
+internal fun cancelDirectStringWorkerBeforeStart(
+    future: Future<*>,
+    started: AtomicBoolean,
+    completion: CountDownLatch
+): Boolean {
+    if (future.cancel(true) && started.compareAndSet(false, true)) {
+        completion.countDown()
+        return true
+    }
+    return false
+}
+
 private val directStringExecutor by lazy {
     Executors.newFixedThreadPool(directStringExecutorParallelism) { runnable ->
         Thread(runnable, "graphite-cypher-scan-${directStringWorkerNumber.incrementAndGet()}").apply {
@@ -2457,7 +2476,7 @@ class QueryPipeline private constructor(
                 val taskStarted = started[index]
                 val completion = completions[index]
                 if (future != null && taskStarted != null && completion != null) {
-                    if (future.cancel(true) && taskStarted.compareAndSet(false, true)) completion.countDown()
+                    cancelDirectStringWorkerBeforeStart(future, taskStarted, completion)
                 }
             }
             awaitDirectStringTasks(completions.filterNotNull())
@@ -2523,7 +2542,7 @@ class QueryPipeline private constructor(
                 val taskStarted = started[index]
                 val completion = completions[index]
                 if (future != null && taskStarted != null && completion != null) {
-                    if (future.cancel(true) && taskStarted.compareAndSet(false, true)) completion.countDown()
+                    cancelDirectStringWorkerBeforeStart(future, taskStarted, completion)
                 }
             }
             awaitDirectStringTasks(completions.filterNotNull())
@@ -2619,9 +2638,7 @@ class QueryPipeline private constructor(
         fun stopWorkers(cancel: Boolean) {
             if (cancel) {
                 futures.forEachIndexed { index, future ->
-                    if (future.cancel(true) && started[index].compareAndSet(false, true)) {
-                        completions[index].countDown()
-                    }
+                    cancelDirectStringWorkerBeforeStart(future, started[index], completions[index])
                 }
             } else {
                 repeat(workerCount) { taskIndexes.add(-1) }

--- a/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/DirectStringWorkerCancellationTest.kt
+++ b/graphite-cypher/src/test/kotlin/io/johnsonlee/graphite/cypher/DirectStringWorkerCancellationTest.kt
@@ -1,0 +1,51 @@
+package io.johnsonlee.graphite.cypher
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.FutureTask
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DirectStringWorkerCancellationTest {
+    @Test
+    fun `cancels a worker that never started and releases its completion latch`() {
+        val future = FutureTask { }
+        val started = AtomicBoolean(false)
+        val completion = CountDownLatch(1)
+
+        val cancelled = cancelDirectStringWorkerBeforeStart(future, started, completion)
+
+        assertTrue(cancelled, "a not-started worker must be cancelled before start")
+        assertTrue(future.isCancelled)
+        assertTrue(started.get(), "the started flag is claimed so the worker body cannot run")
+        assertEquals(0L, completion.count, "the completion latch is released")
+    }
+
+    @Test
+    fun `leaves an already started worker to finish on its own`() {
+        val future = FutureTask { }
+        val started = AtomicBoolean(true)
+        val completion = CountDownLatch(1)
+
+        val cancelled = cancelDirectStringWorkerBeforeStart(future, started, completion)
+
+        assertFalse(cancelled, "a started worker owns its completion latch")
+        assertEquals(1L, completion.count, "the latch is not touched for a started worker")
+    }
+
+    @Test
+    fun `does not release the latch when the future can no longer be cancelled`() {
+        val future = FutureTask { }
+        future.run()
+        val started = AtomicBoolean(false)
+        val completion = CountDownLatch(1)
+
+        val cancelled = cancelDirectStringWorkerBeforeStart(future, started, completion)
+
+        assertFalse(cancelled, "a finished future cannot be cancelled")
+        assertFalse(started.get(), "the started flag is untouched when cancellation fails")
+        assertEquals(1L, completion.count, "the latch is not released when cancellation fails")
+    }
+}


### PR DESCRIPTION
## Summary

The cypher module's line coverage sits exactly on the 98% gate and flips between **97.9975%** (fails `run-unit-test`) and **98.0132%** (passes) run to run. The two lines that flip are the direct-string worker's cancel-before-start branch, inlined at three sites in `QueryPipeline.kt`:

```kotlin
if (future.cancel(true) && started.compareAndSet(false, true)) completion.countDown()
```

That not-started branch is reached only when a query stops early or fails while a pooled worker future is still queued, i.e. only when cancellation wins the race against the worker starting. Normal single-query runs size the pool to the worker count, so the branch is hit or missed by timing, and the module's coverage lands on the wrong side of the threshold at random. It has intermittently failed `run-unit-test` on unrelated PRs (#117, #119).

## Change

- Extract the branch into `internal fun cancelDirectStringWorkerBeforeStart(future, started, completion)`; the three sites (`runDirectStringTasksInOrderUntil`, the fixed-worker variant's `cancelAndJoin`, and its `stopWorkers`) now call it. No behavior change: a not-started future is cancelled and its latch released, a started worker keeps running to its own `finally`, a future that can no longer be cancelled is left alone.
- `DirectStringWorkerCancellationTest` drives the helper's three outcomes directly with `FutureTask` and `AtomicBoolean`, no threads or pool, so the branch is covered every run.

## Validation

- `:cypher:compileKotlin`, `:cypher:compileTestKotlin`, `:cypher:detekt` pass.
- Full `:cypher` kover after the change: **98.0142%** (covered 6219 / missed 126), with the helper's lines covered every run.

This unblocks `run-unit-test` for any PR whose cypher coverage was riding the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yd879evHTgiGieE2o22jW

---
_Generated by [Claude Code](https://claude.ai/code/session_016yd879evHTgiGieE2o22jW)_