### PR TITLE
Disable client keep-alive so the method-compat accounting window has no vanishing Keep-Alive-Timer

### DIFF
--- a/.github/scripts/benchmark-gate.test.mjs
+++ b/.github/scripts/benchmark-gate.test.mjs
@@ -3322,6 +3322,11 @@ test("a candidate-owned smoke exercises the new CPU accounting harness in a real
     assert.doesNotMatch(job, /Install base-owned Explorer harnesses/, "the smoke must not install the base harness");
     // A real graphCount=4 fork over all four corpora.
     assert.match(job, /-p graphCount=4 -p scenario=count/);
+    // And the worst-case graph count over the scenarios that tripped the accounting, with
+    // fail-on-error so an abort in measure() fails the step -- proving the matrix, not just 4/count.
+    assert.match(job, /-p graphCount=36 -p scenario=prefix,contains/);
+    assert.match(job, /-foe true/);
+    assert.match(job, /\["contains", "prefix"\]/, "the long-scenario assert must require both named scenarios");
     // Asserts the fork published a valid javaThreadCpuNanos row with nonnegative accounting diagnostics.
     assert.match(job, /secondaryMetrics\.requestsSucceeded\.score == 1/);
     assert.match(job, /secondaryMetrics\.javaThreadCpuNanos\.score > 0/);

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -850,10 +850,11 @@ jobs:
         echo "cpu-accounting smoke: candidate fork published a valid javaThreadCpuNanos row"
 
     # The 4-graph/count smoke alone did not establish the accounting across the gate matrix: the
-    # tripwire fired on the longer 17/36-graph scenarios (prefix, contains) where a benign idle
-    # server thread was reaped inside the window. Run the worst-case graph count over both named
-    # scenarios on the candidate (pinned) harness with fail-on-error, so an abort in measure() fails
-    # this step. Completion proves the pinned pool keeps the accounting usable across the matrix.
+    # tripwire fired on the longer 17/36-graph scenarios (prefix, contains) where the JDK
+    # HttpURLConnection client's Keep-Alive-Timer thread exits inside the window. Run the worst-case
+    # graph count over both named scenarios on the candidate harness (which runs with
+    # http.keepAlive=false) with fail-on-error, so an abort in measure() fails this step. Completion
+    # proves the fix keeps the accounting usable across the matrix.
     - name: Exercise the long method scenarios that tripped the accounting
       run: |
         JAR=jmh-candidate-native/candidate-native-explore-jmh.jar

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -761,7 +761,7 @@ jobs:
     name: validate-cpu-accounting
     needs: [prepare-latency-fixtures]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
     - name: Checkout PR
@@ -848,6 +848,45 @@ jobs:
             .secondaryMetrics.jitTimeMillis.score >= 0
           )' "${FILE}" >/dev/null
         echo "cpu-accounting smoke: candidate fork published a valid javaThreadCpuNanos row"
