### PR TITLE
Gate method-compatibility CPU on javaThreadCpuNanos, keep process CPU advisory

### DIFF
--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -3310,6 +3310,32 @@ test("method-compatibility shards run the CPU accounting contract in its own JVM
     assert.ok(contract < firstFork, "the contract must run before the first measured fork");
 });
 
+test("the method-compatibility shard gates CPU on javaThreadCpuNanos and keeps processCpuNanos advisory", () => {
+    const workflow = fs.readFileSync(new URL("../workflows/benchmark.yml", import.meta.url), "utf8");
+    const start = workflow.indexOf("\n  method-compatibility-shard:");
+    const job = workflow.slice(start + 1, workflow.indexOf("\n  validate-cpu-accounting:"));
+    assert.ok(start > 0 && job.length > 0, "the method-compatibility-shard job must exist");
+
+    // The blocking CPU gate now measures request-serving Java-thread CPU, not whole-process CPU.
+    assert.match(job, /gate_metric cpu javaThreadCpuNanos '[^']*' false/,
+        "cpu must gate on javaThreadCpuNanos as a blocking metric");
+    assert.match(job, /'cpu:javaThreadCpuNanos:[^:]*:false'/,
+        "the final-enforcement spec must gate cpu on javaThreadCpuNanos (blocking)");
+    // Whole-process CPU is retained only as an advisory row so a swing can still be attributed.
+    assert.match(job, /gate_metric process-cpu processCpuNanos '[^']*' true/,
+        "processCpuNanos must be an advisory (non-blocking) metric");
+    assert.match(job, /'process-cpu:processCpuNanos:[^:]*:true'/,
+        "the final-enforcement spec must keep processCpuNanos advisory");
+    // The blocking gate must no longer be whole-process CPU.
+    assert.doesNotMatch(job, /gate_metric cpu processCpuNanos [^\n]* false/,
+        "processCpuNanos must not remain the blocking cpu gate");
+    assert.doesNotMatch(job, /'cpu:processCpuNanos:[^:]*:false'/,
+        "the spec must not keep processCpuNanos as the blocking cpu metric");
+    // The advisory process-CPU report and status join the shard aggregation.
+    assert.match(job, /-process-cpu-report\.md/, "the advisory process-CPU report must be aggregated into the shard report");
+    assert.match(job, /-process-cpu-status\.json/, "the advisory process-CPU status must be aggregated into the shard status");
+});
+
 test("a candidate-owned smoke exercises the new CPU accounting harness in a real fork", () => {
     const workflow = fs.readFileSync(new URL("../workflows/benchmark.yml", import.meta.url), "utf8");
     assert.match(workflow, /^  validate-cpu-accounting:$/m, "a candidate-owned CPU-accounting smoke job must exist");

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -670,7 +670,8 @@ jobs:
 
         NEED_CONFIRMATION=0
         gate_metric wall '' 'wall time' false || NEED_CONFIRMATION=1
-        gate_metric cpu processCpuNanos 'CPU time' false || NEED_CONFIRMATION=1
+        gate_metric cpu javaThreadCpuNanos 'CPU time (Java threads)' false || NEED_CONFIRMATION=1
+        gate_metric process-cpu processCpuNanos 'process CPU time (advisory)' true || NEED_CONFIRMATION=1
         gate_metric rss-after residentSetAfterBytes 'RSS after query' false || NEED_CONFIRMATION=1
         gate_metric rss-delta residentSetDeltaBytes 'RSS query delta (advisory)' true || NEED_CONFIRMATION=1
 
@@ -704,7 +705,8 @@ jobs:
         FINAL_FAILURE=0
         for SPEC in \
           'wall::wall time:false' \
-          'cpu:processCpuNanos:CPU time:false' \
+          'cpu:javaThreadCpuNanos:CPU time (Java threads):false' \
+          'process-cpu:processCpuNanos:process CPU time (advisory):true' \
           'rss-after:residentSetAfterBytes:RSS after query:false' \
           'rss-delta:residentSetDeltaBytes:RSS query delta (advisory):true'; do
           IFS=: read -r SLUG METRIC TITLE ADVISORY <<< "${SPEC}"
@@ -731,6 +733,7 @@ jobs:
         cat \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-wall-report.md" \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-cpu-report.md" \
+          "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-process-cpu-report.md" \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-rss-after-report.md" \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-rss-delta-report.md" \
           > "benchmark-results/method-compatibility-shard-${GRAPH_COUNT}-${GROUP}-report.md"
@@ -741,6 +744,7 @@ jobs:
         }' \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-wall-status.json" \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-cpu-status.json" \
+          "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-process-cpu-status.json" \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-rss-after-status.json" \
           "benchmark-results/method-compatibility-${GRAPH_COUNT}-${GROUP}-rss-delta-status.json" \
           > "benchmark-results/method-compatibility-shard-${GRAPH_COUNT}-${GROUP}-status.json"


### PR DESCRIPTION
## Summary

The metric switch that follows the harness PR (#119). #119 landed the request-serving **Java-thread CPU** accounting (`javaThreadCpuNanos`, measured by Java-thread identity) as main's base-installed `MethodDiscoveryCompatibilityBenchmark`. Because the benchmark workflow installs the base-owned harness over both trees, both sides of the `method-compatibility` gate now emit `javaThreadCpuNanos`. This PR flips the blocking CPU gate to it.

## What changes

In the `method-compatibility-shard` gate step:

- **`cpu` gate → `javaThreadCpuNanos` (blocking).** The request row's CPU is now the sum of each Java thread's own `ThreadMXBean.getThreadCpuTime` over the window — the JVM's internal collector/compiler/VM threads are never in it.
- **`processCpuNanos` → advisory (`process-cpu`, non-blocking).** Whole-process CPU is still reported so a swing can be attributed (against `gcTimeMillis`/`jitTimeMillis`), but it no longer fails the gate.
- The advisory `process-cpu` report and status join the shard report/status aggregation alongside the existing metrics.

No production code changes; this is a workflow gate change only.

## Why

The shards gated each request row on `processCpuNanos`, which folds the concurrent collector and compiler threads into the row. On the hosted runner that figure swings between runs of **identical code** — over 22 rows of recent heads the process-CPU deltas ranged −32%..+57% (stdev 22%) while the wall rows stayed within −9%..+13% (stdev 6%), and every red shard was a process-CPU row with all wall rows passing. Gating on the request-serving Java-thread CPU removes that collector/JIT noise from the blocking decision while keeping the process figure visible.

This run is the main-vs-main validation of the #119 harness: the reviewed harness is the base-installed control on both revisions, so any movement in `javaThreadCpuNanos` here is the metric's own run-to-run behaviour on identical code, not a candidate diff.

## Validation

- `.github/scripts/benchmark-gate.test.mjs`: 91 node tests pass, including a new test asserting the shard gates `cpu` on `javaThreadCpuNanos` (blocking), keeps `processCpuNanos` advisory, and aggregates the advisory process-CPU report and status.
- `benchmark.yml` parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yd879evHTgiGieE2o22jW

---
_Generated by [Claude Code](https://claude.ai/code/session_016yd879evHTgiGieE2o22jW)_