+
+    # The 4-graph/count smoke alone did not establish the accounting across the gate matrix: the
+    # tripwire fired on the longer 17/36-graph scenarios (prefix, contains) where a benign idle
+    # server thread was reaped inside the window. Run the worst-case graph count over both named
+    # scenarios on the candidate (pinned) harness with fail-on-error, so an abort in measure() fails
+    # this step. Completion proves the pinned pool keeps the accounting usable across the matrix.
+    - name: Exercise the long method scenarios that tripped the accounting
+      run: |
+        JAR=jmh-candidate-native/candidate-native-explore-jmh.jar
+        GRAPH_ARGS="-Dandroid.graph.path=${PWD}/fixture-graphs/android \
+          -Dtika.graph.path=${PWD}/fixture-graphs/tika \
+          -Dhive.graph.path=${PWD}/fixture-graphs/hive \
+          -Dkotlin.compiler.graph.path=${PWD}/fixture-graphs/kotlin-compiler"
+        java -jar "${JAR}" \
+          'io.johnsonlee.graphite.cli.MethodDiscoveryCompatibilityBenchmark.methodScenarioGate' \
+          -wi 0 -i 1 -f 1 -t 1 -foe true -rf json \
+          -p graphCount=36 -p scenario=prefix,contains \
+          -jvmArgsAppend "${GRAPH_ARGS} -Dgraphite.method.compatibility.output=${PWD}/benchmark-results/candidate-cpu-accounting-longscan.txt" \
+          -rff "${PWD}/benchmark-results/candidate-cpu-accounting-longscan.json"
+
+    - name: Assert the long scenarios completed without aborting the accounting
+      run: |
+        FILE=benchmark-results/candidate-cpu-accounting-longscan.json
+        EXPECTED='io.johnsonlee.graphite.cli.MethodDiscoveryCompatibilityBenchmark.methodScenarioGate'
+        jq -e --arg expected "${EXPECTED}" '
+          length == 2 and
+          ([.[].params.scenario] | sort) == ["contains", "prefix"] and
+          all(.[];
+            .benchmark == $expected and
+            .params.graphCount == "36" and
+            .mode == "ss" and
+            .primaryMetric.score > 0 and
+            .secondaryMetrics.requestsSucceeded.score == 1 and
+            .secondaryMetrics.javaThreadCpuNanos.score > 0 and
+            .secondaryMetrics.processCpuNanos.score > 0 and
+            .secondaryMetrics.jvmInternalCpuNanos.score >= 0 and
+            .secondaryMetrics.cpuAccountingUnderflowNanos.score >= 0
+          )' "${FILE}" >/dev/null
+        echo "cpu-accounting smoke: 36-graph prefix and contains completed on the pinned harness"
 
     - name: Upload CPU accounting smoke result
       if: always()

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
@@ -12,6 +12,7 @@ import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.input.LoaderConfig
 import io.johnsonlee.graphite.sootup.JavaProjectLoader
 import io.johnsonlee.graphite.webgraph.GraphStore
+import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.openjdk.jmh.annotations.AuxCounters
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
@@ -366,6 +367,21 @@ open class ExplorerMemoryBenchmark {
 }
 
 /**
+ * A Jetty pool that keeps every server thread for the life of the trial. Jetty's default
+ * [QueuedThreadPool] reaps idle worker threads on their idle timeout and idle reserved threads via
+ * its [org.eclipse.jetty.util.thread.ReservedThreadExecutor]; on the longer 17/36-graph method
+ * scenarios that reaping lands inside a measured window, and [RequestCpuAccounting] then fails
+ * closed because a Java thread present at the window start is gone at the end. Disabling the idle
+ * timeout (and reserved threads) removes that benign churn without weakening the tripwire: a genuine
+ * request worker that vanishes still trips it.
+ */
+internal fun pinnedServerThreadPool(): QueuedThreadPool =
+    QueuedThreadPool(SERVER_MAX_THREADS, SERVER_MIN_THREADS, NO_IDLE_TIMEOUT_MILLIS).apply {
+        name = "graphite-method-bench-jetty"
+        reservedThreads = 0
+    }
+
+/**
  * Paired migration gate for the method-discovery HTTP surface.
  *
  * The candidate copy of this source is compiled into both revisions. A base server is therefore
@@ -424,6 +440,13 @@ open class MethodDiscoveryCompatibilityBenchmark {
         topology = TopologyService(registry, emptyList(), root).also { it.rebuild() }
         app = Javalin.create { config ->
             config.jsonMapper(JavalinGson(GsonBuilder().create()))
+            // Pin the embedded Jetty pool so no idle server thread is reaped inside a measured
+            // window. RequestCpuAccounting fails closed when a Java thread present at the window
+            // start is gone at the end; Jetty's default QueuedThreadPool reaps idle worker and
+            // reserved threads on their idle timeout, which on the longer 17/36-graph scenarios
+            // lands inside the window and trips the tripwire on identical code. See
+            // pinnedServerThreadPool.
+            config.jetty.threadPool = pinnedServerThreadPool()
         }.start(0)
         cypherGuard = CypherQueryGuard(TARGET_CYPHER_CONCURRENCY, TARGET_CYPHER_WORK_BUDGET)
         ExploreRoutes(cypherGuard).register(app, registry, topology)
@@ -1681,6 +1704,12 @@ private fun forceTopologyHeapGc() {
         Thread.sleep(TOPOLOGY_HEAP_GC_PAUSE_MS)
     }
 }
+
+// A very large idle timeout keeps the benchmark server's Jetty threads from being reaped inside a
+// measured window; Int.MAX_VALUE ms is ~24 days, far beyond any trial.
+private const val NO_IDLE_TIMEOUT_MILLIS = Int.MAX_VALUE
+private const val SERVER_MIN_THREADS = 8
+private const val SERVER_MAX_THREADS = 64
 
 private const val TOPOLOGY_HEAP_GRAPH_COUNT = 3
 private const val TOPOLOGY_HEAP_GC_ATTEMPTS = 3

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
@@ -377,7 +377,11 @@ open class ExplorerMemoryBenchmark {
 @BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Measurement(iterations = 1)
-@Fork(1, jvmArgs = ["-Xmx8g"])
+// http.keepAlive=false stops the JDK's HttpURLConnection client (used by rawRequest) from spawning a
+// Keep-Alive-Timer daemon thread. That thread is present at a measured window's start and exits when
+// the keep-alive cache idles (~seconds later), which on the longer 17/36-graph scenarios lands inside
+// the window and makes RequestCpuAccounting fail closed on a non-request client-lifecycle thread.
+@Fork(1, jvmArgs = ["-Xmx8g", "-Dhttp.keepAlive=false"])
 open class MethodDiscoveryCompatibilityBenchmark {
 
     @Param("4", "17", "36")
@@ -424,13 +428,6 @@ open class MethodDiscoveryCompatibilityBenchmark {
         topology = TopologyService(registry, emptyList(), root).also { it.rebuild() }
         app = Javalin.create { config ->
             config.jsonMapper(JavalinGson(GsonBuilder().create()))
-            // Pin the embedded Jetty pool so no idle server thread is reaped inside a measured
-            // window. RequestCpuAccounting fails closed when a Java thread present at the window
-            // start is gone at the end; Jetty's default QueuedThreadPool reaps idle worker and
-            // reserved threads on their idle timeout, which on the longer 17/36-graph scenarios
-            // lands inside the window and trips the tripwire on identical code. See
-            // pinnedServerThreadPool.
-            config.jetty.threadPool = pinnedServerThreadPool()
         }.start(0)
         cypherGuard = CypherQueryGuard(TARGET_CYPHER_CONCURRENCY, TARGET_CYPHER_WORK_BUDGET)
         ExploreRoutes(cypherGuard).register(app, registry, topology)

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/ExplorerMemoryBenchmark.kt
@@ -12,7 +12,6 @@ import io.johnsonlee.graphite.graph.MethodPattern
 import io.johnsonlee.graphite.input.LoaderConfig
 import io.johnsonlee.graphite.sootup.JavaProjectLoader
 import io.johnsonlee.graphite.webgraph.GraphStore
-import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.openjdk.jmh.annotations.AuxCounters
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
@@ -365,21 +364,6 @@ open class ExplorerMemoryBenchmark {
         private val HTTP_SUCCESS_RANGE = 200..299
     }
 }
-
-/**
- * A Jetty pool that keeps every server thread for the life of the trial. Jetty's default
- * [QueuedThreadPool] reaps idle worker threads on their idle timeout and idle reserved threads via
- * its [org.eclipse.jetty.util.thread.ReservedThreadExecutor]; on the longer 17/36-graph method
- * scenarios that reaping lands inside a measured window, and [RequestCpuAccounting] then fails
- * closed because a Java thread present at the window start is gone at the end. Disabling the idle
- * timeout (and reserved threads) removes that benign churn without weakening the tripwire: a genuine
- * request worker that vanishes still trips it.
- */
-internal fun pinnedServerThreadPool(): QueuedThreadPool =
-    QueuedThreadPool(SERVER_MAX_THREADS, SERVER_MIN_THREADS, NO_IDLE_TIMEOUT_MILLIS).apply {
-        name = "graphite-method-bench-jetty"
-        reservedThreads = 0
-    }
 
 /**
  * Paired migration gate for the method-discovery HTTP surface.
@@ -1704,12 +1688,6 @@ private fun forceTopologyHeapGc() {
         Thread.sleep(TOPOLOGY_HEAP_GC_PAUSE_MS)
     }
 }
-
-// A very large idle timeout keeps the benchmark server's Jetty threads from being reaped inside a
-// measured window; Int.MAX_VALUE ms is ~24 days, far beyond any trial.
-private const val NO_IDLE_TIMEOUT_MILLIS = Int.MAX_VALUE
-private const val SERVER_MIN_THREADS = 8
-private const val SERVER_MAX_THREADS = 64
 
 private const val TOPOLOGY_HEAP_GRAPH_COUNT = 3
 private const val TOPOLOGY_HEAP_GC_ATTEMPTS = 3

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/RequestCpuAccounting.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/RequestCpuAccounting.kt
@@ -135,6 +135,8 @@ object MethodCompatibilityCpuAccountingContract {
             checkCollidingNameWorkerIsCharged(failures)
             checkTransientWorkerFailsClosed(failures)
             checkEndSnapshotReadRaceFailsClosed(failures)
+            checkPresentThenGoneFailsClosed(failures)
+            checkPinnedServerPoolHoldsThreadsAcrossWindow(failures)
             checkProcessBound("idle action", failures) { 0L }
             checkProcessBound("collector-loaded action", failures) { collectorLoad() }
         } catch (@Suppress("TooGenericExceptionCaught") failure: RuntimeException) {
@@ -237,6 +239,71 @@ object MethodCompatibilityCpuAccountingContract {
     }
 
     /**
+     * A Java thread present at the window start that exits inside the window is in the before
+     * snapshot but not the after snapshot; the accounting must fail closed rather than drop the CPU
+     * it accrued before exiting. This is the branch a benign idle server thread was tripping on the
+     * longer method scenarios: the repair keeps the tripwire and stops the server pool from reaping
+     * mid-window (see the pinned-pool check below), rather than weakening this guarantee.
+     */
+    private fun checkPresentThenGoneFailsClosed(failures: MutableList<String>) {
+        val release = java.util.concurrent.CountDownLatch(1)
+        val worker = Thread {
+            runCatching { release.await() }
+        }.apply { isDaemon = true; start() }
+        // The worker is parked and present in the before snapshot; releasing and joining it inside
+        // the window makes it exit before the end snapshot is taken.
+        val failedClosed = runCatching {
+            RequestCpuAccounting.measure {
+                release.countDown()
+                worker.join()
+                0L
+            }
+        }.isFailure
+        println("cpu-accounting-contract: present-then-gone worker failed closed = $failedClosed")
+        if (!failedClosed) {
+            failures.add("a thread present at the window start that exited inside it was not caught; " +
+                "the row would drop its pre-exit CPU")
+        }
+    }
+
+    /**
+     * The benchmark server's pool is pinned ([pinnedServerThreadPool]) so no idle server thread is
+     * reaped inside a measured window and trips [checkPresentThenGoneFailsClosed]. Its threads must
+     * stay present across a window longer than a default idle timeout, and the accounting must
+     * complete. Only Java threads count toward liveness, so the JVM's own native threads are
+     * irrelevant here.
+     */
+    private fun checkPinnedServerPoolHoldsThreadsAcrossWindow(failures: MutableList<String>) {
+        val pool = pinnedServerThreadPool()
+        if (pool.idleTimeout != Int.MAX_VALUE || pool.reservedThreads != 0) {
+            failures.add("the pinned server pool is not configured to hold threads: " +
+                "idleTimeout=${pool.idleTimeout}, reservedThreads=${pool.reservedThreads}")
+            return
+        }
+        pool.start()
+        val release = java.util.concurrent.CountDownLatch(1)
+        try {
+            val busy = java.util.concurrent.CountDownLatch(CPU_ACCOUNTING_PINNED_POOL_JOBS)
+            repeat(CPU_ACCOUNTING_PINNED_POOL_JOBS) {
+                pool.execute { busy.countDown(); runCatching { release.await() } }
+            }
+            busy.await()
+            val outcome = runCatching {
+                RequestCpuAccounting.measure { Thread.sleep(CPU_ACCOUNTING_PINNED_WINDOW_MILLIS); 0L }
+            }
+            val held = outcome.isSuccess
+            println("cpu-accounting-contract: pinned pool held its threads across the window = $held")
+            if (!held) {
+                failures.add("the pinned server pool lost a thread inside the window: " +
+                    (outcome.exceptionOrNull()?.message ?: "unknown"))
+            }
+        } finally {
+            release.countDown()
+            pool.stop()
+        }
+    }
+
+    /**
      * The request-serving Java sum is per-thread on-CPU time over an interval the process figure
      * contains, so it can exceed the process figure only by snapshot overhead, whatever the JVM's
      * own threads did around the action. A larger overshoot means the intervals are not nested.
@@ -265,6 +332,12 @@ object MethodCompatibilityCpuAccountingContract {
 }
 
 private const val CPU_ACCOUNTING_WORKER_NANOS = 200_000_000L
+
+/** Enough pinned-pool workers to hold threads present across the window; a window longer than a
+ * default Jetty idle timeout, so an unpinned pool would have reaped inside it. */
+private const val CPU_ACCOUNTING_PINNED_POOL_JOBS = 4
+private const val CPU_ACCOUNTING_PINNED_WINDOW_MILLIS = 300L
+
 private const val CPU_ACCOUNTING_GARBAGE_CHUNKS = 512
 private const val CPU_ACCOUNTING_GARBAGE_CHUNK_BYTES = 1 shl 20
 private const val CPU_ACCOUNTING_GARBAGE_RETAINED = 64

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/RequestCpuAccounting.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/RequestCpuAccounting.kt
@@ -3,23 +3,6 @@ package io.johnsonlee.graphite.cli
 import java.lang.management.ManagementFactory
 import java.lang.management.ThreadMXBean
 import kotlin.system.exitProcess
-import org.eclipse.jetty.util.thread.QueuedThreadPool
-
-/**
- * A Jetty pool that keeps every server thread for the life of the trial. Jetty's default
- * [QueuedThreadPool] reaps idle worker threads on their idle timeout and idle reserved threads via
- * its `ReservedThreadExecutor`; on the longer 17/36-graph method scenarios that reaping lands
- * inside a measured window, and [RequestCpuAccounting] then fails closed because a Java thread
- * present at the window start is gone at the end. Disabling the idle timeout (and reserved threads)
- * removes that benign churn without weakening the tripwire: a genuine request worker that vanishes
- * still trips it. Defined here (the candidate keeps this file, while the benchmark harness is
- * base-installed over both trees) so the caller and the contract share one definition.
- */
-internal fun pinnedServerThreadPool(): QueuedThreadPool =
-    QueuedThreadPool(SERVER_MAX_THREADS, SERVER_MIN_THREADS, NO_IDLE_TIMEOUT_MILLIS).apply {
-        name = "graphite-method-bench-jetty"
-        reservedThreads = 0
-    }
 
 /** One measured window of the request-serving CPU accounting. */
 internal data class RequestCpuSample(
@@ -77,6 +60,9 @@ internal object RequestCpuAccounting {
         val threads = ManagementFactory.getThreadMXBean()
         val beforeStarted = threads.totalStartedThreadCount
         val beforeCpu = threadCpuSnapshot(threads, threads.allThreadIds, unreadable = null)
+        // Names captured at the start so a thread gone by the end can still be identified in the
+        // failure message. Names are only ever reported, never used for an accounting decision.
+        val beforeNames = threadNames(threads, beforeCpu.keys)
         // The process figure is read innermost so its interval is contained in the thread
         // snapshots; the request-serving Java sum can then exceed it only by snapshot overhead.
         val beforeProcess = processCpuTimeNanos()
@@ -89,10 +75,11 @@ internal object RequestCpuAccounting {
         // enumerated at the end but gone before its read returns -1 and is absent from afterCpu, so
         // it counts as vanished rather than present-with-no-CPU -- otherwise a worker exiting during
         // the end snapshot would balance the started count and hide its CPU.
-        val vanished = beforeCpu.keys.count { it !in afterCpu }
-        check(vanished == 0) {
-            "$vanished Java thread(s) present at the start of the window were gone at the end; " +
-                "their in-window CPU cannot be accounted"
+        val vanishedIds = beforeCpu.keys.filter { it !in afterCpu }
+        check(vanishedIds.isEmpty()) {
+            val described = vanishedIds.sorted().joinToString { id -> "${beforeNames[id] ?: "?"}#$id" }
+            "${vanishedIds.size} Java thread(s) present at the start of the window were gone at the " +
+                "end ($described); their in-window CPU cannot be accounted"
         }
         val appeared = afterCpu.keys.count { it !in beforeCpu }
         val transientWorkers = (afterStarted - beforeStarted) - appeared
@@ -135,6 +122,16 @@ internal object RequestCpuAccounting {
         }
         return snapshot
     }
+
+    /** Thread names for [ids], captured up front so a thread gone by the end can still be named. */
+    private fun threadNames(threads: ThreadMXBean, ids: Set<Long>): Map<Long, String> {
+        if (ids.isEmpty()) return emptyMap()
+        val names = HashMap<Long, String>(ids.size * 2)
+        for (info in threads.getThreadInfo(ids.toLongArray())) {
+            if (info != null) names[info.threadId] = info.threadName
+        }
+        return names
+    }
 }
 
 /**
@@ -153,7 +150,6 @@ object MethodCompatibilityCpuAccountingContract {
             checkTransientWorkerFailsClosed(failures)
             checkEndSnapshotReadRaceFailsClosed(failures)
             checkPresentThenGoneFailsClosed(failures)
-            checkPinnedServerPoolHoldsThreadsAcrossWindow(failures)
             checkProcessBound("idle action", failures) { 0L }
             checkProcessBound("collector-loaded action", failures) { collectorLoad() }
         } catch (@Suppress("TooGenericExceptionCaught") failure: RuntimeException) {
@@ -258,65 +254,36 @@ object MethodCompatibilityCpuAccountingContract {
     /**
      * A Java thread present at the window start that exits inside the window is in the before
      * snapshot but not the after snapshot; the accounting must fail closed rather than drop the CPU
-     * it accrued before exiting. This is the branch a benign idle server thread was tripping on the
-     * longer method scenarios: the repair keeps the tripwire and stops the server pool from reaping
-     * mid-window (see the pinned-pool check below), rather than weakening this guarantee.
+     * it accrued before exiting, and the failure must name the vanished thread so the offending
+     * lifecycle can be identified (a JDK `Keep-Alive-Timer` from the harness's HttpURLConnection
+     * client was the one that tripped it on the longer method scenarios). The repair keeps this
+     * tripwire and removes that non-request thread at its source (`http.keepAlive=false`) rather
+     * than weakening the guarantee.
      */
     private fun checkPresentThenGoneFailsClosed(failures: MutableList<String>) {
         val release = java.util.concurrent.CountDownLatch(1)
         val worker = Thread {
             runCatching { release.await() }
-        }.apply { isDaemon = true; start() }
+        }.apply { isDaemon = true; name = PRESENT_THEN_GONE_WORKER_NAME; start() }
         // The worker is parked and present in the before snapshot; releasing and joining it inside
         // the window makes it exit before the end snapshot is taken.
-        val failedClosed = runCatching {
+        val outcome = runCatching {
             RequestCpuAccounting.measure {
                 release.countDown()
                 worker.join()
                 0L
             }
-        }.isFailure
-        println("cpu-accounting-contract: present-then-gone worker failed closed = $failedClosed")
+        }
+        val message = outcome.exceptionOrNull()?.message ?: ""
+        val failedClosed = outcome.isFailure
+        val named = message.contains(PRESENT_THEN_GONE_WORKER_NAME)
+        println("cpu-accounting-contract: present-then-gone worker failed closed = $failedClosed, " +
+            "named = $named")
         if (!failedClosed) {
             failures.add("a thread present at the window start that exited inside it was not caught; " +
                 "the row would drop its pre-exit CPU")
-        }
-    }
-
-    /**
-     * The benchmark server's pool is pinned ([pinnedServerThreadPool]) so no idle server thread is
-     * reaped inside a measured window and trips [checkPresentThenGoneFailsClosed]. Its threads must
-     * stay present across a window longer than a default idle timeout, and the accounting must
-     * complete. Only Java threads count toward liveness, so the JVM's own native threads are
-     * irrelevant here.
-     */
-    private fun checkPinnedServerPoolHoldsThreadsAcrossWindow(failures: MutableList<String>) {
-        val pool = pinnedServerThreadPool()
-        if (pool.idleTimeout != Int.MAX_VALUE || pool.reservedThreads != 0) {
-            failures.add("the pinned server pool is not configured to hold threads: " +
-                "idleTimeout=${pool.idleTimeout}, reservedThreads=${pool.reservedThreads}")
-            return
-        }
-        pool.start()
-        val release = java.util.concurrent.CountDownLatch(1)
-        try {
-            val busy = java.util.concurrent.CountDownLatch(CPU_ACCOUNTING_PINNED_POOL_JOBS)
-            repeat(CPU_ACCOUNTING_PINNED_POOL_JOBS) {
-                pool.execute { busy.countDown(); runCatching { release.await() } }
-            }
-            busy.await()
-            val outcome = runCatching {
-                RequestCpuAccounting.measure { Thread.sleep(CPU_ACCOUNTING_PINNED_WINDOW_MILLIS); 0L }
-            }
-            val held = outcome.isSuccess
-            println("cpu-accounting-contract: pinned pool held its threads across the window = $held")
-            if (!held) {
-                failures.add("the pinned server pool lost a thread inside the window: " +
-                    (outcome.exceptionOrNull()?.message ?: "unknown"))
-            }
-        } finally {
-            release.countDown()
-            pool.stop()
+        } else if (!named) {
+            failures.add("the vanished-thread failure did not name the offending thread: $message")
         }
     }
 
@@ -350,16 +317,8 @@ object MethodCompatibilityCpuAccountingContract {
 
 private const val CPU_ACCOUNTING_WORKER_NANOS = 200_000_000L
 
-/** Enough pinned-pool workers to hold threads present across the window; a window longer than a
- * default Jetty idle timeout, so an unpinned pool would have reaped inside it. */
-private const val CPU_ACCOUNTING_PINNED_POOL_JOBS = 4
-private const val CPU_ACCOUNTING_PINNED_WINDOW_MILLIS = 300L
-
-// A very large idle timeout keeps the benchmark server's Jetty threads from being reaped inside a
-// measured window; Int.MAX_VALUE ms is ~24 days, far beyond any trial.
-private const val NO_IDLE_TIMEOUT_MILLIS = Int.MAX_VALUE
-private const val SERVER_MIN_THREADS = 8
-private const val SERVER_MAX_THREADS = 64
+/** A distinctive name the present-then-gone contract asserts appears in the vanished-thread failure. */
+private const val PRESENT_THEN_GONE_WORKER_NAME = "cpu-accounting-present-then-gone"
 
 private const val CPU_ACCOUNTING_GARBAGE_CHUNKS = 512
 private const val CPU_ACCOUNTING_GARBAGE_CHUNK_BYTES = 1 shl 20

--- a/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/RequestCpuAccounting.kt
+++ b/graphite-explore/src/jmh/kotlin/io/johnsonlee/graphite/cli/RequestCpuAccounting.kt
@@ -3,6 +3,23 @@ package io.johnsonlee.graphite.cli
 import java.lang.management.ManagementFactory
 import java.lang.management.ThreadMXBean
 import kotlin.system.exitProcess
+import org.eclipse.jetty.util.thread.QueuedThreadPool
+
+/**
+ * A Jetty pool that keeps every server thread for the life of the trial. Jetty's default
+ * [QueuedThreadPool] reaps idle worker threads on their idle timeout and idle reserved threads via
+ * its `ReservedThreadExecutor`; on the longer 17/36-graph method scenarios that reaping lands
+ * inside a measured window, and [RequestCpuAccounting] then fails closed because a Java thread
+ * present at the window start is gone at the end. Disabling the idle timeout (and reserved threads)
+ * removes that benign churn without weakening the tripwire: a genuine request worker that vanishes
+ * still trips it. Defined here (the candidate keeps this file, while the benchmark harness is
+ * base-installed over both trees) so the caller and the contract share one definition.
+ */
+internal fun pinnedServerThreadPool(): QueuedThreadPool =
+    QueuedThreadPool(SERVER_MAX_THREADS, SERVER_MIN_THREADS, NO_IDLE_TIMEOUT_MILLIS).apply {
+        name = "graphite-method-bench-jetty"
+        reservedThreads = 0
+    }
 
 /** One measured window of the request-serving CPU accounting. */
 internal data class RequestCpuSample(
@@ -337,6 +354,12 @@ private const val CPU_ACCOUNTING_WORKER_NANOS = 200_000_000L
  * default Jetty idle timeout, so an unpinned pool would have reaped inside it. */
 private const val CPU_ACCOUNTING_PINNED_POOL_JOBS = 4
 private const val CPU_ACCOUNTING_PINNED_WINDOW_MILLIS = 300L
+
+// A very large idle timeout keeps the benchmark server's Jetty threads from being reaped inside a
+// measured window; Int.MAX_VALUE ms is ~24 days, far beyond any trial.
+private const val NO_IDLE_TIMEOUT_MILLIS = Int.MAX_VALUE
+private const val SERVER_MIN_THREADS = 8
+private const val SERVER_MAX_THREADS = 64
 
 private const val CPU_ACCOUNTING_GARBAGE_CHUNKS = 512
 private const val CPU_ACCOUNTING_GARBAGE_CHUNK_BYTES = 1 shl 20


### PR DESCRIPTION
## Summary

Prerequisite harness repair for the `javaThreadCpuNanos` metric switch (#121), addressing the P1 there: on the longer 17/36-graph method scenarios the base fork aborts before comparison because `RequestCpuAccounting.measure` reports 1–2 Java threads present at the window start but gone at the end.

### Root cause (corrected)

The vanished thread is **not** a Jetty worker. Javalin 6.4.0's default `QueuedThreadPool` uses a 60s idle timeout and the server starts immediately before measurement, so its workers cannot reach that timeout within the 11–19s window where #121 failed. The actual thread is the JDK `HttpURLConnection` client's **`Keep-Alive-Timer`**, which the benchmark's `rawRequest()` spawns during setup; it is present at the window start and exits when the keep-alive cache idles, landing inside the longer windows.

Reproduced locally on JDK 17 (isolated, no project deps): after one `HttpURLConnection` request + `disconnect()`, `Keep-Alive-Timer` is in the start snapshot and vanishes within ~15s; with `-Dhttp.keepAlive=false` it is never created and nothing vanishes — exactly the liveness pattern and timing of #121.

This stayed hidden on #119 because the workflow installed the old process-only base harness on both sides; now that the identity harness is the base-installed control on `main`, the tripwire reaches the real 17/36 path (both #121 and #117 hit it).

### Fix

- **Fix the actual lifecycle**: the method-compatibility fork runs with `-Dhttp.keepAlive=false`, so the client never spawns `Keep-Alive-Timer`. What's measured is the server's request-serving CPU; disabling client connection reuse is symmetric across base and candidate. The tripwire is unchanged — a genuine request worker that vanishes still fails closed.
- **Name the offender**: `measure()` now reports each vanished thread by `name#id`, captured at the start snapshot (names are only reported, never used for an accounting decision), so a future non-request lifecycle is identified rather than guessed.

### Coverage

- `MethodCompatibilityCpuAccountingContract.checkPresentThenGoneFailsClosed` (deterministic) asserts a thread present at the window start that exits inside it fails closed **and** that the failure names the thread. Passes locally.
- `validate-cpu-accounting` runs `graphCount=36` over `scenario=prefix,contains` on the candidate harness (which runs with `http.keepAlive=false`) with `-foe true`, so an abort fails the job. It passes because the cause is addressed, and would still abort without the flag.

### Landing order

The method-compatibility shards install the base-owned harness, so this repair must land on `main` before the shards stop aborting and before #121 promotes `javaThreadCpuNanos` to a blocking gate. Expect this PR's own `method-compatibility-*` shards to still abort (they run the pre-merge base harness); the candidate-harness `validate-cpu-accounting` job is the proof for this PR.

### Validation

- `:explore:compileJmhKotlin` passes for the candidate, and with `origin/main`'s harness installed over the candidate `RequestCpuAccounting` (the `build-explore-jmh` scenario).
- The contract passes locally (`present-then-gone failed closed = true, named = true`).
- 90 node gate tests pass; `benchmark.yml` parses as valid YAML.

(The branch name still says "pin-jetty-pool" from the first attempt; left as-is to avoid churning the PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yd879evHTgiGieE2o22jW